### PR TITLE
Silence bridge v2 + connect-seam, playout & smart-block fixes

### DIFF
--- a/internal/broadcast/server.go
+++ b/internal/broadcast/server.go
@@ -293,11 +293,15 @@ func (m *Mount) Broadcast(data []byte) {
 	// silence bridge can hold its output to a wall-clock realtime budget.
 	atomic.AddInt64(&m.bytesOut, int64(len(data)))
 
-	// Store in ring buffer for new clients
-	m.buffer.Write(data)
-
 	m.mu.RLock()
 	defer m.mu.RUnlock()
+
+	// The ring write happens under the same mount lock as the client fan-out
+	// below so that both are atomic against attachClient's snapshot+register:
+	// a chunk lands either wholly before the snapshot (delivered via preroll)
+	// or wholly after registration (delivered via the channel), never both and
+	// never neither.
+	m.buffer.Write(data)
 
 	skipped := false
 	for c := range m.clients {
@@ -412,6 +416,23 @@ func (m *Mount) inGap() bool {
 		return false
 	}
 	return time.Since(time.Unix(0, fedNs)) > m.bridgeGraceD
+}
+
+// attachClient atomically snapshots up to prerollBytes of recent ring-buffer
+// audio and registers c for live delivery, under the write side of the same
+// lock Broadcast holds across its ring write and channel fan-out. That
+// pairing is what makes the connect seam clean: every chunk is either wholly
+// in the returned preroll or wholly in c.ch, so the caller can write the
+// preroll first and then drain the channel without duplicating or losing a
+// chunk. Returns the snapshot and the connection count after registration.
+func (m *Mount) attachClient(c *client, prerollBytes int) (preroll []byte, connections int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if prerollBytes > 0 {
+		preroll = m.buffer.GetRecent(prerollBytes)
+	}
+	m.clients[c] = struct{}{}
+	return preroll, len(m.clients)
 }
 
 // FeedFrom reads from an io.Reader and broadcasts the data.
@@ -554,15 +575,33 @@ func (m *Mount) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		userAgent:  r.UserAgent(),
 	}
 
-	// Register client for delivery. It does NOT count as a listener yet:
-	// the counters roll only after the connection is fully established
+	// Preroll sizing. Quality switches (nobuffer=1) get ~200ms to prime the
+	// connection without affecting sync; normal connects get 2 seconds of
+	// audio for a quick, stable start (capped at 64KB, floored at 8KB).
+	var prerollBytes int
+	if skipBuffer {
+		prerollBytes = (m.Bitrate * 1000 / 8) / 5 // 200ms of audio
+		if prerollBytes < 1000 {
+			prerollBytes = 1000
+		}
+	} else {
+		prerollBytes = (m.Bitrate * 1000 / 8) * 2 // 2 seconds of audio
+		if prerollBytes > 64000 {
+			prerollBytes = 64000 // Cap at 64KB (~4s at 128kbps)
+		}
+		if prerollBytes < 8000 {
+			prerollBytes = 8000 // Minimum 8KB
+		}
+	}
+
+	// Register client for delivery, snapshotting the preroll atomically with
+	// registration (attachClient) so a chunk arriving at the connect seam is
+	// never delivered twice or lost. The client does NOT count as a listener
+	// yet: the counters roll only after the connection is fully established
 	// (establishThresholdBytes delivered), so recycled/parked connections
 	// never inflate the listener numbers they used to (issue #18: ~1,415
 	// reported against ~15 real).
-	m.mu.Lock()
-	m.clients[c] = struct{}{}
-	connectionCount := len(m.clients)
-	m.mu.Unlock()
+	preroll, connectionCount := m.attachClient(c, prerollBytes)
 
 	m.logger.Info().Str("mount", m.Name).Int("connections", connectionCount).Bool("quality_switch", skipBuffer).
 		Str("remote", c.remoteAddr).Str("ua", c.userAgent).Msg("client connected (unestablished)")
@@ -590,42 +629,10 @@ func (m *Mount) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		m.publishListenerStats(listeners, "connect")
 	}
 
-	// Send buffered data to help client start faster
-	// For quality switches (nobuffer=1), send minimal data to prime connection
-	// This prevents browser timeout while waiting for live data
-	if skipBuffer {
-		// Send ~200ms of audio to prime the connection without affecting sync much
-		// At 128kbps: 200ms = ~3KB, At 64kbps: 200ms = ~1.5KB
-		primeBytes := (m.Bitrate * 1000 / 8) / 5 // 200ms of audio
-		if primeBytes < 1000 {
-			primeBytes = 1000
-		}
-		if recent := m.buffer.GetRecent(primeBytes); len(recent) > 0 {
-			if err := writeAndFlush(recent); err != nil {
-				m.logger.Info().Err(err).Msg("initial buffer write failed (skipBuffer)")
-				return
-			}
-		}
-	} else {
-		// Send 2 seconds of audio for quick start and stable playback
-		// At 128kbps: 2s = 32KB, At 64kbps: 2s = 16KB
-		bufferBytes := (m.Bitrate * 1000 / 8) * 2 // 2 seconds of audio
-		if bufferBytes > 64000 {
-			bufferBytes = 64000 // Cap at 64KB (~4s at 128kbps)
-		}
-		if bufferBytes < 8000 {
-			bufferBytes = 8000 // Minimum 8KB
-		}
-		if recent := m.buffer.GetRecent(bufferBytes); len(recent) > 0 {
-			if err := writeAndFlush(recent); err != nil {
-				m.logger.Info().Err(err).Int("bytes", len(recent)).Msg("initial buffer write failed")
-				return
-			}
-			m.logger.Info().Int("bytes", len(recent)).Msg("initial buffer sent, entering main loop")
-		}
-	}
-
-	// Cleanup on disconnect. Only an established client rolls the counters
+	// Cleanup on disconnect. Registered BEFORE the preroll write below: an
+	// early return on a failed preroll used to leave the client behind in
+	// m.clients forever (a zombie connection no serve loop would ever remove).
+	// Only an established client rolls the counters
 	// back and emits a disconnect event — a connection that never qualified
 	// was never counted, so it has nothing to undo.
 	defer func() {
@@ -654,6 +661,19 @@ func (m *Mount) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			m.publishListenerStats(listeners, "disconnect")
 		}
 	}()
+
+	// Write the preroll snapshot before draining live chunks: c.ch only holds
+	// chunks broadcast after the snapshot, so this order preserves the stream.
+	// It bypasses delivered() on purpose; a single connect burst absorbs into
+	// socket buffers whether or not a listener exists, so it must not count
+	// toward establishment.
+	if len(preroll) > 0 {
+		if err := writeAndFlush(preroll); err != nil {
+			m.logger.Info().Err(err).Int("bytes", len(preroll)).Msg("initial buffer write failed")
+			return
+		}
+		m.logger.Info().Int("bytes", len(preroll)).Msg("initial buffer sent, entering main loop")
+	}
 
 	// Create a single timer for keepalive - reused instead of creating new ones.
 	// Stays above writeTimeout (30s) and below the server IdleTimeout (60s).

--- a/internal/broadcast/server.go
+++ b/internal/broadcast/server.go
@@ -251,14 +251,14 @@ func NewMount(name, contentType string, bitrate int, logger zerolog.Logger, bus 
 	}
 
 	return &Mount{
-		Name:        name,
-		ContentType: contentType,
-		Bitrate:     bitrate,
-		clients:     make(map[*client]struct{}),
-		buffer:      newRingBuffer(bufferSize),
-		logger:      logger.With().Str("mount", name).Logger(),
-		inputDone:   make(chan struct{}),
-		bus:         bus,
+		Name:         name,
+		ContentType:  contentType,
+		Bitrate:      bitrate,
+		clients:      make(map[*client]struct{}),
+		buffer:       newRingBuffer(bufferSize),
+		logger:       logger.With().Str("mount", name).Logger(),
+		inputDone:    make(chan struct{}),
+		bus:          bus,
 		silentFrame:  mp3SilenceFrame(contentType, bitrate),
 		bridgeStop:   make(chan struct{}),
 		bridgeGraceD: bridgeGrace,

--- a/internal/broadcast/server.go
+++ b/internal/broadcast/server.go
@@ -58,6 +58,83 @@ type Mount struct {
 	// pre-roll and parks (recycled browser <audio> elements, proxy-held
 	// sockets) never counts. Guarded by mu.
 	establishedCount int
+
+	// silentFrame is one CBR MP3 frame of digital silence sized to this mount's
+	// bitrate, or nil for a codec/bitrate the silence bridge can't encode.
+	// runSilenceBridge emits it across input gaps (a track/program transition
+	// stops one pipeline before the next attaches) so a downstream puller (OBS
+	// restream to YouTube) never sees a stall long enough to drop — but only
+	// while the mount is behind its wall-clock realtime budget; see bytesOut.
+	silentFrame []byte
+	bridgeStop  chan struct{}
+	bridgeStart sync.Once // starts the bridge goroutine on first real feed
+	bridgeEnd   sync.Once // closes bridgeStop exactly once
+
+	// Bridge tuning, captured from the package vars at NewMount so the bridge
+	// goroutine never reads the mutable globals (tests shorten those, and a
+	// goroutine from an earlier test still draining would race the write).
+	bridgeGraceD time.Duration
+	bridgePollD  time.Duration
+	bridgeSlackD time.Duration
+
+	// bytesOut counts every byte handed to Broadcast (real feed and bridge
+	// silence alike). The bridge compares it against a wall-clock realtime
+	// budget: silence flows only while delivery is BEHIND realtime. This is
+	// what the v1.40.19 bridge lacked — it filled every gap at full bitrate,
+	// which removed the drain windows paced clients (OBS restreams) used to
+	// catch up after per-boundary bursts, so their backlog compounded until the
+	// 256-chunk send channel overflowed and the connection reset. Atomic.
+	bytesOut int64
+}
+
+// Silence-bridge tuning. A gap shorter than bridgeGrace is left alone: client
+// kernel/app buffers absorb it, and inserting silence on every fast track
+// change would be needless. bridgePoll is how often the bridge advances its
+// budget and checks for a gap. bridgeMaxSlack bounds how far the budget
+// accountant may drift from bytesOut in either direction, so hours of small
+// encoder clock drift can't build unbounded credit or debt. All three are
+// vars, not consts, only so tests can shorten them.
+var (
+	bridgeGrace    = 300 * time.Millisecond
+	bridgePoll     = 50 * time.Millisecond
+	bridgeMaxSlack = 4 * time.Second
+)
+
+// mpeg1L3BitrateIndex maps a CBR MP3 bitrate (kbps) to its MPEG-1 Layer III
+// bitrate index. Only standard MPEG-1 values are listed; anything else
+// disables the bridge for that mount.
+var mpeg1L3BitrateIndex = map[int]byte{
+	32: 1, 40: 2, 48: 3, 56: 4, 64: 5, 80: 6, 96: 7, 112: 8,
+	128: 9, 160: 10, 192: 11, 224: 12, 256: 13, 320: 14,
+}
+
+// mp3SilenceFrame builds one CBR MPEG-1 Layer III frame whose payload is all
+// zeroes. A zeroed main_data section decodes to digital silence in lame,
+// ffmpeg, and mpg123, and CBR silent frames concatenate seamlessly, so a
+// stream of these is valid, silent audio. It assumes 44.1 kHz, which every
+// station mount runs (director sets SampleRate: 44100). Returns nil for any
+// content type or bitrate it can't encode (AAC/OGG mounts, non-standard
+// bitrates), which leaves those mounts on the prior behaviour with no bridge.
+func mp3SilenceFrame(contentType string, bitrateKbps int) []byte {
+	if !strings.Contains(contentType, "mpeg") {
+		return nil
+	}
+	brIndex, ok := mpeg1L3BitrateIndex[bitrateKbps]
+	if !ok {
+		return nil
+	}
+	const sampleRate = 44100 // MPEG-1 sample-rate index 0
+	// MPEG-1 Layer III carries 1152 samples per frame; CBR length, no padding.
+	frameLen := 144 * bitrateKbps * 1000 / sampleRate
+	if frameLen < 4 {
+		return nil
+	}
+	frame := make([]byte, frameLen)
+	frame[0] = 0xFF              // frame sync (8 bits)
+	frame[1] = 0xFB              // sync (3) + MPEG-1 (11) + Layer III (01) + no CRC (1)
+	frame[2] = brIndex<<4 | 0x00 // bitrate index, sample-rate index 0 (44.1k), no padding/private
+	frame[3] = 0x00              // stereo, no mode ext, not copyright/original, no emphasis
+	return frame
 }
 
 // establishSeconds of continuously delivered audio marks a connection as an
@@ -182,6 +259,11 @@ func NewMount(name, contentType string, bitrate int, logger zerolog.Logger, bus 
 		logger:      logger.With().Str("mount", name).Logger(),
 		inputDone:   make(chan struct{}),
 		bus:         bus,
+		silentFrame:  mp3SilenceFrame(contentType, bitrate),
+		bridgeStop:   make(chan struct{}),
+		bridgeGraceD: bridgeGrace,
+		bridgePollD:  bridgePoll,
+		bridgeSlackD: bridgeMaxSlack,
 	}
 }
 
@@ -206,6 +288,10 @@ func (m *Mount) Broadcast(data []byte) {
 	if len(data) == 0 {
 		return
 	}
+
+	// Account every delivered byte (real feed and bridge silence alike) so the
+	// silence bridge can hold its output to a wall-clock realtime budget.
+	atomic.AddInt64(&m.bytesOut, int64(len(data)))
 
 	// Store in ring buffer for new clients
 	m.buffer.Write(data)
@@ -235,11 +321,116 @@ func (m *Mount) Broadcast(data []byte) {
 	}
 }
 
+// runSilenceBridge keeps the outgoing byte stream alive across input gaps,
+// without ever pushing delivery ahead of realtime. It maintains a wall-clock
+// byte budget that grows at the mount's bitrate; each poll it advances the
+// budget, clamps it to within bridgeMaxSlack of bytesOut (so slow drift can't
+// bank unbounded credit or debt), and — only when the mount is in a gap
+// (inGap) AND delivery is behind budget — emits silent frames until the two
+// meet again. A mount that ran ahead of realtime (boundary burst, connect
+// pre-roll) is deliberately left quiet through the gap: that is the drain
+// window where paced clients (OBS restreams re-encoding toward YouTube) work
+// off their backlog, and filling it is exactly what regressed v1.40.19.
+// It never touches lastFedAt, so the director's dead-air detection still
+// fires and still restarts the real pipeline; the bridge only covers the seam.
+// baseline and start anchor the budget: bytes delivered before the bridge
+// existed are history, not debt. Both are captured synchronously by the
+// caller (FeedFrom's bridgeStart.Do), BEFORE the first feed's bytes flow, so
+// a fast first feed can't slip under the baseline while this goroutine is
+// still being scheduled.
+func (m *Mount) runSilenceBridge(baseline int64, start time.Time) {
+	byteRate := float64(m.Bitrate * 1000 / 8)
+	if byteRate <= 0 {
+		byteRate = 16000 // 128 kbps
+	}
+	frameLen := int64(len(m.silentFrame))
+
+	poll := time.NewTicker(m.bridgePollD)
+	defer poll.Stop()
+
+	budget := float64(baseline)
+	last := start
+	filling := false
+
+	for {
+		select {
+		case <-m.bridgeStop:
+			return
+		case now := <-poll.C:
+			budget += now.Sub(last).Seconds() * byteRate
+			last = now
+
+			out := atomic.LoadInt64(&m.bytesOut)
+			slack := m.bridgeSlackD.Seconds() * byteRate
+			if budget > float64(out)+slack {
+				budget = float64(out) + slack
+			} else if budget < float64(out)-slack {
+				budget = float64(out) - slack
+			}
+
+			if !m.inGap() {
+				if filling {
+					m.logger.Info().Msg("silence bridge released: live feed resumed")
+					filling = false
+				}
+				continue
+			}
+
+			// Emit only up to the budget; the next poll grows it by one tick's
+			// worth, so sustained output averages exactly realtime.
+			emitted := false
+			for m.inGap() && atomic.LoadInt64(&m.bytesOut)+frameLen <= int64(budget) {
+				m.Broadcast(m.silentFrame)
+				telemetry.BroadcastBridgedChunksTotal.WithLabelValues(m.Name).Inc()
+				emitted = true
+			}
+			if emitted && !filling {
+				m.logger.Info().Msg("silence bridge filling input gap")
+				filling = true
+			}
+		}
+	}
+}
+
+// inGap reports whether the mount is in an input gap the silence bridge may
+// fill: a client is connected, no live feed is attached, and real audio last
+// arrived longer ago than bridgeGrace. lastFedAt is advanced only by FeedFrom
+// (real audio), never by the bridge itself, so the time since it is exactly
+// the current gap length, and the grace test keeps working while the bridge
+// runs. Whether silence actually flows is additionally gated on the realtime
+// budget in runSilenceBridge.
+func (m *Mount) inGap() bool {
+	fedNs := atomic.LoadInt64(&m.lastFedAt)
+	if fedNs == 0 {
+		return false // never fed real audio: don't prepend silence at startup
+	}
+	m.mu.RLock()
+	noInput := m.inputCount == 0
+	hasClients := len(m.clients) > 0
+	m.mu.RUnlock()
+	if !noInput || !hasClients {
+		return false
+	}
+	return time.Since(time.Unix(0, fedNs)) > m.bridgeGraceD
+}
+
 // FeedFrom reads from an io.Reader and broadcasts the data.
 // This is typically connected to GStreamer's stdout.
 // Note: Call ClearBuffer() on all related mounts BEFORE calling FeedFrom
 // to ensure synchronized buffer clearing across HQ/LQ mount pairs.
 func (m *Mount) FeedFrom(r io.Reader) error {
+	// Start the silence bridge on the first real feed. Starting it here (not in
+	// NewMount) keeps it inert for mounts that are only ever driven directly via
+	// Broadcast, which is every unit test, so the bridge never perturbs them.
+	if m.silentFrame != nil {
+		m.bridgeStart.Do(func() {
+			// Snapshot the budget anchor here, not in the goroutine: this runs
+			// before the feed below delivers its first byte, so those bytes
+			// count against the budget rather than vanishing into the baseline.
+			go m.runSilenceBridge(atomic.LoadInt64(&m.bytesOut), time.Now())
+		})
+	}
+
 	// Register this feed
 	m.mu.Lock()
 	m.inputCount++
@@ -568,6 +759,9 @@ func (m *Mount) ClearBuffer() {
 
 // Close disconnects all clients.
 func (m *Mount) Close() {
+	// Stop the silence bridge goroutine if it ever started.
+	m.bridgeEnd.Do(func() { close(m.bridgeStop) })
+
 	m.mu.Lock()
 	defer m.mu.Unlock()
 

--- a/internal/broadcast/silence_bridge_test.go
+++ b/internal/broadcast/silence_bridge_test.go
@@ -1,0 +1,302 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package broadcast
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/friendsincode/grimnir_radio/internal/events"
+	"github.com/rs/zerolog"
+)
+
+// A silent MP3 frame must carry a valid MPEG-1 Layer III header and the CBR
+// length for its bitrate, and be all zeroes past the 4-byte header so it decodes
+// to digital silence.
+func TestMP3SilenceFrame(t *testing.T) {
+	cases := []struct {
+		bitrate   int
+		wantLen   int
+		wantByte2 byte
+	}{
+		{128, 417, 0x90}, // 144*128000/44100 = 417, bitrate index 9
+		{64, 208, 0x50},  // 144*64000/44100 = 208, bitrate index 5
+	}
+	for _, tc := range cases {
+		f := mp3SilenceFrame("audio/mpeg", tc.bitrate)
+		if len(f) != tc.wantLen {
+			t.Fatalf("bitrate %d: frame len = %d, want %d", tc.bitrate, len(f), tc.wantLen)
+		}
+		if f[0] != 0xFF || f[1] != 0xFB {
+			t.Fatalf("bitrate %d: bad sync/header %02X %02X", tc.bitrate, f[0], f[1])
+		}
+		if f[2] != tc.wantByte2 {
+			t.Fatalf("bitrate %d: byte2 = %02X, want %02X", tc.bitrate, f[2], tc.wantByte2)
+		}
+		for i := 4; i < len(f); i++ {
+			if f[i] != 0 {
+				t.Fatalf("bitrate %d: payload byte %d = %02X, want 0 (silence)", tc.bitrate, i, f[i])
+			}
+		}
+	}
+}
+
+// Non-MP3 codecs and non-standard bitrates get no frame, which disables the
+// bridge for those mounts rather than emitting bytes a decoder can't parse.
+func TestMP3SilenceFrame_Unsupported(t *testing.T) {
+	for _, tc := range []struct {
+		ct      string
+		bitrate int
+	}{
+		{"audio/aac", 128},
+		{"audio/ogg", 128},
+		{"audio/mpeg", 130}, // not a standard MP3 bitrate
+	} {
+		if f := mp3SilenceFrame(tc.ct, tc.bitrate); f != nil {
+			t.Fatalf("mp3SilenceFrame(%q, %d) = %d bytes, want nil", tc.ct, tc.bitrate, len(f))
+		}
+	}
+}
+
+// When a live feed ends with the stream behind its realtime budget, the bridge
+// must keep the outgoing stream flowing so a connected puller is never starved
+// into dropping.
+func TestMount_SilenceBridge_FillsGap(t *testing.T) {
+	origGrace, origPoll := bridgeGrace, bridgePoll
+	bridgeGrace, bridgePoll = 40*time.Millisecond, 10*time.Millisecond
+	defer func() { bridgeGrace, bridgePoll = origGrace, origPoll }()
+
+	bus := events.NewBus()
+	m := NewMount("test", "audio/mpeg", 128, zerolog.Nop(), bus)
+	defer m.Close()
+
+	// One real feed that ends immediately (EOF), which sets lastFedAt and then
+	// drops inputCount to 0: the exact seam between two tracks. This also starts
+	// the bridge goroutine (first FeedFrom). The feed is one frame, far below
+	// wall-clock realtime, so the mount is behind budget and the bridge must run.
+	if err := m.FeedFrom(newByteReader(m.silentFrame)); err != io.EOF {
+		t.Fatalf("FeedFrom returned %v, want io.EOF", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(m.ServeHTTP))
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/live")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var got int64
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := resp.Body.Read(buf)
+			atomic.AddInt64(&got, int64(n))
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	// After the grace, the bridge should be feeding silence. Sample the byte
+	// count across a window that has no live feed at all, and require it to keep
+	// climbing: that only happens if the bridge is emitting.
+	if !waitFor(t, 2*time.Second, func() bool { return atomic.LoadInt64(&got) > 0 }) {
+		t.Fatal("client received no data during input gap; bridge did not fill it")
+	}
+	mid := atomic.LoadInt64(&got)
+	time.Sleep(200 * time.Millisecond)
+	end := atomic.LoadInt64(&got)
+	if end <= mid {
+		t.Fatalf("byte count did not advance during gap (mid=%d end=%d); bridge stalled", mid, end)
+	}
+}
+
+// The bridge must pace against the realtime budget: over a window it may not
+// emit meaningfully more than bitrate. The v1.40.19 bridge had no such bound
+// tied to a wall-clock budget, which let stream delivery run ahead of realtime
+// and accumulate client backlog (the prod regression).
+func TestMount_SilenceBridge_PacesAtRealtime(t *testing.T) {
+	origGrace, origPoll := bridgeGrace, bridgePoll
+	bridgeGrace, bridgePoll = 20*time.Millisecond, 10*time.Millisecond
+	defer func() { bridgeGrace, bridgePoll = origGrace, origPoll }()
+
+	bus := events.NewBus()
+	m := NewMount("test", "audio/mpeg", 128, zerolog.Nop(), bus)
+	defer m.Close()
+
+	if err := m.FeedFrom(newByteReader(m.silentFrame)); err != io.EOF {
+		t.Fatalf("FeedFrom returned %v, want io.EOF", err)
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(m.ServeHTTP))
+	defer srv.Close()
+	resp, err := http.Get(srv.URL + "/live")
+	if err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var got int64
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			n, err := resp.Body.Read(buf)
+			atomic.AddInt64(&got, int64(n))
+			if err != nil {
+				return
+			}
+		}
+	}()
+
+	if !waitFor(t, 2*time.Second, func() bool { return atomic.LoadInt64(&got) > 0 }) {
+		t.Fatal("bridge never started emitting")
+	}
+	start := atomic.LoadInt64(&got)
+	const window = 500 * time.Millisecond
+	time.Sleep(window)
+	emitted := atomic.LoadInt64(&got) - start
+	// 128 kbps = 16000 B/s -> 8000 B in 500ms. Allow 2x for poll granularity,
+	// slack catch-up, and scheduling jitter; the broken behaviour (unbounded
+	// ahead-of-realtime emission) blows well past this.
+	if maxBytes := int64(2 * 16000 * window.Seconds()); emitted > maxBytes {
+		t.Fatalf("bridge emitted %d bytes in %v, want <= %d (realtime-ish)", emitted, window, maxBytes)
+	}
+}
+
+// A mount that is AHEAD of its realtime budget (bytes were delivered faster
+// than wall clock, e.g. an encoder burst at a track boundary) must NOT be
+// bridged: the gap is the drain window where paced clients catch up. Silence
+// starts only once the budget overtakes what was already sent.
+func TestMount_SilenceBridge_HoldsWhileAheadThenDrains(t *testing.T) {
+	origGrace, origPoll := bridgeGrace, bridgePoll
+	bridgeGrace, bridgePoll = 20*time.Millisecond, 10*time.Millisecond
+	defer func() { bridgeGrace, bridgePoll = origGrace, origPoll }()
+
+	bus := events.NewBus()
+	m := NewMount("test", "audio/mpeg", 128, zerolog.Nop(), bus)
+	defer m.Close()
+
+	// Register a bare client directly on the mount instead of going through
+	// ServeHTTP: the HTTP path's connect pre-roll can double-deliver a chunk
+	// that lands between client registration and the ring-buffer read, which
+	// would contaminate the byte accounting this test depends on. Reading
+	// c.ch observes exactly what Broadcast delivered, nothing else.
+	c := &client{ch: make(chan []byte, 256), done: make(chan struct{})}
+	m.mu.Lock()
+	m.clients[c] = struct{}{}
+	m.mu.Unlock()
+
+	drain := func() int64 {
+		var n int64
+		for {
+			select {
+			case data := <-c.ch:
+				n += int64(len(data))
+			default:
+				return n
+			}
+		}
+	}
+
+	// Burst ~700ms worth of audio (11200 B at 16000 B/s) through a real feed in
+	// one go: the mount is now ~700ms ahead of realtime, like a boundary burst.
+	burst := make([]byte, 11200)
+	if err := m.FeedFrom(newByteReader(burst)); err != io.EOF {
+		t.Fatalf("FeedFrom returned %v, want io.EOF", err)
+	}
+	if got := drain(); got != int64(len(burst)) {
+		t.Fatalf("client received %d bytes of the burst, want %d", got, len(burst))
+	}
+
+	// For the next ~200ms the mount is still ahead of budget; the bridge must
+	// hold off even though inputCount is 0, a client is attached, and the grace
+	// (20ms) has long expired. Allow one frame of slop for poll-edge timing.
+	time.Sleep(200 * time.Millisecond)
+	if over := drain(); over > int64(len(m.silentFrame)) {
+		t.Fatalf("bridge emitted %d bytes while mount was ahead of realtime budget", over)
+	}
+
+	// Once wall clock catches up with the burst (~700ms in), the deficit
+	// returns and the bridge must start filling again.
+	var resumed int64
+	if !waitFor(t, 3*time.Second, func() bool {
+		resumed += drain()
+		return resumed > int64(len(m.silentFrame))
+	}) {
+		t.Fatal("bridge never resumed after the surplus drained")
+	}
+}
+
+// While a live feed is attached the bridge must stay silent: inputCount > 0
+// means real audio is flowing and injecting frames would double it.
+func TestMount_SilenceBridge_IdleWhileFeeding(t *testing.T) {
+	origGrace, origPoll := bridgeGrace, bridgePoll
+	bridgeGrace, bridgePoll = 20*time.Millisecond, 10*time.Millisecond
+	defer func() { bridgeGrace, bridgePoll = origGrace, origPoll }()
+
+	bus := events.NewBus()
+	m := NewMount("test", "audio/mpeg", 128, zerolog.Nop(), bus)
+	defer m.Close()
+
+	// Hold a feed open (pipe never closed) so inputCount stays 1, and register a
+	// client so the only gate left is inputCount.
+	pr, pw := io.Pipe()
+	defer pw.Close()
+	go func() { _ = m.FeedFrom(pr) }()
+	if !waitFor(t, time.Second, func() bool { return m.inputActive() }) {
+		t.Fatal("feed never registered")
+	}
+	if _, err := pw.Write(m.silentFrame); err != nil {
+		t.Fatalf("prime feed: %v", err)
+	}
+
+	m.mu.Lock()
+	c := &client{ch: make(chan []byte, 256), done: make(chan struct{})}
+	m.clients[c] = struct{}{}
+	m.mu.Unlock()
+
+	// inGap must report false the whole time a feed is attached.
+	deadline := time.Now().Add(150 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if m.inGap() {
+			t.Fatal("inGap true while a live feed is attached")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// inputActive reports whether any feed is currently attached. Test helper.
+func (m *Mount) inputActive() bool {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.inputCount > 0
+}
+
+// newByteReader returns a reader that yields p once then io.EOF.
+func newByteReader(p []byte) io.Reader {
+	return &sliceReader{data: p}
+}
+
+type sliceReader struct {
+	data []byte
+	pos  int
+}
+
+func (r *sliceReader) Read(p []byte) (int, error) {
+	if r.pos >= len(r.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, r.data[r.pos:])
+	r.pos += n
+	return n, nil
+}

--- a/internal/broadcast/silence_bridge_test.go
+++ b/internal/broadcast/silence_bridge_test.go
@@ -7,9 +7,11 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 package broadcast
 
 import (
+	"encoding/binary"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -272,6 +274,76 @@ func TestMount_SilenceBridge_IdleWhileFeeding(t *testing.T) {
 			t.Fatal("inGap true while a live feed is attached")
 		}
 		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+// A client connecting while chunks are broadcasting must receive a clean
+// splice: every chunk lands either wholly in the ring-buffer preroll or wholly
+// in the live channel, never both (double delivery) and never neither (a lost
+// chunk). The old connect seam registered the client and THEN snapshotted the
+// ring outside any common lock, so a chunk arriving in between was delivered
+// twice: once in the preroll, once through the channel.
+func TestMount_AttachClient_NoDoubleDeliveryAtConnectSeam(t *testing.T) {
+	bus := events.NewBus()
+	m := NewMount("test", "audio/mpeg", 128, zerolog.Nop(), bus)
+	defer m.Close()
+
+	// Broadcast 4-byte big-endian sequence numbers in a tight loop. Chunk size
+	// divides the ring size (80000 at 128kbps), so chunk boundaries survive the
+	// ring wrap and the preroll tail is always a whole chunk.
+	var seq uint32
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		buf := make([]byte, 4)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			binary.BigEndian.PutUint32(buf, atomic.AddUint32(&seq, 1))
+			m.Broadcast(append([]byte(nil), buf...))
+			time.Sleep(50 * time.Microsecond)
+		}
+	}()
+	defer func() { close(stop); wg.Wait() }()
+
+	// Let the ring accumulate more than the preroll we'll ask for, so the
+	// snapshot holds only real numbered chunks.
+	const prerollBytes = 400
+	if !waitFor(t, 2*time.Second, func() bool { return atomic.LoadUint32(&seq) > prerollBytes }) {
+		t.Fatal("broadcaster never filled the ring")
+	}
+
+	for i := 0; i < 300; i++ {
+		c := &client{ch: make(chan []byte, 4096), done: make(chan struct{})}
+		preroll, _ := m.attachClient(c, prerollBytes)
+		if len(preroll) < 4 {
+			t.Fatalf("iteration %d: preroll too short: %d bytes", i, len(preroll))
+		}
+		tail := binary.BigEndian.Uint32(preroll[len(preroll)-4:])
+
+		var first uint32
+		select {
+		case data := <-c.ch:
+			first = binary.BigEndian.Uint32(data)
+		case <-time.After(time.Second):
+			t.Fatalf("iteration %d: no live chunk after attach", i)
+		}
+
+		if first <= tail {
+			t.Fatalf("iteration %d: connect seam double-delivered: preroll tail seq %d, first live seq %d", i, tail, first)
+		}
+		if first != tail+1 {
+			t.Fatalf("iteration %d: chunk lost at connect seam: preroll tail seq %d, first live seq %d", i, tail, first)
+		}
+
+		m.mu.Lock()
+		delete(m.clients, c)
+		m.mu.Unlock()
 	}
 }
 

--- a/internal/playout/director.go
+++ b/internal/playout/director.go
@@ -3999,6 +3999,11 @@ func (d *Director) recordPlayHistory(entry models.ScheduleEntry, extra map[strin
 // interrupted when the cut happens meaningfully early (>30s before expected end). It records
 // cut_offset_ms so findResumeOffset can use it for the next play of the same track.
 func (d *Director) closeCurrentPlayHistory(ctx context.Context, stationID, mountID string, positionMS int64) {
+	// Empty IDs can't match a row and Postgres rejects "" bound against a uuid
+	// column with 22P02, so bail before the query rather than log a hard error.
+	if stationID == "" || mountID == "" {
+		return
+	}
 	now := time.Now()
 	var h models.PlayHistory
 	if err := d.db.WithContext(ctx).

--- a/internal/playout/director.go
+++ b/internal/playout/director.go
@@ -298,22 +298,25 @@ func (d *Director) tick(ctx context.Context) error {
 		}
 
 		// Hard-boundary preemption handoff: when an entry's scheduled slot has ended
-		// but its pipeline may still be running, explicitly clear the active state
-		// and stop the pipeline before starting the new entry. This prevents the old
-		// pipeline's handleTrackEnded goroutine from racing with the new entry's state.
+		// but its pipeline may still be running, clear the ended entry's stale state
+		// so its handleTrackEnded goroutine (already guarded on entry identity and
+		// EndsAt) can't reclaim the mount. Deliberately do NOT StopPipeline here:
+		// EnsurePipeline* calls stopIfRunning right before launching the successor,
+		// so the old pipeline is torn down and the new one started back-to-back.
+		// Stopping it now instead left the mount silent through all of handleEntry's
+		// DB/prep work — the per-boundary "double-clutch" gap seen in prod (426
+		// preemptions, one every 2-3 min on busy mounts). Swapping at launch closes
+		// that gap; the old audio keeps flowing until the handover.
 		if hasActive && active.EntryID != entry.ID && active.StationID == entry.StationID &&
 			!now.Before(active.Ends) {
-			d.logger.Info().
+			d.logger.Debug().
 				Str("mount", entry.MountID).
 				Str("preempted", active.EntryID).
 				Str("new_entry", entry.ID).
-				Msg("hard boundary: clearing preempted entry state before starting new")
+				Msg("hard boundary handoff: clearing ended entry state; pipeline swaps at launch")
 			d.mu.Lock()
 			delete(d.active, entry.MountID)
 			d.mu.Unlock()
-			if err := d.manager.StopPipeline(entry.MountID); err != nil {
-				d.logger.Debug().Err(err).Str("mount", entry.MountID).Msg("preemption stop pipeline")
-			}
 			hasActive = false
 		}
 

--- a/internal/playout/director_coverage_test.go
+++ b/internal/playout/director_coverage_test.go
@@ -197,6 +197,40 @@ func TestCloseCurrentPlayHistory_EmptyMediaIDSafe(t *testing.T) {
 	d.closeCurrentPlayHistory(ctx, stationID, mountID, 60_000)
 }
 
+func TestCloseCurrentPlayHistory_EmptyIDsGuarded(t *testing.T) {
+	// Empty station/mount IDs bound into the WHERE against uuid columns make
+	// Postgres throw 22P02 (invalid input syntax for type uuid); prod hit this
+	// at a hard-boundary cut whose ended entry carried no IDs (director.go,
+	// 2026-07-06 21:00:05). The guard must return before the query runs.
+	// SQLite, unlike Postgres, happily matches empty strings, which gives this
+	// test its observable: a seeded row with empty IDs must stay untouched.
+	d := newCoverageDirector(t)
+	ctx := context.Background()
+
+	now := time.Now()
+	h := models.PlayHistory{
+		ID:        uuid.NewString(),
+		StationID: "",
+		MountID:   "",
+		Title:     "orphan row",
+		StartedAt: now.Add(-1 * time.Minute),
+		EndedAt:   now.Add(10 * time.Minute), // in-progress; a cut now is >30s early
+	}
+	if err := d.db.Create(&h).Error; err != nil {
+		t.Fatalf("seed play history: %v", err)
+	}
+
+	d.closeCurrentPlayHistory(ctx, "", "", 60_000)
+
+	var got models.PlayHistory
+	if err := d.db.First(&got, "id = ?", h.ID).Error; err != nil {
+		t.Fatalf("reload play history: %v", err)
+	}
+	if got.Metadata != nil && got.Metadata["was_interrupted"] == true {
+		t.Fatal("closeCurrentPlayHistory ran its query with empty IDs; guard did not return early")
+	}
+}
+
 // ── resolveEntryForNow ────────────────────────────────────────────────────
 
 func TestResolveEntryForNow_NonRecurringInWindow(t *testing.T) {

--- a/internal/playout/director_tick_test.go
+++ b/internal/playout/director_tick_test.go
@@ -496,6 +496,101 @@ func TestTick_HardBoundaryPreemption_ClearsOldActiveBeforeStartingNew(t *testing
 	}
 }
 
+// At a hard-boundary preemption the director must NOT stop the old pipeline
+// explicitly. The successor launch (playMedia → EnsurePipeline*, which calls
+// stopIfRunning directly) already tears the old process down back-to-back with
+// the start, so the old audio keeps flowing until the handover. Stopping it
+// early instead left the mount silent through all of handleEntry's DB/prep work
+// — the per-boundary "double-clutch" gap prod operators felt (426 preemptions
+// in one window, one every 2-3 min on busy mounts).
+//
+// playMedia does its own legitimate stop-before-start, so the meaningful
+// invariant is a delta, not an absolute count: preempting entry1 must drive the
+// SAME number of Manager.StopPipeline calls as launching entry2 fresh. Any
+// excess is the redundant early stop the double-clutch fix removes.
+func TestTick_HardBoundaryPreemption_AddsNoExtraStopVsFreshLaunch(t *testing.T) {
+	// launchStops seeds entry2 as the sole current media entry and runs one
+	// tick, optionally seeding d.active with a stale, already-ended entry to
+	// force the hard-boundary preemption path. The stale entry lives only in
+	// d.active (the preemption block reads memory, not the DB), so the two runs
+	// differ by exactly that block; entry2's launch is otherwise identical.
+	// Returns how many times the tick called Manager.StopPipeline.
+	launchStops := func(t *testing.T, withPreemptedActive bool) int {
+		t.Helper()
+		d, mgr := newMockDirector(t, &models.ScheduleEntry{}, &models.Playlist{}, &models.PlaylistItem{}, &models.SmartBlock{})
+
+		stationID := uuid.NewString()
+		mountID := uuid.NewString()
+
+		mount := models.Mount{
+			ID:         mountID,
+			StationID:  stationID,
+			Name:       "hb-delta-" + mountID[:8],
+			Format:     "mp3",
+			Bitrate:    128,
+			SampleRate: 44100,
+			Channels:   2,
+		}
+		if err := d.db.Create(&mount).Error; err != nil {
+			t.Fatalf("seed mount: %v", err)
+		}
+
+		media2 := models.MediaItem{
+			ID: uuid.NewString(), StationID: stationID, Path: "/tmp/m2.mp3",
+			Duration: 5 * time.Minute, AnalysisState: models.AnalysisComplete,
+		}
+		if err := d.db.Create(&media2).Error; err != nil {
+			t.Fatalf("seed media2: %v", err)
+		}
+
+		now := time.Now().UTC()
+		entry2 := models.ScheduleEntry{
+			ID: uuid.NewString(), StationID: stationID, MountID: mountID,
+			SourceType: "media", SourceID: media2.ID,
+			StartsAt: now.Add(-1 * time.Second), EndsAt: now.Add(5 * time.Minute),
+		}
+		if err := d.db.Create(&entry2).Error; err != nil {
+			t.Fatalf("seed entry2: %v", err)
+		}
+
+		if withPreemptedActive {
+			// A stale active entry, past its end, that entry2 must preempt. Kept
+			// out of the DB on purpose so it is never independently processed.
+			d.mu.Lock()
+			d.active[mountID] = playoutState{
+				EntryID: uuid.NewString(), StationID: stationID, MediaID: uuid.NewString(),
+				Ends: now.Add(-1 * time.Second), SourceType: "media",
+			}
+			d.mu.Unlock()
+		}
+
+		d.broadcast.CreateMount(mount.Name, "audio/mpeg", 128)
+		d.broadcast.CreateMount(mount.Name+"-lq", "audio/mpeg", 64)
+
+		if err := d.tick(context.Background()); err != nil {
+			t.Errorf("tick returned error: %v", err)
+		}
+
+		// Sanity: entry2 must own the mount in both cases, else the counts
+		// aren't comparing the same launch.
+		d.mu.Lock()
+		st, ok := d.active[mountID]
+		d.mu.Unlock()
+		if !ok || st.EntryID != entry2.ID {
+			t.Fatalf("entry2 did not take the mount (preempt=%v); got %+v ok=%v", withPreemptedActive, st, ok)
+		}
+		return mgr.stopCalls
+	}
+
+	fresh := launchStops(t, false)
+	preempted := launchStops(t, true)
+
+	if preempted != fresh {
+		t.Errorf("hard-boundary preemption drove %d StopPipeline calls vs %d for a fresh launch; the %d extra is the redundant early stop the double-clutch fix removes",
+			preempted, fresh, preempted-fresh)
+	}
+}
+
 func TestCheckDeadAir_RestartsIdleMount(t *testing.T) {
 	d, _ := newMockDirector(t, &models.ScheduleEntry{})
 

--- a/internal/playout/mock_test.go
+++ b/internal/playout/mock_test.go
@@ -39,6 +39,7 @@ type mockManager struct {
 	ensureErr   error
 	stopErr     error
 	stdinWriter io.WriteCloser
+	stopCalls   int // number of StopPipeline invocations (preemption assertions)
 }
 
 func newMockManager() *mockManager {
@@ -82,6 +83,7 @@ func (m *mockManager) GetPipeline(mountID string) PipelineInterface {
 }
 
 func (m *mockManager) StopPipeline(mountID string) error {
+	m.stopCalls++
 	delete(m.pipelines, mountID)
 	return m.stopErr
 }

--- a/internal/smartblock/definition.go
+++ b/internal/smartblock/definition.go
@@ -38,7 +38,11 @@ type InterstitialsConfig struct {
 	PerBreak             int                  `json:"perBreak"` // how many ads per break
 	Logic                string               `json:"logic"`    // "any" (OR) or "all" (AND)
 	IncludePublicArchive bool                 `json:"includePublicArchive"`
-	Sources              []InterstitialSource `json:"sources"`
+	// MaxDurationSec caps how long a picked interstitial may be, in seconds.
+	// Zero uses defaultInterstitialMaxDuration. Keeps a title/label substring
+	// match from pulling a full episode into a short-insert slot.
+	MaxDurationSec int                  `json:"maxDurationSec"`
+	Sources        []InterstitialSource `json:"sources"`
 }
 
 // BumperConfig controls tail-fill with short tracks after the main sequence.
@@ -50,6 +54,10 @@ type BumperConfig struct {
 	Query                string `json:"query"`
 	IncludePublicArchive bool   `json:"include_public_archive"`
 	MaxPerGap            int    `json:"max_per_gap"`
+	// MaxDurationSec caps how long a picked bumper may be, in seconds. Zero uses
+	// defaultBumperMaxDuration. Bumpers are the shortest inserts (station IDs,
+	// jingles), so the default is tighter than the interstitial one.
+	MaxDurationSec int `json:"max_duration_sec"`
 }
 
 // FilterRule applies a comparison against media metadata.

--- a/internal/smartblock/definition.go
+++ b/internal/smartblock/definition.go
@@ -33,11 +33,11 @@ type InterstitialSource struct {
 
 // InterstitialsConfig controls periodic ad/interstitial insertion within the sequence.
 type InterstitialsConfig struct {
-	Enabled              bool                 `json:"enabled"`
-	EveryN               int                  `json:"every"`    // insert after every N music tracks
-	PerBreak             int                  `json:"perBreak"` // how many ads per break
-	Logic                string               `json:"logic"`    // "any" (OR) or "all" (AND)
-	IncludePublicArchive bool                 `json:"includePublicArchive"`
+	Enabled              bool   `json:"enabled"`
+	EveryN               int    `json:"every"`    // insert after every N music tracks
+	PerBreak             int    `json:"perBreak"` // how many ads per break
+	Logic                string `json:"logic"`    // "any" (OR) or "all" (AND)
+	IncludePublicArchive bool   `json:"includePublicArchive"`
 	// MaxDurationSec caps how long a picked interstitial may be, in seconds.
 	// Zero uses defaultInterstitialMaxDuration. Keeps a title/label substring
 	// match from pulling a full episode into a short-insert slot.

--- a/internal/smartblock/engine.go
+++ b/internal/smartblock/engine.go
@@ -366,6 +366,11 @@ func applyLegacyRuleCompat(def Definition, rules map[string]any) Definition {
 		if def.Bumpers.MaxPerGap < 1 {
 			def.Bumpers.MaxPerGap = 8
 		}
+		// Dashboard emits camelCase, which the snake_case struct tag misses on
+		// the direct unmarshal, so pick up the bumper duration cap here too.
+		if maxDur, ok := bumpers["maxDurationSec"]; ok {
+			def.Bumpers.MaxDurationSec = toInt(maxDur)
+		}
 	}
 
 	// Loop-to-fill preference from legacy flat rules key.
@@ -489,15 +494,37 @@ func (e *Engine) tailFillBumpers(ctx context.Context, result *GenerateResult, cf
 	}
 }
 
+// Insert-duration caps. Bumpers and interstitials are short inserts between
+// music tracks, so a title/label substring match must never pull in a full
+// episode that merely contains the search word (a ~60-minute "Before the First
+// Cup ... Donate Your Body ..." episode matched a "donate" interstitial query
+// on prod, 2026-07). The defaults are grounded in the station-local pools at
+// the time: bumpers ran 21s to 1:59, interstitials 2:45 to 4:47. A station that
+// genuinely needs longer inserts raises MaxDurationSec on the rule.
+const (
+	defaultBumperMaxDuration       = 5 * time.Minute
+	defaultInterstitialMaxDuration = 10 * time.Minute
+)
+
+// effectiveMaxDuration resolves a configured MaxDurationSec (seconds) to a
+// duration, falling back to def when unset or non-positive.
+func effectiveMaxDuration(sec int, def time.Duration) time.Duration {
+	if sec > 0 {
+		return time.Duration(sec) * time.Second
+	}
+	return def
+}
+
 // fetchBumperCandidates loads media items matching the bumper source config.
 func (e *Engine) fetchBumperCandidates(ctx context.Context, cfg BumperConfig, stationID string) ([]models.MediaItem, error) {
+	maxDur := effectiveMaxDuration(cfg.MaxDurationSec, defaultBumperMaxDuration)
 	query := e.db.WithContext(ctx).Where("station_id = ?", stationID).
-		Where("analysis_state != ? AND duration > 0", models.AnalysisFailed)
+		Where("analysis_state != ? AND duration > 0 AND duration <= ?", models.AnalysisFailed, maxDur)
 	if cfg.IncludePublicArchive {
 		query = e.db.WithContext(ctx).
 			Where("(station_id = ?) OR (show_in_archive = ? AND station_id IN (SELECT id FROM stations WHERE active = ? AND public = ? AND approved = ?))",
 				stationID, true, true, true, true).
-			Where("analysis_state != ? AND duration > 0", models.AnalysisFailed)
+			Where("analysis_state != ? AND duration > 0 AND duration <= ?", models.AnalysisFailed, maxDur)
 	}
 
 	var tracks []models.MediaItem
@@ -541,13 +568,14 @@ func (e *Engine) fetchInterstitialCandidates(ctx context.Context, cfg Interstiti
 		return nil, nil
 	}
 
+	maxDur := effectiveMaxDuration(cfg.MaxDurationSec, defaultInterstitialMaxDuration)
 	baseQuery := e.db.WithContext(ctx).Where("station_id = ?", stationID).
-		Where("analysis_state != ? AND duration > 0", models.AnalysisFailed)
+		Where("analysis_state != ? AND duration > 0 AND duration <= ?", models.AnalysisFailed, maxDur)
 	if cfg.IncludePublicArchive {
 		baseQuery = e.db.WithContext(ctx).
 			Where("(station_id = ?) OR (show_in_archive = ? AND station_id IN (SELECT id FROM stations WHERE active = ? AND public = ? AND approved = ?))",
 				stationID, true, true, true, true).
-			Where("analysis_state != ? AND duration > 0", models.AnalysisFailed)
+			Where("analysis_state != ? AND duration > 0 AND duration <= ?", models.AnalysisFailed, maxDur)
 	}
 
 	clauses := make([]string, 0, len(cfg.Sources))

--- a/internal/smartblock/interstitial_duration_cap_test.go
+++ b/internal/smartblock/interstitial_duration_cap_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package smartblock
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+	"github.com/rs/zerolog"
+)
+
+// A title/label substring match can pull in a long file that merely contains
+// the search word. On prod (2026-07) a ~60-minute "Before the First Cup ...
+// Donate Your Body to Mad Science ..." episode matched a "donate" interstitial
+// query and played mid-block. Both candidate fetchers cap pick duration so a
+// full show can never land as a short insert. The defaults differ because the
+// two pools do: station-local bumpers ran 21s–1:59, interstitials 2:45–4:47.
+
+func idsOf(items []models.MediaItem) []string {
+	out := make([]string, len(items))
+	for i, it := range items {
+		out[i] = it.ID
+	}
+	return out
+}
+
+func TestFetchInterstitialCandidates_DefaultCapExcludesLongFile(t *testing.T) {
+	db := newTestDB(t)
+	stationID := "station-int"
+
+	short := models.MediaItem{
+		ID: "int-short", StationID: stationID, Title: "Donate to RLM spot",
+		Duration: 3 * time.Minute, AnalysisState: models.AnalysisComplete,
+	}
+	long := models.MediaItem{
+		ID: "int-long", StationID: stationID, Title: "Before the First Cup - Donate Your Body 5-5-16",
+		Duration: 60 * time.Minute, AnalysisState: models.AnalysisComplete,
+	}
+	if err := db.Create(&[]models.MediaItem{short, long}).Error; err != nil {
+		t.Fatalf("seed media: %v", err)
+	}
+
+	eng := New(db, zerolog.Nop())
+	cfg := InterstitialsConfig{
+		Enabled: true,
+		Sources: []InterstitialSource{{SourceType: "title", Query: "donate"}},
+	}
+	items, err := eng.fetchInterstitialCandidates(context.Background(), cfg, stationID)
+	if err != nil {
+		t.Fatalf("fetchInterstitialCandidates: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != short.ID {
+		t.Fatalf("default cap should keep only the short spot; got %d items %v", len(items), idsOf(items))
+	}
+}
+
+func TestFetchInterstitialCandidates_ExplicitCapOverride(t *testing.T) {
+	db := newTestDB(t)
+	stationID := "station-int2"
+
+	short := models.MediaItem{
+		ID: "int2-short", StationID: stationID, Title: "Donate short",
+		Duration: 3 * time.Minute, AnalysisState: models.AnalysisComplete,
+	}
+	long := models.MediaItem{
+		ID: "int2-long", StationID: stationID, Title: "Donate long sponsor read",
+		Duration: 30 * time.Minute, AnalysisState: models.AnalysisComplete,
+	}
+	if err := db.Create(&[]models.MediaItem{short, long}).Error; err != nil {
+		t.Fatalf("seed media: %v", err)
+	}
+
+	eng := New(db, zerolog.Nop())
+	// A station that genuinely runs long sponsor reads lifts the cap to 45min.
+	cfg := InterstitialsConfig{
+		Enabled:        true,
+		MaxDurationSec: 45 * 60,
+		Sources:        []InterstitialSource{{SourceType: "title", Query: "donate"}},
+	}
+	items, err := eng.fetchInterstitialCandidates(context.Background(), cfg, stationID)
+	if err != nil {
+		t.Fatalf("fetchInterstitialCandidates: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("explicit 45min cap should keep both; got %d items %v", len(items), idsOf(items))
+	}
+}
+
+func TestFetchBumperCandidates_DefaultCapExcludesLongFile(t *testing.T) {
+	db := newTestDB(t)
+	stationID := "station-bumpcap"
+
+	short := models.MediaItem{
+		ID: "bumpcap-short", StationID: stationID, Title: "Station bumper donate",
+		Duration: 20 * time.Second, AnalysisState: models.AnalysisComplete,
+	}
+	long := models.MediaItem{
+		ID: "bumpcap-long", StationID: stationID, Title: "Full episode bumper mislabel",
+		Duration: 55 * time.Minute, AnalysisState: models.AnalysisComplete,
+	}
+	if err := db.Create(&[]models.MediaItem{short, long}).Error; err != nil {
+		t.Fatalf("seed media: %v", err)
+	}
+
+	eng := New(db, zerolog.Nop())
+	cfg := BumperConfig{SourceType: "title", Query: "bumper"}
+	items, err := eng.fetchBumperCandidates(context.Background(), cfg, stationID)
+	if err != nil {
+		t.Fatalf("fetchBumperCandidates: %v", err)
+	}
+	if len(items) != 1 || items[0].ID != short.ID {
+		t.Fatalf("default cap should keep only the short bumper; got %d items %v", len(items), idsOf(items))
+	}
+}
+
+// The two default caps differ: an 8-minute file is a plausible interstitial
+// (under the 10min default) but never a bumper (over the 5min default). One
+// file, matched by both queries, must pass the interstitial fetch and fail the
+// bumper fetch.
+func TestDefaultCaps_DifferByCategory(t *testing.T) {
+	db := newTestDB(t)
+	stationID := "station-split"
+
+	mid := models.MediaItem{
+		ID: "split-8min", StationID: stationID, Title: "RLM bumper donate 8 minute segment",
+		Duration: 8 * time.Minute, AnalysisState: models.AnalysisComplete,
+	}
+	if err := db.Create(&mid).Error; err != nil {
+		t.Fatalf("seed media: %v", err)
+	}
+
+	eng := New(db, zerolog.Nop())
+
+	inter, err := eng.fetchInterstitialCandidates(context.Background(), InterstitialsConfig{
+		Enabled: true,
+		Sources: []InterstitialSource{{SourceType: "title", Query: "donate"}},
+	}, stationID)
+	if err != nil {
+		t.Fatalf("fetchInterstitialCandidates: %v", err)
+	}
+	if len(inter) != 1 {
+		t.Fatalf("8min file should pass the 10min interstitial cap; got %d", len(inter))
+	}
+
+	bump, err := eng.fetchBumperCandidates(context.Background(), BumperConfig{
+		SourceType: "title", Query: "bumper",
+	}, stationID)
+	if err != nil {
+		t.Fatalf("fetchBumperCandidates: %v", err)
+	}
+	if len(bump) != 0 {
+		t.Fatalf("8min file should fail the 5min bumper cap; got %d %v", len(bump), idsOf(bump))
+	}
+}

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -372,6 +372,19 @@ var (
 		},
 		[]string{"mount"},
 	)
+
+	// BroadcastBridgedChunksTotal counts silent frames the silence bridge fed
+	// into a mount to cover an input gap while delivery was behind realtime.
+	// A steady trickle at track boundaries is expected; a sustained climb means
+	// the playout side is leaving real gaps (pipeline spin-up too slow, encoder
+	// crashing) that the bridge is papering over.
+	BroadcastBridgedChunksTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "grimnir_broadcast_bridged_chunks_total",
+			Help: "Total silent chunks fed by the silence bridge, per mount",
+		},
+		[]string{"mount"},
+	)
 )
 
 // Track resume (cut-position recovery) metrics


### PR DESCRIPTION
Five fixes from the stream-drop investigation, one commit each.

**Silence bridge v2 (deficit budget).** The v1.40.19 bridge filled every input gap at full bitrate. Those gaps were the only drain windows where paced pull clients (OBS restreams re-encoding toward YouTube) worked off per-boundary surpluses like connect pre-roll & encoder spin-up bursts, so backlog compounded at every track boundary until the 256-chunk (~46s at 128kbps) send channel overflowed: skips, then resets. High-transition channels crossed that threshold in hours. v2 keeps a per-mount byte budget that grows at the mount's bitrate; Broadcast counts every delivered byte, & the bridge emits silence only while delivery is behind the budget, never ahead. Drift clamps to 4s either way. New `grimnir_broadcast_bridged_chunks_total{mount}` counter.

**Connect-seam atomicity.** Broadcast registered a client, then snapshotted the ring buffer for the pre-roll with no shared lock, so a chunk arriving between the two steps went out twice. The ring write now sits under the same mount lock as the fan-out, & a new `attachClient` snapshots & registers together. The disconnect cleanup moved ahead of the first write, closing a leak where a failed pre-roll write left a client registered forever.

**22P02 guard.** An empty stationID or mountID bound against a uuid column makes Postgres throw 22P02. `closeCurrentPlayHistory` returns early on empty IDs.

**Double-clutch handoff.** The hard-boundary preemption block stopped the ended entry's pipeline immediately, then ran all of `handleEntry`'s DB & prep work, then launched the successor, leaving the mount silent for that span. The stop was redundant: every `EnsurePipeline*` calls `stopIfRunning` right before launch, synchronous, no double-feed window. Dropping it lets the old audio flow until the back-to-back handover.

**Smart-block insert duration cap.** A title substring match pulled a ~60-minute episode into a short-insert slot because its title contained the search word. Both candidate fetchers now cap pick duration: bumpers at 5 min, interstitials at 10 min, overridable per rule via `maxDurationSec`.

## Testing

Full `./internal/...` suite green locally. Bridge & connect-seam tests run under `-race`, 5 consecutive passes. Each fix ships with a test that failed before the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
