### PR TITLE
fix(compose): restart: unless-stopped on postgres + redis (survive host restarts)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
   postgres:
     image: postgres:15-alpine
     container_name: grimnir-postgres
+    restart: unless-stopped
     environment:
       POSTGRES_USER: grimnir
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-grimnir_secret}
@@ -24,6 +25,7 @@ services:
   redis:
     image: redis:7-alpine
     container_name: grimnir-redis
+    restart: unless-stopped
     command: redis-server --appendonly yes --requirepass ${REDIS_PASSWORD:-redis_secret}
     volumes:
       - redis-data:/data


### PR DESCRIPTION
## Summary

`postgres` and `redis` had no `restart` policy in the compose, while `grimnirradio` and `mediaengine` are `unless-stopped`. When the docker host restarts (this happened in prod: a drive dropped in the proxmox host and the VM was moved to another server), the DB and cache stay down, but `grimnir-radio` keeps restarting straight into `hostname resolving error: lookup postgres ... no such host` and the station goes off-air until someone runs `up` by hand.

## Fix

Add `restart: unless-stopped` to the `postgres` and `redis` services so the whole stack auto-recovers from a host/docker restart in the right order (DB up, then the app connects).

The running prod box was already hardened live with `docker update --restart unless-stopped grimnir-postgres grimnir-redis` (no disruption); this makes it durable across `compose` recreates and applies to every deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
