### PR TITLE
fix(update-banner): show release notes as clean plain text (#67)

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -192,13 +192,43 @@ func parseVersion(v string) [3]int {
 	return result
 }
 
-// truncateNotes truncates release notes to a maximum length.
+// truncateNotes reduces a GitHub release body (markdown) to one plain-text line
+// for the update banner. It skips heading and blank lines (so "## What's Changed"
+// is passed over), strips leading list/heading markers and inline emphasis, and
+// caps the length. Release bodies are untrusted, so the result stays plain text
+// and is never rendered as HTML.
 func truncateNotes(s string, maxLen int) string {
-	// Take only the first line or first N characters
-	lines := strings.SplitN(s, "\n", 2)
-	s = strings.TrimSpace(lines[0])
-	if len(s) > maxLen {
-		return s[:maxLen-3] + "..."
+	line := firstReleaseContentLine(s)
+	if len(line) > maxLen {
+		return line[:maxLen-3] + "..."
 	}
-	return s
+	return line
+}
+
+func firstReleaseContentLine(s string) string {
+	lines := strings.Split(s, "\n")
+	// Prefer the first non-heading, non-empty line: the first real change.
+	for _, raw := range lines {
+		t := strings.TrimSpace(raw)
+		if t == "" || strings.HasPrefix(t, "#") {
+			continue
+		}
+		return stripReleaseMarkdown(t)
+	}
+	// Only headings/blank lines present: strip the first non-empty one.
+	for _, raw := range lines {
+		if t := strings.TrimSpace(raw); t != "" {
+			return stripReleaseMarkdown(t)
+		}
+	}
+	return ""
+}
+
+func stripReleaseMarkdown(line string) string {
+	line = strings.TrimSpace(line)
+	line = strings.TrimLeft(line, "#>-*+ ") // leading heading/list/quote markers
+	for _, m := range []string{"**", "__", "`"} {
+		line = strings.ReplaceAll(line, m, "")
+	}
+	return strings.TrimSpace(line)
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,42 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package version
+
+import "testing"
+
+// The update banner shows truncateNotes(release.Body) as plain text. GitHub
+// auto-generated bodies start with "## What's Changed", which rendered as raw
+// markdown in the banner (#67). truncateNotes must return a clean plain-text
+// line: no leading '#'/'*' markers, and it should skip the heading to the first
+// real change line.
+func TestTruncateNotes_StripsMarkdownAndSkipsHeading(t *testing.T) {
+	body := "## What's Changed\n* Fix the crash by @alice in #12\n\n**Full Changelog**: https://x/y"
+	got := truncateNotes(body, 200)
+	if want := "Fix the crash by @alice in #12"; got != want {
+		t.Fatalf("truncateNotes = %q, want %q", got, want)
+	}
+}
+
+func TestTruncateNotes_PlainLineUnchanged(t *testing.T) {
+	if got := truncateNotes("Just a plain summary.", 200); got != "Just a plain summary." {
+		t.Fatalf("truncateNotes = %q, want plain line unchanged", got)
+	}
+}
+
+func TestTruncateNotes_HeadingOnlyStripsMarkers(t *testing.T) {
+	if got := truncateNotes("## Only a heading here", 200); got != "Only a heading here" {
+		t.Fatalf("truncateNotes = %q, want heading markers stripped", got)
+	}
+}
+
+func TestTruncateNotes_Truncates(t *testing.T) {
+	long := "abcdefghijklmnopqrstuvwxyz"
+	got := truncateNotes(long, 10)
+	if len(got) != 10 || got[len(got)-3:] != "..." {
+		t.Fatalf("truncateNotes = %q, want 10 chars ending with ...", got)
+	}
+}


### PR DESCRIPTION
Runs Postgres-16 CI for the #67 fix. Review on GitLab.