### PR TITLE
fix(ci,docker): build control plane with CGo for go-gst (unblocks v2 CI + image publish)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
           sudo apt-get update -qq
           sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq \
             libgstreamer1.0-dev \
+            libgstreamer-plugins-base1.0-dev \
             gstreamer1.0-plugins-base \
             gstreamer1.0-plugins-good \
             gstreamer1.0-plugins-ugly \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
             gstreamer1.0-plugins-good \
             gstreamer1.0-plugins-ugly \
             gstreamer1.0-plugins-bad \
+            gstreamer1.0-libav \
             gstreamer1.0-tools \
             libsrt-openssl-dev
           gst-launch-1.0 --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,14 @@
 # syntax=docker/dockerfile:1
 # Build stage
-FROM golang:1.24-alpine AS builder
+# Pinned to alpine 3.22 to match the runtime stage below: the CGo binary links
+# glib/gstreamer, so builder & runtime must share the same alpine (glib) version,
+# or the binary fails to relocate symbols at startup.
+FROM golang:1.24-alpine3.22 AS builder
 
-# Install build dependencies
-RUN apk add --no-cache git ca-certificates tzdata
+# Install build dependencies. The control plane links go-gst (CGo: gst, gst/base,
+# gst/app), so the builder needs a C toolchain + GStreamer dev headers and the
+# build must run with CGO_ENABLED=1 (below).
+RUN apk add --no-cache git ca-certificates tzdata gcc musl-dev pkgconf gstreamer-dev gst-plugins-base-dev
 
 WORKDIR /build
 
@@ -22,13 +27,14 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     --mount=type=cache,target=/root/.cache/go-build \
     VERSION_VAL="${VERSION:-$(git describe --tags --always --dirty 2>/dev/null || echo 'dev')}" && \
     VERSION_VAL="${VERSION_VAL#v}" && \
-    CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build \
     -ldflags="-w -s -X github.com/friendsincode/grimnir_radio/internal/version.Version=${VERSION_VAL}" \
     -o grimnirradio \
     ./cmd/grimnirradio
 
 # Runtime stage
-FROM alpine:3.19
+# Must match the builder's alpine (glib/gstreamer version) above.
+FROM alpine:3.22
 
 # Install runtime dependencies
 RUN apk add --no-cache \


### PR DESCRIPTION
## Summary

Every v2 build has been red — both the `CI` workflow on `v2-dev` and `docker-publish` on the v2 tags — while v1 builds passed. Root cause: the v2 control plane now links **go-gst** (CGo: `gst`, `gst/base`, `gst/app`), but CI and the Dockerfile were still configured for a CGo-free build. v1 didn't import go-gst, which is why it was unaffected.

## CI fix (`.github/workflows/ci.yml`)

`go mod tidy` (and vet/test after it) failed at `# github.com/go-gst/go-gst/gst/app`: the workflow installed `libgstreamer1.0-dev` and the runtime plugin packs but not `libgstreamer-plugins-base1.0-dev`, which carries the `gstreamer-app-1.0` headers `gst/app` needs. Added that package.

## Docker fix (`Dockerfile`)

The builder used `CGO_ENABLED=0`, so the go-gst types came back `undefined`. Now:
- builder installs `gcc musl-dev pkgconf gstreamer-dev gst-plugins-base-dev` and builds with `CGO_ENABLED=1`;
- builder and runtime are pinned to the **same alpine (3.22)**. Without parity the CGo binary links newer glib/gstreamer than the runtime provides and crashes at startup (`Error relocating: g_once_init_enter_pointer: symbol not found` for an alpine-3.23 build on an alpine-3.19 runtime).

## Validation

Locally, with the matched 3.22 pair: `CGO_ENABLED=1 go build ./cmd/grimnirradio` compiles on `golang:1.24-alpine3.22`, and the resulting binary runs on `alpine:3.22` (prints usage, exit 0, no relocation errors). The CI workflow fix is exercised by this PR's own CI run.

## Not in this PR

`build-mediaengine` fails with the identical `CGO_ENABLED=0` root cause, but `Dockerfile.mediaengine` has an **ubuntu:22.04** runtime, so its fix needs a glibc-matched builder rather than the alpine approach here. Tracked as a follow-up so it can be validated on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
