### PR TITLE
fix(schedule): resolve virtual recurring ids in the edit-modal read paths (#49)

### DIFF
--- a/internal/web/pages_schedule.go
+++ b/internal/web/pages_schedule.go
@@ -1436,6 +1436,42 @@ func parseRecurringInstanceID(id string) (string, time.Time, bool) {
 	return parentID, day, true
 }
 
+// resolveScheduleEntry loads a schedule entry by id, transparently handling the
+// virtual recurring-instance id form ({parentUUID}_{YYYYMMDD}). For a virtual id
+// it returns the concrete override row for that occurrence when one exists, else
+// the recurrence parent. The raw virtual id is never sent to the uuid id column,
+// so this is safe on Postgres, where such an id is a 22P02, not a not-found (#49).
+func (h *Handler) resolveScheduleEntry(id string) (*models.ScheduleEntry, error) {
+	parentID, dayStart, ok := parseRecurringInstanceID(id)
+	if !ok {
+		var entry models.ScheduleEntry
+		if err := h.db.First(&entry, "id = ?", id).Error; err != nil {
+			return nil, err
+		}
+		return &entry, nil
+	}
+
+	// Virtual recurring instance: prefer a concrete override for that parent/day,
+	// otherwise fall back to the recurrence parent.
+	dayEnd := dayStart.Add(24 * time.Hour)
+	var override models.ScheduleEntry
+	err := h.db.Where("recurrence_parent_id = ? AND starts_at >= ? AND starts_at < ?", parentID, dayStart, dayEnd).
+		Order("starts_at ASC").
+		First(&override).Error
+	if err == nil {
+		return &override, nil
+	}
+	if !errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, err
+	}
+
+	var parent models.ScheduleEntry
+	if err := h.db.First(&parent, "id = ?", parentID).Error; err != nil {
+		return nil, err
+	}
+	return &parent, nil
+}
+
 func (h *Handler) scheduleOverlaps(stationID string, startsAt, endsAt time.Time, excludeID string) (bool, error) {
 	q := h.db.Model(&models.ScheduleEntry{}).
 		Where("station_id = ?", stationID).
@@ -1579,11 +1615,12 @@ func deterministicSmartBlockSeed(entry models.ScheduleEntry, blockID string) int
 func (h *Handler) ScheduleEntryDetails(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 
-	var entry models.ScheduleEntry
-	if err := h.db.First(&entry, "id = ?", id).Error; err != nil {
+	resolved, err := h.resolveScheduleEntry(id)
+	if err != nil {
 		http.Error(w, "Entry not found", http.StatusNotFound)
 		return
 	}
+	entry := *resolved
 
 	response := map[string]any{
 		"id":          entry.ID,
@@ -2402,9 +2439,8 @@ func (h *Handler) ScheduleSourceTracks(w http.ResponseWriter, r *http.Request) {
 	// Look up existing track overrides from the entry metadata
 	var trackOverrides map[string]string
 	if entryID != "" {
-		var entry models.ScheduleEntry
-		if h.db.Select("id, metadata").First(&entry, "id = ?", entryID).Error == nil && entry.Metadata != nil {
-			if overridesRaw, ok := entry.Metadata["track_overrides"]; ok {
+		if resolved, err := h.resolveScheduleEntry(entryID); err == nil && resolved.Metadata != nil {
+			if overridesRaw, ok := resolved.Metadata["track_overrides"]; ok {
 				if ovMap, ok := overridesRaw.(map[string]any); ok {
 					trackOverrides = make(map[string]string, len(ovMap))
 					for k, v := range ovMap {

--- a/internal/web/pages_schedule_recurring_read_test.go
+++ b/internal/web/pages_schedule_recurring_read_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package web
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+// A recurring occurrence is addressed by a virtual id ({parentUUID}_{YYYYMMDD}).
+// The read endpoints must resolve that to a concrete row before querying the uuid
+// id column; passing the virtual id straight in is a 404 on sqlite and a 22P02 on
+// Postgres (issue #49). With no per-occurrence override, it resolves to the parent.
+func TestScheduleEntryDetails_VirtualRecurringID_ResolvesToParent(t *testing.T) {
+	db, station := newScheduleEdgeTestDB(t)
+
+	parent := models.ScheduleEntry{
+		ID:             "11111111-1111-1111-1111-111111111111",
+		StationID:      station.ID,
+		MountID:        "m1",
+		StartsAt:       time.Date(2026, 3, 9, 10, 0, 0, 0, time.UTC),
+		EndsAt:         time.Date(2026, 3, 9, 11, 0, 0, 0, time.UTC),
+		SourceType:     "playlist",
+		SourceID:       "playlist-1",
+		RecurrenceType: models.RecurrenceWeekly,
+	}
+	if err := db.Create(&parent).Error; err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	h := &Handler{db: db, logger: zerolog.Nop()}
+
+	occ := time.Date(2026, 3, 16, 10, 0, 0, 0, time.UTC)
+	virtualID := recurrenceInstanceKey(parent.ID, occ, time.UTC)
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/schedule/entries/"+virtualID+"/details", nil)
+	req = withScheduleRouteID(req, virtualID)
+	rec := httptest.NewRecorder()
+
+	h.ScheduleEntryDetails(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("virtual recurring id should resolve, got status %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["source_type"] != "playlist" || resp["source_id"] != "playlist-1" {
+		t.Fatalf("expected parent source playlist/playlist-1, got %v/%v", resp["source_type"], resp["source_id"])
+	}
+}
+
+// When the occurrence has its own concrete override row, the read resolves to that
+// override, not the parent, so the modal shows the per-occurrence edit.
+func TestScheduleEntryDetails_VirtualRecurringID_PrefersOverride(t *testing.T) {
+	db, station := newScheduleEdgeTestDB(t)
+
+	parentID := "22222222-2222-2222-2222-222222222222"
+	parent := models.ScheduleEntry{
+		ID:             parentID,
+		StationID:      station.ID,
+		MountID:        "m1",
+		StartsAt:       time.Date(2026, 3, 9, 10, 0, 0, 0, time.UTC),
+		EndsAt:         time.Date(2026, 3, 9, 11, 0, 0, 0, time.UTC),
+		SourceType:     "playlist",
+		SourceID:       "playlist-1",
+		RecurrenceType: models.RecurrenceWeekly,
+	}
+	if err := db.Create(&parent).Error; err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	occ := time.Date(2026, 3, 16, 10, 0, 0, 0, time.UTC)
+	override := models.ScheduleEntry{
+		ID:                 "33333333-3333-3333-3333-333333333333",
+		StationID:          station.ID,
+		MountID:            "m1",
+		StartsAt:           occ,
+		EndsAt:             occ.Add(time.Hour),
+		SourceType:         "media",
+		SourceID:           "media-override",
+		RecurrenceParentID: &parentID,
+	}
+	if err := db.Create(&override).Error; err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	h := &Handler{db: db, logger: zerolog.Nop()}
+	virtualID := recurrenceInstanceKey(parentID, occ, time.UTC)
+
+	req := httptest.NewRequest(http.MethodGet, "/dashboard/schedule/entries/"+virtualID+"/details", nil)
+	req = withScheduleRouteID(req, virtualID)
+	rec := httptest.NewRecorder()
+
+	h.ScheduleEntryDetails(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("virtual recurring id should resolve, got status %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if resp["source_type"] != "media" || resp["source_id"] != "media-override" {
+		t.Fatalf("expected override source media/media-override, got %v/%v", resp["source_type"], resp["source_id"])
+	}
+}
+
+// The shared resolver both read handlers use: a plain uuid passes straight
+// through, and an unknown id surfaces an error rather than being swallowed.
+func TestResolveScheduleEntry_PlainAndMissing(t *testing.T) {
+	db, station := newScheduleEdgeTestDB(t)
+
+	entry := models.ScheduleEntry{
+		ID:         "44444444-4444-4444-4444-444444444444",
+		StationID:  station.ID,
+		MountID:    "m1",
+		StartsAt:   time.Date(2026, 3, 9, 10, 0, 0, 0, time.UTC),
+		EndsAt:     time.Date(2026, 3, 9, 11, 0, 0, 0, time.UTC),
+		SourceType: "playlist",
+		SourceID:   "playlist-1",
+	}
+	if err := db.Create(&entry).Error; err != nil {
+		t.Fatalf("create entry: %v", err)
+	}
+
+	h := &Handler{db: db, logger: zerolog.Nop()}
+
+	got, err := h.resolveScheduleEntry(entry.ID)
+	if err != nil {
+		t.Fatalf("plain uuid should resolve: %v", err)
+	}
+	if got.ID != entry.ID {
+		t.Fatalf("plain uuid resolved to %s, want %s", got.ID, entry.ID)
+	}
+
+	if _, err := h.resolveScheduleEntry("55555555-5555-5555-5555-555555555555"); err == nil {
+		t.Fatal("unknown id should return an error, got nil")
+	}
+}


### PR DESCRIPTION
Runs the Postgres-16 CI suite for the #49 fix. Review/tracking on GitLab. See the GitLab MR for full detail; this PR exists to exercise ci.yml on the pull_request event.