### PR TITLE
v1.40.10 (final 1.x): backport ICY listener zombie-disconnect fix

### DIFF
--- a/internal/broadcast/server.go
+++ b/internal/broadcast/server.go
@@ -9,6 +9,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 package broadcast
 
 import (
+	"errors"
 	"io"
 	"net/http"
 	"sync"
@@ -18,6 +19,15 @@ import (
 	"github.com/friendsincode/grimnir_radio/internal/events"
 	"github.com/rs/zerolog"
 )
+
+// writeTimeout bounds how long a single write or flush to a client may block.
+// A live stream pushes audio continuously, so a healthy client's kernel send
+// buffer drains well within this window; only a stalled or half-open client
+// (laptop slept, NAT dropped the flow) blocks longer. We disconnect those
+// instead of counting them as zombies, which otherwise linger until the kernel
+// TCP retransmit timeout (~15 min). Must stay below the keepalive interval.
+// It is a var, not a const, only so tests can shorten it.
+var writeTimeout = 10 * time.Second
 
 // Mount represents a single audio stream mount point.
 type Mount struct {
@@ -247,24 +257,27 @@ func (m *Mount) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	m.buffer.mu.RUnlock()
 	m.logger.Debug().Int("buffer_pos", bufPos).Bool("skip_buffer", skipBuffer).Msg("client connecting, buffer state")
 
-	// Try to get the Flusher interface - check for wrapped writers
-	var flusher http.Flusher
-	if f, ok := w.(http.Flusher); ok {
-		flusher = f
-	} else {
-		// Try ResponseController as fallback (Go 1.20+)
-		rc := http.NewResponseController(w)
-		// Create a wrapper that uses ResponseController
-		flusher = &rcFlusher{rc: rc, logger: m.logger}
-	}
+	// ResponseController drives both flushing & per-write deadlines. A write
+	// deadline is what bounds a half-open client's lifetime: without it the
+	// serve goroutine parks inside w.Write on a dead socket until the kernel
+	// gives up (~15 min) & the client stays in the count the whole time.
+	rc := http.NewResponseController(w)
 
-	// Helper to write and flush data
+	// writeAndFlush writes a chunk under a fresh write deadline. Any error
+	// (a closed socket, or a deadline exceeded on a client that stopped
+	// draining) returns so the caller disconnects & the defer drops the client
+	// from the count. A writer that doesn't support deadlines or flushing
+	// (errors.ErrUnsupported) degrades to the prior best-effort behavior.
 	writeAndFlush := func(data []byte) error {
-		_, err := w.Write(data)
-		if err != nil {
+		if err := rc.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil && !errors.Is(err, errors.ErrUnsupported) {
 			return err
 		}
-		flusher.Flush()
+		if _, err := w.Write(data); err != nil {
+			return err
+		}
+		if err := rc.Flush(); err != nil && !errors.Is(err, errors.ErrUnsupported) {
+			return err
+		}
 		return nil
 	}
 
@@ -374,10 +387,19 @@ func (m *Mount) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			keepalive.Reset(30 * time.Second)
 		case <-keepalive.C:
-			// No data for 30 seconds - flush and continue waiting
-			// This keeps the connection alive during gaps between tracks
+			// No data for 30 seconds - flush under a write deadline so a dead
+			// or half-open client is detected during an idle gap between tracks
+			// instead of lingering in the count. A real flush error means the
+			// connection is gone; disconnect.
+			if err := rc.SetWriteDeadline(time.Now().Add(writeTimeout)); err != nil && !errors.Is(err, errors.ErrUnsupported) {
+				m.logger.Info().Err(err).Int("writes", writeCount).Msg("keepalive deadline failed, disconnecting client")
+				return
+			}
+			if err := rc.Flush(); err != nil && !errors.Is(err, errors.ErrUnsupported) {
+				m.logger.Info().Err(err).Int("writes", writeCount).Msg("keepalive flush failed, disconnecting client")
+				return
+			}
 			m.logger.Debug().Int("writes", writeCount).Msg("keepalive flush")
-			flusher.Flush()
 			keepalive.Reset(30 * time.Second)
 		}
 	}
@@ -424,20 +446,6 @@ func (m *Mount) Close() {
 		c.mu.Unlock()
 	}
 	m.clients = make(map[*client]struct{})
-}
-
-// rcFlusher wraps http.ResponseController to implement http.Flusher
-type rcFlusher struct {
-	rc        *http.ResponseController
-	logger    zerolog.Logger
-	errLogged bool // only log flush errors once per connection
-}
-
-func (f *rcFlusher) Flush() {
-	if err := f.rc.Flush(); err != nil && !f.errLogged {
-		f.logger.Debug().Err(err).Msg("ResponseController flush failed")
-		f.errLogged = true
-	}
 }
 
 func itoa(i int) string {

--- a/internal/broadcast/server_test.go
+++ b/internal/broadcast/server_test.go
@@ -8,12 +8,29 @@ package broadcast
 
 import (
 	"bytes"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/friendsincode/grimnir_radio/internal/events"
 	"github.com/rs/zerolog"
 )
+
+// waitFor polls cond until it is true or the deadline passes.
+func waitFor(t *testing.T, d time.Duration, cond func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(d)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
 
 func TestMount_BytesReceivedAt_ZeroBeforeFeed(t *testing.T) {
 	bus := events.NewBus()
@@ -39,5 +56,63 @@ func TestMount_BytesReceivedAt_UpdatedAfterFeed(t *testing.T) {
 	}
 	if got.Before(before) {
 		t.Errorf("BytesReceivedAt() = %v, want after %v", got, before)
+	}
+}
+
+// TestMount_StalledClientIsDisconnected proves the zombie fix: a client that
+// stops reading (half-open) is dropped from the count within the write-deadline
+// window, instead of lingering until the kernel TCP timeout (~15 min). See #18.
+func TestMount_StalledClientIsDisconnected(t *testing.T) {
+	orig := writeTimeout
+	writeTimeout = 200 * time.Millisecond
+	defer func() { writeTimeout = orig }()
+
+	bus := events.NewBus()
+	m := NewMount("test", "audio/mpeg", 128, zerolog.Nop(), bus)
+
+	srv := httptest.NewServer(http.HandlerFunc(m.ServeHTTP))
+	defer srv.Close()
+
+	// Dial raw so we can read the response start, then stop reading to simulate
+	// a stalled listener whose socket buffers fill while audio keeps flowing.
+	conn, err := net.Dial("tcp", strings.TrimPrefix(srv.URL, "http://"))
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer conn.Close()
+	if tc, ok := conn.(*net.TCPConn); ok {
+		_ = tc.SetReadBuffer(2048) // small receive window so writes block sooner
+	}
+
+	if _, err := conn.Write([]byte("GET /live HTTP/1.1\r\nHost: x\r\n\r\n")); err != nil {
+		t.Fatalf("request: %v", err)
+	}
+	// Read the headers + a little body, then never read again.
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	_, _ = conn.Read(make([]byte, 1024))
+
+	if !waitFor(t, 2*time.Second, func() bool { return m.ClientCount() == 1 }) {
+		t.Fatalf("client never registered; ClientCount=%d", m.ClientCount())
+	}
+
+	// Keep feeding audio so the serve loop keeps writing into the stalled pipe.
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		chunk := make([]byte, 64*1024)
+		tick := time.NewTicker(5 * time.Millisecond)
+		defer tick.Stop()
+		for {
+			select {
+			case <-stop:
+				return
+			case <-tick.C:
+				m.Broadcast(chunk)
+			}
+		}
+	}()
+
+	if !waitFor(t, 5*time.Second, func() bool { return m.ClientCount() == 0 }) {
+		t.Fatalf("stalled client was not disconnected; ClientCount=%d", m.ClientCount())
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -23,7 +23,7 @@ import (
 // This is set at build time via ldflags:
 //
 //	-X github.com/friendsincode/grimnir_radio/internal/version.Version=X.Y.Z
-var Version = "1.40.9"
+var Version = "1.40.10"
 
 // GitHubRepo is the repository to check for updates
 const GitHubRepo = "friendsincode/grimnir_radio"


### PR DESCRIPTION
## Summary

Final 1.x release. Backports the ICY/HTTP listener disconnect fix from v2 so stalled or half-open listeners drop promptly instead of lingering until the kernel TCP retransmit timeout (~15 min) and inflating the listener count.

## Change

`internal/broadcast/server.go`: the serve loop sets a per-write `SetWriteDeadline` (via `ResponseController`) before each write and in the keepalive branch, and treats a deadline or flush error as a disconnect. This bounds a dead client's lifetime to `writeTimeout` (10s). Removes the now-unused `rcFlusher`. Adds a race-tested regression test, `TestMount_StalledClientIsDisconnected`.

## Why

Without a write deadline, a client that stops reading (laptop sleep, NAT/firewall eviction) sends no FIN/RST, so the serve goroutine parks in `w.Write` until the kernel gives up. The client stays in the mount's client map the whole time, inflating counts and leaking goroutines.

## Notes

- 1.40.10 is the final 1.x release; all forward work is v2.
- Cherry-picked from the v2 fix onto the same `internal/broadcast` base (clean pick).
- Local: builds, `go vet` clean, `broadcast` tests pass with `-race`; full `make ci` was run to validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
