### PR TITLE
fix(schedule): add the entry Duplicate route + surface its failures (#58)

### DIFF
--- a/internal/web/pages_schedule.go
+++ b/internal/web/pages_schedule.go
@@ -1339,6 +1339,73 @@ func (h *Handler) ScheduleUpdateEntry(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(entry)
 }
 
+// ScheduleEntryDuplicate creates a standalone (non-recurring) copy of a schedule
+// entry (#58). A virtual recurring-occurrence id resolves to its concrete source
+// through resolveScheduleEntry; the copy lands at the clicked occurrence's time
+// (sent in the body) and never joins the original series.
+func (h *Handler) ScheduleEntryDuplicate(w http.ResponseWriter, r *http.Request) {
+	station := h.GetStation(r)
+	if station == nil {
+		http.Error(w, "No station selected", http.StatusBadRequest)
+		return
+	}
+
+	id := chi.URLParam(r, "id")
+	src, err := h.resolveScheduleEntry(id)
+	if err != nil || src.StationID != station.ID {
+		http.NotFound(w, r)
+		return
+	}
+
+	// Times default to the resolved entry's; the calendar sends the clicked
+	// occurrence's times so a duplicated occurrence lands where it was clicked.
+	startsAt, endsAt := src.StartsAt, src.EndsAt
+	var body struct {
+		StartsAt *time.Time `json:"starts_at"`
+		EndsAt   *time.Time `json:"ends_at"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err == nil {
+		if body.StartsAt != nil && body.EndsAt != nil && body.EndsAt.After(*body.StartsAt) {
+			startsAt, endsAt = *body.StartsAt, *body.EndsAt
+		}
+	}
+
+	newID := uuid.New().String()
+	dup := models.ScheduleEntry{
+		ID:             newID,
+		StationID:      station.ID,
+		MountID:        src.MountID,
+		StartsAt:       startsAt,
+		EndsAt:         endsAt,
+		SourceType:     src.SourceType,
+		SourceID:       src.SourceID,
+		Metadata:       src.Metadata,
+		RecurrenceType: models.RecurrenceNone,
+		SeriesID:       &newID,
+	}
+	if err := h.db.Create(&dup).Error; err != nil {
+		http.Error(w, "Failed to duplicate entry", http.StatusInternalServerError)
+		return
+	}
+
+	if h.eventBus != nil {
+		h.eventBus.Publish(events.EventScheduleUpdate, events.Payload{
+			"entry_id":    dup.ID,
+			"station_id":  dup.StationID,
+			"mount_id":    dup.MountID,
+			"starts_at":   dup.StartsAt,
+			"ends_at":     dup.EndsAt,
+			"source_type": dup.SourceType,
+			"source_id":   dup.SourceID,
+			"metadata":    dup.Metadata,
+			"event":       "duplicate",
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(dup)
+}
+
 // ScheduleDeleteEntry deletes a schedule entry
 func (h *Handler) ScheduleDeleteEntry(w http.ResponseWriter, r *http.Request) {
 	station := h.GetStation(r)

--- a/internal/web/pages_schedule_duplicate_test.go
+++ b/internal/web/pages_schedule_duplicate_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package web
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+// Context-menu Duplicate on a recurring occurrence creates a standalone (non-
+// recurring) copy at the clicked occurrence's time, leaving the series intact
+// (#58). Virtual ids resolve through the shared helper before copying.
+func TestScheduleEntryDuplicate_CreatesStandaloneCopyAtOccurrenceTime(t *testing.T) {
+	db, station := newScheduleEdgeTestDB(t)
+
+	parentStart := time.Date(2026, 3, 9, 10, 0, 0, 0, time.UTC)
+	parent := models.ScheduleEntry{
+		ID:             "parent-entry",
+		StationID:      station.ID,
+		MountID:        "m1",
+		StartsAt:       parentStart,
+		EndsAt:         parentStart.Add(time.Hour),
+		SourceType:     "playlist",
+		SourceID:       "playlist-1",
+		RecurrenceType: models.RecurrenceWeekly,
+	}
+	if err := db.Create(&parent).Error; err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	h := &Handler{db: db, logger: zerolog.Nop()}
+
+	occ := time.Date(2026, 3, 16, 10, 0, 0, 0, time.UTC)
+	virtualID := recurrenceInstanceKey(parent.ID, occ, time.UTC)
+	reqBody, _ := json.Marshal(map[string]any{"starts_at": occ, "ends_at": occ.Add(time.Hour)})
+	req := httptest.NewRequest(http.MethodPost, "/dashboard/schedule/entries/"+virtualID+"/duplicate", bytes.NewReader(reqBody))
+	req = withScheduleRouteID(req, virtualID)
+	req = req.WithContext(context.WithValue(req.Context(), ctxKeyStation, &station))
+	rr := httptest.NewRecorder()
+
+	h.ScheduleEntryDuplicate(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	var all []models.ScheduleEntry
+	if err := db.Order("created_at ASC").Find(&all).Error; err != nil {
+		t.Fatalf("load entries: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2 entries after duplicate, got %d", len(all))
+	}
+	dup := all[1]
+	if dup.ID == parent.ID {
+		t.Fatal("duplicate reused the parent id")
+	}
+	if dup.RecurrenceType != models.RecurrenceNone {
+		t.Fatalf("duplicate should be standalone, got recurrence %q", dup.RecurrenceType)
+	}
+	if dup.RecurrenceParentID != nil || dup.IsInstance {
+		t.Fatal("duplicate should not be a recurrence instance")
+	}
+	if dup.SourceType != "playlist" || dup.SourceID != "playlist-1" {
+		t.Fatalf("duplicate source mismatch: %s/%s", dup.SourceType, dup.SourceID)
+	}
+	if !dup.StartsAt.Equal(occ) {
+		t.Fatalf("duplicate StartsAt=%v want occurrence time %v", dup.StartsAt, occ)
+	}
+
+	var reloaded models.ScheduleEntry
+	if err := db.First(&reloaded, "id = ?", parent.ID).Error; err != nil {
+		t.Fatalf("reload parent: %v", err)
+	}
+	if reloaded.RecurrenceType != models.RecurrenceWeekly || !reloaded.StartsAt.Equal(parentStart) {
+		t.Fatal("parent series was modified by the duplicate")
+	}
+}

--- a/internal/web/routes.go
+++ b/internal/web/routes.go
@@ -244,6 +244,7 @@ func (h *Handler) Routes(r chi.Router) {
 					r.Get("/entries/{id}/details", h.ScheduleEntryDetails)
 					r.With(h.RequireRole("manager")).Put("/entries/{id}", h.ScheduleUpdateEntry)
 					r.With(h.RequireRole("manager")).Delete("/entries/{id}", h.ScheduleDeleteEntry)
+					r.With(h.RequireRole("manager")).Post("/entries/{id}/duplicate", h.ScheduleEntryDuplicate)
 					r.With(h.RequireRole("manager")).Post("/refresh", h.ScheduleRefresh)
 
 					r.Get("/source-tracks", h.ScheduleSourceTracks) // JSON track list for any source

--- a/internal/web/templates/pages/dashboard/schedule/calendar.html
+++ b/internal/web/templates/pages/dashboard/schedule/calendar.html
@@ -3511,11 +3511,18 @@ document.addEventListener('DOMContentLoaded', function() {
     async function duplicateEvent(event) {
         try {
             const response = await fetch(`/dashboard/schedule/entries/${event.id}/duplicate`, {
-                method: 'POST'
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    starts_at: event.start ? event.start.toISOString() : null,
+                    ends_at: event.end ? event.end.toISOString() : null
+                })
             });
             if (response.ok) {
                 calendar.refetchEvents();
                 grimnirUtils.showToast('Event duplicated', 'success');
+            } else {
+                grimnirUtils.showToast('Failed to duplicate', 'error');
             }
         } catch (e) {
             grimnirUtils.showToast('Failed to duplicate', 'error');


### PR DESCRIPTION
Runs Postgres-16 CI for the #58 fix. Review on GitLab; this PR exercises ci.yml.