### PR TITLE
fix(schedule): surface context-menu Delete failures with an error toast (#59)

### DIFF
--- a/internal/web/templates/pages/dashboard/schedule/calendar.html
+++ b/internal/web/templates/pages/dashboard/schedule/calendar.html
@@ -3504,7 +3504,11 @@ document.addEventListener('DOMContentLoaded', function() {
                 }
                 eventModal.hide();
                 grimnirUtils.showToast(isRecurring ? 'Recurring schedule ended' : 'Entry deleted', 'success');
+            } else {
+                grimnirUtils.showToast('Failed to delete entry', 'error');
             }
+        }).catch(() => {
+            grimnirUtils.showToast('Failed to delete entry', 'error');
         });
     }
 


### PR DESCRIPTION
CI check for the #59 frontend fix (confirms no Go regression). Review on GitLab.