### PR TITLE
fix: reap killed decoder children to stop zombie processes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,9 @@ services:
       dockerfile: Dockerfile
     image: ghcr.io/friendsincode/grimnir_radio:latest
     container_name: grimnir-radio
+    # Run tini as PID 1 to reap any orphaned/defunct child processes
+    # (ffmpeg/gst-launch decoders) as a backstop to in-code Wait() reaping.
+    init: true
     depends_on:
       postgres:
         condition: service_healthy

--- a/internal/harbor/decoder.go
+++ b/internal/harbor/decoder.go
@@ -108,6 +108,10 @@ func (d *decoderProc) Close() error {
 	}
 	if d.cmd != nil && d.cmd.Process != nil {
 		_ = d.cmd.Process.Kill()
+		// Reap the killed child; Kill terminates but does not reap, only Wait
+		// does. Without this the gst-launch wrapper lingers as a <defunct>
+		// zombie until the process restarts.
+		_ = d.cmd.Wait()
 	}
 	return nil
 }

--- a/internal/playout/crossfade.go
+++ b/internal/playout/crossfade.go
@@ -219,6 +219,10 @@ func (d *decoderProc) stop() error {
 		// orphaned, which was the root cause of the v1.40.x audible echo:
 		// orphan decoders kept feeding the mount's encoder pipe.
 		killProcessGroup(d.cmd, syscall.SIGKILL)
+		// Reap the killed child so it doesn't linger as a <defunct> zombie.
+		// SIGKILL terminates the process but does not reap it; only Wait does.
+		// The group is already killed, so Wait returns promptly.
+		_ = d.cmd.Wait()
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

The control-plane process leaked zombie child processes: every crossfade PCM decoder (`ffmpeg` + `gst-launch` via `sh -c`) and Harbor source decoder (`gst-launch`) was killed on teardown but never reaped, leaving `<defunct>` children that slowly consume PID slots until the process restarts.

## Root cause

In Go, `Process.Kill()` (and context-cancel kill) terminates a child but does **not** reap it; only `Cmd.Wait()` reaps. Both decoders killed without ever calling `Wait()`:

- `internal/playout/crossfade.go` `stop()`: `killProcessGroup(... SIGKILL)` with no `Wait()`.
- `internal/harbor/decoder.go` `Close()`: `Process.Kill()` with no `Wait()`.

The container compounds it: the Go binary runs as PID 1 (no subreaper), so orphaned/defunct children aren't mopped up.

## Fix

- Add `_ = cmd.Wait()` after the kill at both sites (the process is already SIGKILL'd, so `Wait()` returns promptly).
- Add `init: true` to the `grimnir` service in `docker-compose.yml` so tini runs as PID 1 and reaps any future stragglers as defense-in-depth.

## Notes

- Other spawn sites (waveform, orphan scanner, recording tag tools, public-page ffmpeg, media-engine analyzer) already use `Run()`/`Output()`/`CombinedOutput()` or pair `Start` with `Wait`, so they're clean.
- Reaping isn't cleanly unit-testable without the external binaries present; verified by code review plus build/vet/tests on the affected packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
