### PR TITLE
feat(schedule): surface overlap conflicts, air newest, self-heal horizon (#75)

### DIFF
--- a/internal/playout/director.go
+++ b/internal/playout/director.go
@@ -278,11 +278,36 @@ func (d *Director) tick(ctx context.Context) error {
 		return err
 	}
 
+	// Unresolved-overlap safety net: when two is_instance entries on one mount both
+	// cover now, the newest instance (latest created_at) is the canonical plan; the
+	// older one is a stale overlap the scheduler failed to trim (#75). Record, per
+	// mount, the newest created_at among instances that cover now so the loop can
+	// refuse to start (or let an older overlap overwrite) the mount. Only instances
+	// are considered — recurring parents and crossfade lookahead are untouched.
+	overlapWinner := make(map[string]time.Time)
+	for i := range entries {
+		e := entries[i]
+		if !e.IsInstance || e.StartsAt.After(now) || e.EndsAt.Before(now) {
+			continue
+		}
+		if cur, ok := overlapWinner[e.MountID]; !ok || e.CreatedAt.After(cur) {
+			overlapWinner[e.MountID] = e.CreatedAt
+		}
+	}
+
 	for _, rawEntry := range entries {
 		loc := d.getStationTimezone(ctx, rawEntry.StationID)
 		entry, playKey, playUntil, ok := resolveEntryForNow(rawEntry, now, loc)
 		if !ok {
 			continue
+		}
+
+		// If a newer instance also covers now on this mount, this older instance is a
+		// stale overlap: don't let it claim the mount or overwrite the newer one.
+		if rawEntry.IsInstance && !rawEntry.StartsAt.After(now) && !rawEntry.EndsAt.Before(now) {
+			if winner, ok := overlapWinner[entry.MountID]; ok && winner.After(rawEntry.CreatedAt) {
+				continue
+			}
 		}
 
 		// Soft boundary mode: if something is currently active on this mount, allow it to overrun
@@ -492,6 +517,7 @@ func (d *Director) getScheduleSnapshot(ctx context.Context, now time.Time) ([]mo
 			now.Add(lookahead), now.Add(-lookback), false, now.Add(lookahead)).
 		Where("recurrence_end_date IS NULL OR recurrence_end_date >= ?", now.AddDate(0, 0, -1).Truncate(24*time.Hour)).
 		Order("starts_at ASC").
+		Order("created_at DESC").
 		Find(&entries).Error
 	if err != nil {
 		// If we have a cache, keep running and try again next tick.

--- a/internal/playout/newest_wins_test.go
+++ b/internal/playout/newest_wins_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package playout
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+	"github.com/google/uuid"
+)
+
+// TestTick_NewestInstanceWins verifies the playout safety net for unresolved
+// overlaps: when two is_instance=true media entries on one mount both cover
+// now, the director must play the NEWEST instance (latest created_at), never
+// the older one. Two sub-cases exercise different code paths:
+//
+//   - equal starts_at: the newer created_at must win purely on the query's
+//     created_at DESC secondary sort (newest claims the mount first).
+//   - older starts LATER: the older instance starts after the newer, so under
+//     starts_at ASC it is reached LAST in the loop; without a guard its
+//     last-write would overwrite the newer. The guard must skip the older once
+//     the newer overlapping instance also covers now.
+func TestTick_NewestInstanceWins(t *testing.T) {
+	now := time.Now().UTC()
+
+	cases := []struct {
+		name          string
+		olderStartsAt time.Time
+		newerStartsAt time.Time
+	}{
+		{
+			name:          "equal starts_at newer created_at wins",
+			olderStartsAt: now.Add(-2 * time.Minute),
+			newerStartsAt: now.Add(-2 * time.Minute),
+		},
+		{
+			// Newer instance starts EARLIER, older instance starts LATER — both
+			// still cover now. Under starts_at ASC the newer is processed first and
+			// the older LAST, so plain last-write-wins would leave the older active.
+			// Only the guard (skip an older instance when a newer one covers now)
+			// makes the newer win here, so this sub-case genuinely exercises it.
+			name:          "older starts later must not overwrite newer",
+			olderStartsAt: now.Add(-30 * time.Second),
+			newerStartsAt: now.Add(-2 * time.Minute),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, _ := newMockDirector(t, &models.ScheduleEntry{})
+			ctx := context.Background()
+
+			stationID := uuid.NewString()
+			mountID := uuid.NewString()
+
+			mount := models.Mount{
+				ID:         mountID,
+				StationID:  stationID,
+				Name:       "newest-wins-" + mountID[:8],
+				Format:     "mp3",
+				Bitrate:    128,
+				SampleRate: 44100,
+				Channels:   2,
+			}
+			if err := d.db.Create(&mount).Error; err != nil {
+				t.Fatalf("seed mount: %v", err)
+			}
+
+			// Two media items so each entry resolves a real source.
+			olderMediaID := uuid.NewString()
+			newerMediaID := uuid.NewString()
+			for _, m := range []models.MediaItem{
+				{
+					ID:            olderMediaID,
+					StationID:     stationID,
+					Title:         "Older Track",
+					Artist:        "A",
+					Path:          "/tmp/older.mp3",
+					Duration:      3 * time.Minute,
+					AnalysisState: models.AnalysisComplete,
+				},
+				{
+					ID:            newerMediaID,
+					StationID:     stationID,
+					Title:         "Newer Track",
+					Artist:        "B",
+					Path:          "/tmp/newer.mp3",
+					Duration:      3 * time.Minute,
+					AnalysisState: models.AnalysisComplete,
+				},
+			} {
+				if err := d.db.Create(&m).Error; err != nil {
+					t.Fatalf("seed media: %v", err)
+				}
+			}
+
+			// Both instances cover now on the same mount. The newer instance has
+			// a later created_at. Set CreatedAt explicitly so gorm's auto-timestamp
+			// can't make ordering arbitrary.
+			olderID := uuid.NewString()
+			newerID := uuid.NewString()
+			older := models.ScheduleEntry{
+				ID:         olderID,
+				StationID:  stationID,
+				MountID:    mountID,
+				SourceType: "media",
+				SourceID:   olderMediaID,
+				IsInstance: true,
+				StartsAt:   tc.olderStartsAt,
+				EndsAt:     now.Add(5 * time.Minute),
+				CreatedAt:  now.Add(-1 * time.Hour),
+			}
+			newer := models.ScheduleEntry{
+				ID:         newerID,
+				StationID:  stationID,
+				MountID:    mountID,
+				SourceType: "media",
+				SourceID:   newerMediaID,
+				IsInstance: true,
+				StartsAt:   tc.newerStartsAt,
+				EndsAt:     now.Add(5 * time.Minute),
+				CreatedAt:  now.Add(-1 * time.Minute),
+			}
+			// Insert newer first so raw DB (rowid) order is newer-then-older. For the
+			// equal-starts case, without created_at DESC the tick loop's last-write-wins
+			// would leave the OLDER entry active. For the later-starting-older case, the
+			// older is processed last under starts_at ASC and would win without the guard.
+			if err := d.db.Create(&newer).Error; err != nil {
+				t.Fatalf("seed newer entry: %v", err)
+			}
+			if err := d.db.Create(&older).Error; err != nil {
+				t.Fatalf("seed older entry: %v", err)
+			}
+
+			d.markScheduleDirty()
+
+			if err := d.tick(ctx); err != nil {
+				t.Fatalf("tick returned error: %v", err)
+			}
+
+			d.mu.Lock()
+			state, ok := d.active[mountID]
+			d.mu.Unlock()
+			if !ok {
+				t.Fatal("expected an active entry on the mount after tick")
+			}
+			if state.EntryID != newerID {
+				t.Errorf("active entry = %q, want newest %q (older was %q)", state.EntryID, newerID, olderID)
+			}
+		})
+	}
+}

--- a/internal/scheduler/coverage.go
+++ b/internal/scheduler/coverage.go
@@ -1,0 +1,55 @@
+package scheduler
+
+import (
+	"sort"
+	"time"
+)
+
+// interval is a half-open time window [Start, End).
+type interval struct {
+	Start time.Time
+	End   time.Time
+}
+
+// subtractCovered returns the sub-intervals of window not covered by any interval
+// in covered. Covered intervals may overlap, extend past the window, and need not
+// be sorted. Gaps shorter than minDur are dropped as noise.
+func subtractCovered(window interval, covered []interval, minDur time.Duration) []interval {
+	clamped := make([]interval, 0, len(covered))
+	for _, c := range covered {
+		s, e := c.Start, c.End
+		if s.Before(window.Start) {
+			s = window.Start
+		}
+		if e.After(window.End) {
+			e = window.End
+		}
+		if !s.Before(e) {
+			continue
+		}
+		clamped = append(clamped, interval{s, e})
+	}
+	sort.Slice(clamped, func(i, j int) bool { return clamped[i].Start.Before(clamped[j].Start) })
+
+	var gaps []interval
+	cursor := window.Start
+	for _, c := range clamped {
+		if c.Start.After(cursor) {
+			gaps = append(gaps, interval{cursor, c.Start})
+		}
+		if c.End.After(cursor) {
+			cursor = c.End
+		}
+	}
+	if cursor.Before(window.End) {
+		gaps = append(gaps, interval{cursor, window.End})
+	}
+
+	out := gaps[:0]
+	for _, g := range gaps {
+		if g.End.Sub(g.Start) >= minDur {
+			out = append(out, g)
+		}
+	}
+	return out
+}

--- a/internal/scheduler/coverage_test.go
+++ b/internal/scheduler/coverage_test.go
@@ -1,0 +1,40 @@
+package scheduler
+
+import (
+	"testing"
+	"time"
+)
+
+func ts(h, m int) time.Time { return time.Date(2026, 7, 20, h, m, 0, 0, time.UTC) }
+
+func TestSubtractCovered(t *testing.T) {
+	win := interval{ts(16, 0), ts(0, 0).AddDate(0, 0, 1)} // 16:00 -> next-day 00:00
+	min := time.Minute
+
+	cases := []struct {
+		name    string
+		covered []interval
+		want    []interval
+	}{
+		{"nothing covered", nil, []interval{win}},
+		{"fully covered", []interval{win}, nil},
+		{"JW: 16-17 covered", []interval{{ts(16, 0), ts(17, 0)}}, []interval{{ts(17, 0), win.End}}},
+		{"mid-block hole", []interval{{ts(18, 0), ts(19, 0)}}, []interval{{ts(16, 0), ts(18, 0)}, {ts(19, 0), win.End}}},
+		{"overlapping covers merge", []interval{{ts(16, 0), ts(18, 0)}, {ts(17, 0), ts(19, 0)}}, []interval{{ts(19, 0), win.End}}},
+		{"cover extends past window clamps", []interval{{ts(15, 0), ts(17, 0)}}, []interval{{ts(17, 0), win.End}}},
+		{"sub-min gap dropped", []interval{{ts(16, 0), win.End.Add(-30 * time.Second)}}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := subtractCovered(win, tc.covered, min)
+			if len(got) != len(tc.want) {
+				t.Fatalf("got %d gaps %v, want %d %v", len(got), got, len(tc.want), tc.want)
+			}
+			for i := range got {
+				if !got[i].Start.Equal(tc.want[i].Start) || !got[i].End.Equal(tc.want[i].End) {
+					t.Errorf("gap %d = %v, want %v", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}

--- a/internal/scheduler/gapfill_test.go
+++ b/internal/scheduler/gapfill_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+	"github.com/google/uuid"
+	"gorm.io/gorm"
+)
+
+// JW case — same mount, a 1h media row at 16:00-17:00 already materialized,
+// the 8h block (16:00-00:00) must fill 17:00-00:00, not skip the whole block.
+func TestMaterializeSmartBlockEntry_FillsUncoveredRemainder(t *testing.T) {
+	svc, db := newRunTestService(t)
+	stationID, mountID := "st-jw", "mt-jw"
+	if err := db.Create(&models.Station{ID: stationID, Name: "Test", Timezone: "UTC"}).Error; err != nil {
+		t.Fatalf("create station: %v", err)
+	}
+	if err := db.Create(&models.Mount{
+		ID: mountID, StationID: stationID, Name: "Main",
+		URL: "https://example.invalid/main.mp3", Format: "mp3",
+	}).Error; err != nil {
+		t.Fatalf("create mount: %v", err)
+	}
+
+	// seed a smart block so materializeSmartBlock has something to expand
+	sbID := seedMinimalSmartBlock(t, db, stationID)
+
+	base := time.Date(2026, 7, 20, 16, 0, 0, 0, time.UTC)
+	// Leftover 1h media already covering 16:00-17:00 on the same mount.
+	if err := db.Create(&models.ScheduleEntry{
+		ID: "leftover-1h", StationID: stationID, MountID: mountID,
+		SourceType: "media", SourceID: uuid.NewString(), IsInstance: true,
+		StartsAt: base, EndsAt: base.Add(time.Hour),
+	}).Error; err != nil {
+		t.Fatalf("seed leftover: %v", err)
+	}
+
+	entry := models.ScheduleEntry{
+		ID: "block-8h", StationID: stationID, MountID: mountID,
+		SourceType: "smart_block", SourceID: sbID,
+		StartsAt: base, EndsAt: base.Add(8 * time.Hour),
+	}
+	// now is before the block window, so the whole remainder is fillable.
+	now := base.Add(-time.Hour)
+	if err := svc.materializeSmartBlockEntry(context.Background(), stationID, entry, mountID, now); err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+
+	// Media rows produced by the block must start at or after 17:00, never before.
+	var media []models.ScheduleEntry
+	db.Where("station_id = ? AND mount_id = ? AND source_type = 'media' AND id != ?",
+		stationID, mountID, "leftover-1h").Order("starts_at ASC").Find(&media)
+	if len(media) == 0 {
+		t.Fatal("block produced no media in the uncovered 17:00-00:00 window (skipped whole block?)")
+	}
+	if media[0].StartsAt.Before(base.Add(time.Hour)) {
+		t.Errorf("block materialized into covered 16:00-17:00 (starts %v); should start >= 17:00", media[0].StartsAt)
+	}
+}
+
+func seedMinimalSmartBlock(t *testing.T, db *gorm.DB, stationID string) string {
+	t.Helper()
+	plID := uuid.NewString()
+	sb := models.SmartBlock{
+		ID: "sb-fill", StationID: stationID, Name: "Fill",
+		Rules: map[string]any{"targetMinutes": 480, "sourcePlaylists": []string{plID}},
+	}
+	if err := db.Create(&sb).Error; err != nil {
+		t.Fatalf("seed smart block: %v", err)
+	}
+	// A source playlist the block's rules resolve to.
+	if err := db.Create(&models.Playlist{ID: plID, StationID: stationID, Name: "Fill PL"}).Error; err != nil {
+		t.Fatalf("seed playlist: %v", err)
+	}
+	// A single analyzed media item the block can place.
+	mediaID := uuid.NewString()
+	if err := db.Create(&models.MediaItem{
+		ID: mediaID, StationID: stationID, Title: "Track", Path: "/tmp/x.mp3",
+		Duration: 3 * time.Minute, AnalysisState: models.AnalysisComplete,
+	}).Error; err != nil {
+		t.Fatalf("seed media item: %v", err)
+	}
+	if err := db.Create(&models.PlaylistItem{
+		ID: uuid.NewString(), PlaylistID: plID, MediaID: mediaID, Position: 0,
+	}).Error; err != nil {
+		t.Fatalf("seed playlist item: %v", err)
+	}
+	return sb.ID
+}

--- a/internal/scheduler/gapfill_test.go
+++ b/internal/scheduler/gapfill_test.go
@@ -228,3 +228,111 @@ func seedMinimalSmartBlock(t *testing.T, db *gorm.DB, stationID string) string {
 	}
 	return sb.ID
 }
+
+// TestInvalidateStationInstances verifies InvalidateStationInstances deletes only
+// plain future materializer expansions (SeriesID == nil) for one station+parent,
+// while preserving per-occurrence operator overrides (SeriesID set) and never
+// touching another station's rows.
+func TestInvalidateStationInstances(t *testing.T) {
+	svc, db := newRunTestService(t)
+	station1, mount1 := "st-inv-1", "mt-inv-1"
+	station2, mount2 := "st-inv-2", "mt-inv-2"
+	if err := db.Create(&models.Station{ID: station1, Name: "S1", Timezone: "UTC"}).Error; err != nil {
+		t.Fatalf("create station1: %v", err)
+	}
+	if err := db.Create(&models.Station{ID: station2, Name: "S2", Timezone: "UTC"}).Error; err != nil {
+		t.Fatalf("create station2: %v", err)
+	}
+
+	future := time.Now().UTC().Add(24 * time.Hour)
+
+	// station1 recurring parent.
+	parentID := uuid.NewString()
+	if err := db.Create(&models.ScheduleEntry{
+		ID: parentID, StationID: station1, MountID: mount1,
+		SourceType: "smart_block", SourceID: uuid.NewString(),
+		StartsAt: future, EndsAt: future.Add(time.Hour),
+		RecurrenceType: models.RecurrenceDaily, IsInstance: false,
+	}).Error; err != nil {
+		t.Fatalf("create parent: %v", err)
+	}
+
+	// Several plain future expansions (SeriesID nil) produced by the parent.
+	var plainIDs []string
+	for i := 0; i < 3; i++ {
+		id := uuid.NewString()
+		plainIDs = append(plainIDs, id)
+		start := future.Add(time.Duration(i) * 24 * time.Hour)
+		if err := db.Create(&models.ScheduleEntry{
+			ID: id, StationID: station1, MountID: mount1,
+			SourceType: "media", SourceID: uuid.NewString(),
+			StartsAt: start, EndsAt: start.Add(time.Hour),
+			IsInstance: true, RecurrenceParentID: &parentID,
+		}).Error; err != nil {
+			t.Fatalf("create plain expansion %d: %v", i, err)
+		}
+	}
+
+	// One per-occurrence override (SeriesID set) on the same parent, future.
+	overrideID := uuid.NewString()
+	overrideSeries := overrideID
+	if err := db.Create(&models.ScheduleEntry{
+		ID: overrideID, StationID: station1, MountID: mount1,
+		SourceType: "media", SourceID: uuid.NewString(),
+		StartsAt: future.Add(4 * 24 * time.Hour), EndsAt: future.Add(4*24*time.Hour + time.Hour),
+		RecurrenceType: models.RecurrenceNone,
+		IsInstance:     true, RecurrenceParentID: &parentID, SeriesID: &overrideSeries,
+	}).Error; err != nil {
+		t.Fatalf("create override: %v", err)
+	}
+
+	// station2's own parent + plain future expansions.
+	parent2ID := uuid.NewString()
+	if err := db.Create(&models.ScheduleEntry{
+		ID: parent2ID, StationID: station2, MountID: mount2,
+		SourceType: "smart_block", SourceID: uuid.NewString(),
+		StartsAt: future, EndsAt: future.Add(time.Hour),
+		RecurrenceType: models.RecurrenceDaily, IsInstance: false,
+	}).Error; err != nil {
+		t.Fatalf("create parent2: %v", err)
+	}
+	var station2IDs []string
+	for i := 0; i < 2; i++ {
+		id := uuid.NewString()
+		station2IDs = append(station2IDs, id)
+		start := future.Add(time.Duration(i) * 24 * time.Hour)
+		if err := db.Create(&models.ScheduleEntry{
+			ID: id, StationID: station2, MountID: mount2,
+			SourceType: "media", SourceID: uuid.NewString(),
+			StartsAt: start, EndsAt: start.Add(time.Hour),
+			IsInstance: true, RecurrenceParentID: &parent2ID,
+		}).Error; err != nil {
+			t.Fatalf("create station2 expansion %d: %v", i, err)
+		}
+	}
+
+	if err := svc.InvalidateStationInstances(context.Background(), station1, parentID); err != nil {
+		t.Fatalf("InvalidateStationInstances: %v", err)
+	}
+
+	// 1. station1 plain expansions gone.
+	var remainingPlain int64
+	db.Model(&models.ScheduleEntry{}).Where("id IN ?", plainIDs).Count(&remainingPlain)
+	if remainingPlain != 0 {
+		t.Errorf("expected all %d plain expansions deleted, %d remain", len(plainIDs), remainingPlain)
+	}
+
+	// 2. station1 override survives.
+	var overrideCount int64
+	db.Model(&models.ScheduleEntry{}).Where("id = ?", overrideID).Count(&overrideCount)
+	if overrideCount != 1 {
+		t.Errorf("expected override row preserved, got count %d", overrideCount)
+	}
+
+	// 3. station2 untouched.
+	var station2Count int64
+	db.Model(&models.ScheduleEntry{}).Where("id IN ?", station2IDs).Count(&station2Count)
+	if station2Count != int64(len(station2IDs)) {
+		t.Errorf("expected all %d station2 rows untouched, got %d", len(station2IDs), station2Count)
+	}
+}

--- a/internal/scheduler/gapfill_test.go
+++ b/internal/scheduler/gapfill_test.go
@@ -67,6 +67,138 @@ func TestMaterializeSmartBlockEntry_FillsUncoveredRemainder(t *testing.T) {
 	}
 }
 
+// TestMaterialize_NewestParentWinsOverlap seeds two recurring smart-block parents on the
+// same station+mount with overlapping windows and different CreatedAt. The NEWER parent
+// should claim the contested span; the older parent only fills the non-overlapping remainder.
+// Mechanism under test: Pass 2 orders recurring parents created_at DESC so the newest
+// expands and materializes first, and its produced media counts as coverage (Task 1.2) that
+// the older parent then subtracts.
+func TestMaterialize_NewestParentWinsOverlap(t *testing.T) {
+	svc, db := newRunTestService(t)
+	svc.lookahead = 48 * time.Hour
+	stationID, mountID := "st-overlap", "mt-overlap"
+	if err := db.Create(&models.Station{ID: stationID, Name: "Test", Timezone: "UTC"}).Error; err != nil {
+		t.Fatalf("create station: %v", err)
+	}
+	if err := db.Create(&models.Mount{
+		ID: mountID, StationID: stationID, Name: "Main",
+		URL: "https://example.invalid/main.mp3", Format: "mp3",
+	}).Error; err != nil {
+		t.Fatalf("create mount: %v", err)
+	}
+
+	// Two distinct engine-backed smart blocks, each with its own analyzed media.
+	olderBlockID := seedNamedSmartBlock(t, db, stationID, "sb-old")
+	newerBlockID := seedNamedSmartBlock(t, db, stationID, "sb-new")
+
+	// Anchor both recurring parents on a day inside the lookahead window so they both
+	// expand into the same occurrence day. Use tomorrow at fixed hours (UTC station).
+	now := time.Now().UTC().Truncate(time.Hour)
+	base := now.Add(24 * time.Hour).Truncate(24 * time.Hour)
+
+	// Older parent: 12:00-16:00, created earlier.
+	olderStart := base.Add(12 * time.Hour)
+	olderEnd := base.Add(16 * time.Hour)
+	// Newer parent: 14:00-18:00, created later. Overlap span = 14:00-16:00.
+	newerStart := base.Add(14 * time.Hour)
+	newerEnd := base.Add(18 * time.Hour)
+	overlapStart := newerStart
+	overlapEnd := olderEnd
+
+	older := models.ScheduleEntry{
+		ID: "parent-old", StationID: stationID, MountID: mountID,
+		SourceType: "smart_block", SourceID: olderBlockID,
+		StartsAt: olderStart, EndsAt: olderEnd,
+		RecurrenceType: models.RecurrenceDaily, IsInstance: false,
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	newer := models.ScheduleEntry{
+		ID: "parent-new", StationID: stationID, MountID: mountID,
+		SourceType: "smart_block", SourceID: newerBlockID,
+		StartsAt: newerStart, EndsAt: newerEnd,
+		RecurrenceType: models.RecurrenceDaily, IsInstance: false,
+		CreatedAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+	}
+	// Create older first so its DB insert order does NOT favor it; the ordering must
+	// come from created_at DESC, not insertion order.
+	if err := db.Create(&older).Error; err != nil {
+		t.Fatalf("create older parent: %v", err)
+	}
+	if err := db.Create(&newer).Error; err != nil {
+		t.Fatalf("create newer parent: %v", err)
+	}
+
+	if err := svc.materializeDirectScheduleEntries(context.Background(), stationID, now); err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+
+	var media []models.ScheduleEntry
+	db.Where("station_id = ? AND mount_id = ? AND source_type = 'media'", stationID, mountID).
+		Order("starts_at ASC").Find(&media)
+	if len(media) == 0 {
+		t.Fatal("no media produced by either parent")
+	}
+
+	var newerProducedInOverlap, olderProducedInOverlap bool
+	for _, m := range media {
+		blockID, _ := m.Metadata["smart_block_id"].(string)
+		// Does this media row fall inside the contested span?
+		inOverlap := m.StartsAt.Before(overlapEnd) && m.EndsAt.After(overlapStart)
+		if !inOverlap {
+			continue
+		}
+		switch blockID {
+		case newerBlockID:
+			newerProducedInOverlap = true
+		case olderBlockID:
+			olderProducedInOverlap = true
+		}
+	}
+
+	if olderProducedInOverlap {
+		t.Errorf("older block %q produced media in the contested span %v-%v; newer block should win it",
+			olderBlockID, overlapStart, overlapEnd)
+	}
+	if !newerProducedInOverlap {
+		t.Errorf("newer block %q produced no media in the contested span %v-%v",
+			newerBlockID, overlapStart, overlapEnd)
+	}
+}
+
+func seedNamedSmartBlock(t *testing.T, db *gorm.DB, stationID, sbID string) string {
+	t.Helper()
+	plID := uuid.NewString()
+	sb := models.SmartBlock{
+		ID: sbID, StationID: stationID, Name: sbID,
+		// loopToFill lets the block cover its whole multi-hour window from a small
+		// media pool, so each parent can physically reach the contested span; the
+		// contest is then decided by processing order, not by which pool runs dry.
+		Rules: map[string]any{"targetMinutes": 480, "sourcePlaylists": []string{plID}, "loopToFill": true},
+	}
+	if err := db.Create(&sb).Error; err != nil {
+		t.Fatalf("seed smart block %s: %v", sbID, err)
+	}
+	if err := db.Create(&models.Playlist{ID: plID, StationID: stationID, Name: sbID + " PL"}).Error; err != nil {
+		t.Fatalf("seed playlist for %s: %v", sbID, err)
+	}
+	// Several analyzed media items so the engine can fill a multi-hour window.
+	for i := 0; i < 40; i++ {
+		mediaID := uuid.NewString()
+		if err := db.Create(&models.MediaItem{
+			ID: mediaID, StationID: stationID, Title: sbID + "-track", Path: "/tmp/" + mediaID + ".mp3",
+			Duration: 3 * time.Minute, AnalysisState: models.AnalysisComplete,
+		}).Error; err != nil {
+			t.Fatalf("seed media item for %s: %v", sbID, err)
+		}
+		if err := db.Create(&models.PlaylistItem{
+			ID: uuid.NewString(), PlaylistID: plID, MediaID: mediaID, Position: i,
+		}).Error; err != nil {
+			t.Fatalf("seed playlist item for %s: %v", sbID, err)
+		}
+	}
+	return sb.ID
+}
+
 func seedMinimalSmartBlock(t *testing.T, db *gorm.DB, stationID string) string {
 	t.Helper()
 	plID := uuid.NewString()

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -379,6 +379,10 @@ func (s *Service) materializeDirectScheduleEntries(ctx context.Context, stationI
 	if err := s.db.WithContext(ctx).
 		Where("station_id = ? AND source_type IN ? AND recurrence_type != '' AND recurrence_type IS NOT NULL AND is_instance = false AND (recurrence_end_date IS NULL OR recurrence_end_date >= ?)",
 			stationID, directMaterializableSourceTypes, start).
+		// Newest parent first: on a contested overlap span the most-recently-created
+		// recurring parent materializes first and claims it; older parents fill only
+		// the remainder via the coverage subtraction in materializeSmartBlockEntry (#75).
+		Order("created_at DESC").
 		Find(&recurringParents).Error; err != nil {
 		return err
 	}

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -1137,6 +1137,26 @@ func (s *Service) RefreshStation(ctx context.Context, stationID string) error {
 	return s.scheduleStation(ctx, stationID)
 }
 
+// InvalidateStationInstances deletes future materialized instances for one
+// station that were produced by a parent whose recurrence changed or which was
+// removed, so the next materialize pass regenerates them. Per-occurrence
+// operator overrides (SeriesID set) are preserved. Strictly station-scoped;
+// never touches another station's rows.
+func (s *Service) InvalidateStationInstances(ctx context.Context, stationID, parentID string) error {
+	// series_id IS NULL selects ONLY plain materializer expansions: the override
+	// path sets SeriesID and the materializer never does.
+	res := s.db.WithContext(ctx).
+		Where("station_id = ? AND is_instance = true AND recurrence_parent_id = ? AND starts_at > ? AND series_id IS NULL",
+			stationID, parentID, time.Now().UTC()).
+		Delete(&models.ScheduleEntry{})
+	if res.Error != nil {
+		return res.Error
+	}
+	s.logger.Info().Str("station", stationID).Str("parent", parentID).
+		Int64("deleted", res.RowsAffected).Msg("invalidated stale instances for regenerate")
+	return nil
+}
+
 // Upcoming returns upcoming schedule entries within horizon.
 // Simulate returns slot plans calculated by the planner.
 func (s *Service) Simulate(ctx context.Context, stationID string, start time.Time, horizon time.Duration) ([]clock.SlotPlan, error) {

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -401,7 +401,7 @@ func (s *Service) materializeDirectScheduleEntries(ctx context.Context, stationI
 
 		switch entry.SourceType {
 		case "smart_block":
-			if err := s.materializeSmartBlockEntry(ctx, stationID, entry, mountID); err != nil {
+			if err := s.materializeSmartBlockEntry(ctx, stationID, entry, mountID, start); err != nil {
 				s.logger.Warn().Err(err).
 					Str("station", stationID).
 					Str("entry_id", entry.ID).
@@ -423,51 +423,76 @@ func (s *Service) materializeDirectScheduleEntries(ctx context.Context, stationI
 }
 
 // materializeSmartBlockEntry runs the smart-block-specific materialization path: it expands
-// the smart block into concrete media schedule rows. It enforces idempotency via two checks:
+// the smart block into concrete media schedule rows for the sub-windows of its slot that are
+// not already covered. Filling only the uncovered remainder (instead of skipping the whole
+// block when any part is covered) avoids the dead air that the old whole-block-skip guard
+// caused (#71/#75).
 //
-//  1. Mount-agnostic media-overlap check — prevents cross-mount double-materialization when
-//     a clock template on a different mount has already filled this window with media.
-//  2. Same-mount any-source-type check — prevents materializing a smart block on a mount that
-//     already has a playlist, webstream, or other entry occupying the slot.
+// A window position counts as covered by either:
 //
-// Both checks use full overlap predicates (not just starts_at range) so that a track that
-// starts before the slot boundary but ends inside it is correctly detected, preventing
-// spurious 23514 (overlap trigger) violations.
-func (s *Service) materializeSmartBlockEntry(ctx context.Context, stationID string, entry models.ScheduleEntry, mountID string) error {
-	var mediaCount int64
-	if err := s.db.WithContext(ctx).Model(&models.ScheduleEntry{}).
-		Where("station_id = ? AND source_type = 'media' AND starts_at < ? AND ends_at > ?",
-			stationID, entry.EndsAt, entry.StartsAt).
-		Count(&mediaCount).Error; err != nil {
-		return err
+//  1. Any same-mount row that occupies the mount — that is, any real playable row except a
+//     non-instance smart_block parent template. The carve-out `NOT (is_instance = false AND
+//     source_type = 'smart_block')` mirrors the one materializeDirectInstanceEntry uses so the
+//     block never treats its own recurring parent as coverage (which would leave it never
+//     filled). This preserves the old same-mount any-source-type skip: a playlist, webstream,
+//     media instance, or already-materialized media on the mount still blocks the overlap.
+//  2. Any cross-mount source_type = 'media' row — the mount-agnostic 23514 (overlap trigger)
+//     protection that prevents cross-mount double-materialization when a clock template on a
+//     different mount already filled the window with media.
+//
+// Coverage uses a full overlap predicate (starts_at < end AND ends_at > start) so a track that
+// starts before the slot boundary but ends inside it is correctly detected.
+//
+// now clamps the fill window's start: gaps entirely before now are dead past air and are never
+// materialized, so a partially-covered block whose only uncovered remainder is in the past
+// produces nothing (matching the old whole-block skip for already-in-progress slots).
+func (s *Service) materializeSmartBlockEntry(ctx context.Context, stationID string, entry models.ScheduleEntry, mountID string, now time.Time) error {
+	windowStart := entry.StartsAt
+	if windowStart.Before(now) {
+		windowStart = now
 	}
-	if mediaCount > 0 {
+	if !windowStart.Before(entry.EndsAt) {
 		return nil
 	}
+	window := interval{windowStart, entry.EndsAt}
 
-	var mountCount int64
-	if err := s.db.WithContext(ctx).Model(&models.ScheduleEntry{}).
-		Where("station_id = ? AND mount_id = ? AND starts_at < ? AND ends_at > ?",
-			stationID, mountID, entry.EndsAt, entry.StartsAt).
-		Count(&mountCount).Error; err != nil {
+	var rows []models.ScheduleEntry
+	if err := s.db.WithContext(ctx).
+		Where("station_id = ? AND starts_at < ? AND ends_at > ?", stationID, entry.EndsAt, entry.StartsAt).
+		Where("(mount_id = ? AND NOT (is_instance = false AND source_type = 'smart_block')) OR source_type = 'media'", mountID).
+		Find(&rows).Error; err != nil {
 		return err
 	}
-	if mountCount > 0 {
-		return nil
+	covered := make([]interval, 0, len(rows))
+	for _, r := range rows {
+		covered = append(covered, interval{r.StartsAt, r.EndsAt})
 	}
 
-	plan := clock.SlotPlan{
-		SlotID:   entry.ID,
-		StartsAt: entry.StartsAt,
-		EndsAt:   entry.EndsAt,
-		Duration: entry.EndsAt.Sub(entry.StartsAt),
-		SlotType: string(models.SlotTypeSmartBlock),
-		Payload: map[string]any{
-			"smart_block_id": entry.SourceID,
-			"mount_id":       mountID,
-		},
+	const minGap = time.Minute
+	gaps := subtractCovered(window, covered, minGap)
+	for _, g := range gaps {
+		plan := clock.SlotPlan{
+			SlotID:   entry.ID,
+			StartsAt: g.Start,
+			EndsAt:   g.End,
+			Duration: g.End.Sub(g.Start),
+			SlotType: string(models.SlotTypeSmartBlock),
+			Payload: map[string]any{
+				"smart_block_id": entry.SourceID,
+				"mount_id":       mountID,
+			},
+		}
+		if err := s.materializeSmartBlock(ctx, stationID, plan); err != nil {
+			s.logger.Warn().Err(err).
+				Str("station", stationID).
+				Str("entry_id", entry.ID).
+				Time("gap_start", g.Start).
+				Time("gap_end", g.End).
+				Msg("failed to materialize smart block into gap")
+			// continue with remaining gaps rather than abort the whole block
+		}
 	}
-	return s.materializeSmartBlock(ctx, stationID, plan)
+	return nil
 }
 
 // materializeDirectInstanceEntry creates the is_instance=true row that the executor plays

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -47,6 +47,7 @@ const (
 type SchedulerService interface {
 	RefreshStation(ctx context.Context, stationID string) error
 	Materialize(ctx context.Context, req smartblock.GenerateRequest) (smartblock.GenerateResult, error)
+	InvalidateStationInstances(ctx context.Context, stationID, parentID string) error
 }
 
 // WebstreamService defines the interface for webstream operations.

--- a/internal/web/pages_reports_test.go
+++ b/internal/web/pages_reports_test.go
@@ -505,7 +505,8 @@ func TestScheduleRefreshReport_CallsSchedulerWhenSet(t *testing.T) {
 
 // mockScheduler implements SchedulerService for tests.
 type mockScheduler struct {
-	refreshFn func(ctx context.Context, stationID string) error
+	refreshFn    func(ctx context.Context, stationID string) error
+	invalidateFn func(ctx context.Context, stationID, parentID string) error
 }
 
 func (m *mockScheduler) RefreshStation(ctx context.Context, stationID string) error {
@@ -517,6 +518,13 @@ func (m *mockScheduler) RefreshStation(ctx context.Context, stationID string) er
 
 func (m *mockScheduler) Materialize(ctx context.Context, req smartblock.GenerateRequest) (smartblock.GenerateResult, error) {
 	return smartblock.GenerateResult{}, nil
+}
+
+func (m *mockScheduler) InvalidateStationInstances(ctx context.Context, stationID, parentID string) error {
+	if m.invalidateFn != nil {
+		return m.invalidateFn(ctx, stationID, parentID)
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/web/pages_schedule.go
+++ b/internal/web/pages_schedule.go
@@ -572,6 +572,79 @@ func (h *Handler) ScheduleEvents(w http.ResponseWriter, r *http.Request) {
 		activeMountStates[state.MountID] = state
 	}
 
+	// Annotate overlapping entries as operator-resolvable conflicts (#75).
+	// Two entries on the same mount conflict iff their time windows overlap.
+	// The newest (later CreatedAt) entry in a conflicting set is flagged as the
+	// provisional winner; ties break deterministically on the larger id string.
+	// This only annotates — every event that was collected above is still emitted.
+	conflictIDs := make(map[string][]string)
+	provisionalWinner := make(map[string]bool)
+	{
+		byMount := make(map[string][]models.ScheduleEntry)
+		for _, entry := range entries {
+			// Skip materialized display rows (smart_block track expansions). Those
+			// children sit inside their parent's window on the same mount, so
+			// including them would flag every block as conflicting with its own
+			// tracks. Only operator-authored entries participate in conflict
+			// detection.
+			if entry.Metadata != nil {
+				if expanded, _ := entry.Metadata["expanded"].(bool); expanded {
+					continue
+				}
+			}
+			byMount[entry.MountID] = append(byMount[entry.MountID], entry)
+		}
+		newer := func(a, b models.ScheduleEntry) bool {
+			if a.CreatedAt.Equal(b.CreatedAt) {
+				return a.ID > b.ID
+			}
+			return a.CreatedAt.After(b.CreatedAt)
+		}
+		for _, group := range byMount {
+			// Union-find over the group so each connected cluster of mutually
+			// (transitively) overlapping entries gets exactly one winner.
+			parent := make([]int, len(group))
+			for i := range parent {
+				parent[i] = i
+			}
+			var find func(int) int
+			find = func(x int) int {
+				for parent[x] != x {
+					parent[x] = parent[parent[x]]
+					x = parent[x]
+				}
+				return x
+			}
+			for i := 0; i < len(group); i++ {
+				for j := i + 1; j < len(group); j++ {
+					a, b := group[i], group[j]
+					// Overlap predicate (mirrors Validator.itemsOverlap).
+					if a.StartsAt.Before(b.EndsAt) && a.EndsAt.After(b.StartsAt) {
+						conflictIDs[a.ID] = append(conflictIDs[a.ID], b.ID)
+						conflictIDs[b.ID] = append(conflictIDs[b.ID], a.ID)
+						parent[find(i)] = find(j)
+					}
+				}
+			}
+			// For each cluster (root), the newest entry is the provisional
+			// winner. A single-entry cluster (no overlaps) has no conflicts and
+			// so gets no winner.
+			winnerByRoot := make(map[int]int)
+			for idx := range group {
+				if len(conflictIDs[group[idx].ID]) == 0 {
+					continue
+				}
+				root := find(idx)
+				if w, ok := winnerByRoot[root]; !ok || newer(group[idx], group[w]) {
+					winnerByRoot[root] = idx
+				}
+			}
+			for _, idx := range winnerByRoot {
+				provisionalWinner[group[idx].ID] = true
+			}
+		}
+	}
+
 	events := make([]calendarEvent, 0, len(entries))
 	for _, entry := range entries {
 		// Get title based on source type and detect orphaned references
@@ -757,6 +830,9 @@ func (h *Handler) ScheduleEvents(w http.ResponseWriter, r *http.Request) {
 				"runtime_mismatch_reason": runtimeMismatchReason,
 				"status_label":            statusLabel,
 				"status_reason":           statusReason,
+				"conflict":                len(conflictIDs[entry.ID]) > 0,
+				"conflict_ids":            conflictIDs[entry.ID],
+				"provisional_winner":      provisionalWinner[entry.ID],
 			},
 		}
 

--- a/internal/web/pages_schedule.go
+++ b/internal/web/pages_schedule.go
@@ -7,6 +7,7 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 package web
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -1042,6 +1043,33 @@ func (h *Handler) ScheduleCreateEntry(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(entry)
 }
 
+// selfHealStation repopulates a station's materialized horizon after an operator
+// fixes a recurring overlap (removes or changes a recurring entry). It drops the
+// station's stale future plain instances for the parent (operator overrides are
+// preserved) and immediately re-materializes via RefreshStation. Fail-soft: a
+// self-heal error is logged, never surfaced to the operator, so a delete/edit is
+// never blocked on it (#75).
+func (h *Handler) selfHealStation(ctx context.Context, stationID, parentID string) {
+	if h.scheduler == nil {
+		return
+	}
+	if err := h.scheduler.InvalidateStationInstances(ctx, stationID, parentID); err != nil {
+		h.logger.Warn().Err(err).Str("station", stationID).Msg("self-heal invalidate failed")
+	}
+	if err := h.scheduler.RefreshStation(ctx, stationID); err != nil {
+		h.logger.Warn().Err(err).Str("station", stationID).Msg("self-heal refresh failed")
+	}
+}
+
+// scheduleEntryParentID returns the id to invalidate for an entry: its recurrence
+// parent when it is an instance/override, else its own id (it IS the parent).
+func scheduleEntryParentID(e models.ScheduleEntry) string {
+	if e.RecurrenceParentID != nil && *e.RecurrenceParentID != "" {
+		return *e.RecurrenceParentID
+	}
+	return e.ID
+}
+
 // ScheduleUpdateEntry updates a schedule entry
 func (h *Handler) ScheduleUpdateEntry(w http.ResponseWriter, r *http.Request) {
 	station := h.GetStation(r)
@@ -1233,6 +1261,12 @@ func (h *Handler) ScheduleUpdateEntry(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// Forward edit splits the series: the truncated parent's future
+		// materialized instances past the split are now stale. Invalidate them for
+		// the parent; RefreshStation then repopulates the whole horizon (including
+		// the new forward segment) (#75).
+		h.selfHealStation(r.Context(), station.ID, scheduleEntryParentID(entry))
+
 		if h.eventBus != nil {
 			h.eventBus.Publish(events.EventScheduleUpdate, events.Payload{
 				"entry_id":    newEntry.ID,
@@ -1329,6 +1363,14 @@ func (h *Handler) ScheduleUpdateEntry(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 		}
+	}
+
+	// Self-heal only when the recurrence pattern actually changed. A pure
+	// title/source/metadata or time edit leaves the materialized horizon valid, so
+	// it must not invalidate. Recurrence fields (type/days/end-date) reshape which
+	// occurrences exist, so drop this parent's stale instances and repopulate (#75).
+	if input.RecurrenceType != nil || input.RecurrenceDays != nil || input.RecurrenceEndDate != nil {
+		h.selfHealStation(r.Context(), station.ID, scheduleEntryParentID(entry))
 	}
 
 	if h.eventBus != nil {
@@ -1471,6 +1513,9 @@ func (h *Handler) ScheduleDeleteEntry(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Failed to update recurring entry", http.StatusInternalServerError)
 			return
 		}
+		// Truncating the series leaves stale future instances past the new end
+		// date; drop them for this parent and repopulate the horizon (#75).
+		h.selfHealStation(r.Context(), station.ID, parentID)
 		h.publishScheduleDelete(station, parent, "end_recurrence")
 
 	case "all":
@@ -1483,6 +1528,9 @@ func (h *Handler) ScheduleDeleteEntry(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "Failed to delete series", http.StatusInternalServerError)
 			return
 		}
+		// The parent is gone, so invalidate finds nothing to delete, but
+		// RefreshStation still repopulates the freed horizon (#75).
+		h.selfHealStation(r.Context(), station.ID, parentID)
 		h.publishScheduleDelete(station, parent, "delete")
 
 	default: // "occurrence" or unspecified: the safe default, never touches the series
@@ -1506,6 +1554,9 @@ func (h *Handler) ScheduleDeleteEntry(w http.ResponseWriter, r *http.Request) {
 			http.NotFound(w, r) // nothing to except and nothing to delete
 			return
 		}
+		// The new EXDATE changes what should materialize for this day; drop this
+		// parent's stale instances and repopulate the horizon (#75).
+		h.selfHealStation(r.Context(), station.ID, parentID)
 		if parentErr == nil {
 			h.publishScheduleDelete(station, parent, "delete_occurrence")
 		} else {

--- a/internal/web/pages_schedule_endpoints_test.go
+++ b/internal/web/pages_schedule_endpoints_test.go
@@ -414,6 +414,188 @@ func TestScheduleEventsReturnsExpandedRecurringAndOrphanedEntries(t *testing.T) 
 	}
 }
 
+func TestScheduleEvents_ConflictMetadata(t *testing.T) {
+	h, db, _, station := newScheduleEndpointTestHandler(t)
+	for _, record := range []any{
+		&models.Mount{ID: "m1", StationID: station.ID, Name: "Main", Format: "mp3"},
+		&models.MediaItem{ID: "media-a", StationID: station.ID, Title: "Track A", Artist: "Artist A", Duration: 3 * time.Minute, Path: "a.mp3"},
+		&models.MediaItem{ID: "media-b", StationID: station.ID, Title: "Track B", Artist: "Artist B", Duration: 3 * time.Minute, Path: "b.mp3"},
+	} {
+		if err := db.Create(record).Error; err != nil {
+			t.Fatalf("seed record: %v", err)
+		}
+	}
+
+	// Two entries on the same mount with an overlapping time window and
+	// different CreatedAt. The newer entry (later CreatedAt) is the
+	// provisional winner.
+	older := models.ScheduleEntry{
+		ID:         "conflict-older",
+		StationID:  station.ID,
+		MountID:    "m1",
+		StartsAt:   time.Date(2026, 3, 10, 10, 0, 0, 0, time.UTC),
+		EndsAt:     time.Date(2026, 3, 10, 11, 0, 0, 0, time.UTC),
+		SourceType: "media",
+		SourceID:   "media-a",
+		CreatedAt:  time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC),
+	}
+	newer := models.ScheduleEntry{
+		ID:         "conflict-newer",
+		StationID:  station.ID,
+		MountID:    "m1",
+		StartsAt:   time.Date(2026, 3, 10, 10, 30, 0, 0, time.UTC),
+		EndsAt:     time.Date(2026, 3, 10, 11, 30, 0, 0, time.UTC),
+		SourceType: "media",
+		SourceID:   "media-b",
+		CreatedAt:  time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC),
+	}
+	for _, entry := range []models.ScheduleEntry{older, newer} {
+		if err := db.Create(&entry).Error; err != nil {
+			t.Fatalf("create entry: %v", err)
+		}
+	}
+
+	req := scheduleRequest(
+		http.MethodGet,
+		"/dashboard/schedule/events?start=2026-03-09T00:00:00Z&end=2026-03-11T00:00:00Z&view=timeGridWeek&mount_id=m1",
+		nil,
+		&station,
+		"",
+	)
+	rr := httptest.NewRecorder()
+
+	h.ScheduleEvents(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	var payload []map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode events payload: %v", err)
+	}
+	if len(payload) != 2 {
+		t.Fatalf("expected 2 events, got %d: %+v", len(payload), payload)
+	}
+
+	byID := make(map[string]map[string]any, len(payload))
+	for _, event := range payload {
+		id, _ := event["id"].(string)
+		props, ok := event["extendedProps"].(map[string]any)
+		if !ok {
+			t.Fatalf("event %q missing extendedProps: %+v", id, event)
+		}
+		byID[id] = props
+	}
+
+	olderProps, ok := byID["conflict-older"]
+	if !ok {
+		t.Fatalf("older event missing from payload: %+v", payload)
+	}
+	newerProps, ok := byID["conflict-newer"]
+	if !ok {
+		t.Fatalf("newer event missing from payload: %+v", payload)
+	}
+
+	// Both flagged in conflict.
+	if conflict, _ := olderProps["conflict"].(bool); !conflict {
+		t.Fatalf("expected older event conflict=true, got %+v", olderProps["conflict"])
+	}
+	if conflict, _ := newerProps["conflict"].(bool); !conflict {
+		t.Fatalf("expected newer event conflict=true, got %+v", newerProps["conflict"])
+	}
+
+	// Each event's conflict_ids references the other.
+	assertContainsID := func(props map[string]any, want string) {
+		t.Helper()
+		raw, ok := props["conflict_ids"].([]any)
+		if !ok {
+			t.Fatalf("conflict_ids not a slice: %+v", props["conflict_ids"])
+		}
+		for _, v := range raw {
+			if s, _ := v.(string); s == want {
+				return
+			}
+		}
+		t.Fatalf("conflict_ids %+v does not contain %q", raw, want)
+	}
+	assertContainsID(olderProps, "conflict-newer")
+	assertContainsID(newerProps, "conflict-older")
+
+	// Only the newer (later CreatedAt) event is the provisional winner.
+	if winner, _ := newerProps["provisional_winner"].(bool); !winner {
+		t.Fatalf("expected newer event provisional_winner=true, got %+v", newerProps["provisional_winner"])
+	}
+	if winner, _ := olderProps["provisional_winner"].(bool); winner {
+		t.Fatalf("expected older event provisional_winner=false, got %+v", olderProps["provisional_winner"])
+	}
+}
+
+// TestScheduleEvents_ExpandedTracksNotConflicts guards against a false-positive
+// where the conflict pass compared materialized smart_block track expansions
+// against their own parent block. On day/list views a single normal smart block
+// expands into child track events that sit inside the parent's window on the same
+// mount; those must NOT be flagged as conflicts (#75).
+func TestScheduleEvents_ExpandedTracksNotConflicts(t *testing.T) {
+	h, db, _, station := newScheduleEndpointTestHandler(t)
+	for _, record := range []any{
+		&models.Mount{ID: "m1", StationID: station.ID, Name: "Main", Format: "mp3"},
+		&models.MediaItem{ID: "media-1", StationID: station.ID, Title: "Block Track", Artist: "Block Artist", Duration: 180 * time.Second, Path: "block.mp3", Genre: "rock"},
+		&models.SmartBlock{ID: "sb-expand", StationID: station.ID, Name: "Expandable Block", Rules: map[string]any{"genre": "rock", "targetMinutes": 3}},
+	} {
+		if err := db.Create(record).Error; err != nil {
+			t.Fatalf("seed record: %v", err)
+		}
+	}
+	entry := models.ScheduleEntry{
+		ID:         "sb-single",
+		StationID:  station.ID,
+		MountID:    "m1",
+		StartsAt:   time.Date(2026, 3, 8, 13, 0, 0, 0, time.UTC),
+		EndsAt:     time.Date(2026, 3, 8, 13, 3, 0, 0, time.UTC),
+		SourceType: "smart_block",
+		SourceID:   "sb-expand",
+	}
+	if err := db.Create(&entry).Error; err != nil {
+		t.Fatalf("create entry: %v", err)
+	}
+
+	// Day view forces track expansion (expandTracks true).
+	req := scheduleRequest(http.MethodGet, "/dashboard/schedule/events?start=2026-03-08T00:00:00Z&end=2026-03-08T23:59:59Z&view=timeGridDay&mount_id=m1", nil, &station, "")
+	rr := httptest.NewRecorder()
+	h.ScheduleEvents(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	var payload []map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	if len(payload) < 2 {
+		t.Fatalf("expected parent block plus expanded track(s), got %+v", payload)
+	}
+
+	sawExpanded := false
+	for _, event := range payload {
+		id, _ := event["id"].(string)
+		props, ok := event["extendedProps"].(map[string]any)
+		if !ok {
+			t.Fatalf("event %q missing extendedProps: %+v", id, event)
+		}
+		if strings.Contains(id, "-t-media-1") {
+			sawExpanded = true
+		}
+		if conflict, _ := props["conflict"].(bool); conflict {
+			t.Fatalf("event %q falsely flagged conflict=true: %+v", id, props)
+		}
+		if winner, _ := props["provisional_winner"].(bool); winner {
+			t.Fatalf("event %q falsely flagged provisional_winner=true: %+v", id, props)
+		}
+	}
+	if !sawExpanded {
+		t.Fatalf("expected at least one expanded track event, got %+v", payload)
+	}
+}
+
 func TestScheduleEventsHonorsMountFilterAndMetadataFallbacks(t *testing.T) {
 	h, db, _, station := newScheduleEndpointTestHandler(t)
 	now := time.Now().UTC().Truncate(time.Minute)

--- a/internal/web/pages_schedule_endpoints_test.go
+++ b/internal/web/pages_schedule_endpoints_test.go
@@ -27,15 +27,25 @@ import (
 type stubSchedulerService struct {
 	stationID string
 	err       error
+
+	// Recording fields for self-heal wiring assertions (#75).
+	refreshCalls    []string
+	invalidateCalls [][2]string // {stationID, parentID}
 }
 
 func (s *stubSchedulerService) RefreshStation(_ context.Context, stationID string) error {
 	s.stationID = stationID
+	s.refreshCalls = append(s.refreshCalls, stationID)
 	return s.err
 }
 
 func (s *stubSchedulerService) Materialize(_ context.Context, _ smartblock.GenerateRequest) (smartblock.GenerateResult, error) {
 	return smartblock.GenerateResult{}, errors.New("unused")
+}
+
+func (s *stubSchedulerService) InvalidateStationInstances(_ context.Context, stationID, parentID string) error {
+	s.invalidateCalls = append(s.invalidateCalls, [2]string{stationID, parentID})
+	return nil
 }
 
 func newScheduleEndpointTestHandler(t *testing.T) (*Handler, *gorm.DB, models.User, models.Station) {
@@ -2058,4 +2068,56 @@ func TestScheduleSmartBlockTrustPreviewExposesBumperUsage(t *testing.T) {
 			t.Fatalf("unexpected bumper track flags: %+v", payload.Tracks)
 		}
 	})
+}
+
+// TestScheduleDeleteSelfHealsMaterializedHorizon guards the Remove-button round
+// trip (#75): deleting a recurring series must invalidate the station's stale
+// future instances for the parent and re-materialize via RefreshStation. Both
+// calls must fire exactly once with the station id and (for invalidate) the
+// parent id.
+func TestScheduleDeleteSelfHealsMaterializedHorizon(t *testing.T) {
+	h, db, _, station := newScheduleEndpointTestHandler(t)
+	if err := db.Create(&models.Mount{ID: "m1", StationID: station.ID, Name: "Main", Format: "mp3"}).Error; err != nil {
+		t.Fatalf("create mount: %v", err)
+	}
+
+	start := time.Date(2026, 3, 10, 9, 0, 0, 0, time.UTC)
+	parent := models.ScheduleEntry{
+		ID:             "recurring-parent",
+		StationID:      station.ID,
+		MountID:        "m1",
+		StartsAt:       start,
+		EndsAt:         start.Add(time.Hour),
+		SourceType:     "media",
+		SourceID:       "media-1",
+		RecurrenceType: models.RecurrenceDaily,
+	}
+	if err := db.Create(&parent).Error; err != nil {
+		t.Fatalf("create recurring parent: %v", err)
+	}
+
+	stub := &stubSchedulerService{}
+	h.scheduler = stub
+
+	// Delete "this and all following" for the occurrence on 2026-03-12.
+	virtualID := parent.ID + "_20260312"
+	req := scheduleRequest(http.MethodDelete, "/dashboard/schedule/entries/"+virtualID+"?scope=forward", nil, &station, virtualID)
+	rr := httptest.NewRecorder()
+	h.ScheduleDeleteEntry(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	if len(stub.invalidateCalls) != 1 {
+		t.Fatalf("expected InvalidateStationInstances called once, got %d: %v", len(stub.invalidateCalls), stub.invalidateCalls)
+	}
+	if got := stub.invalidateCalls[0]; got[0] != station.ID || got[1] != parent.ID {
+		t.Fatalf("expected invalidate(%q, %q), got (%q, %q)", station.ID, parent.ID, got[0], got[1])
+	}
+	if len(stub.refreshCalls) != 1 {
+		t.Fatalf("expected RefreshStation called once, got %d: %v", len(stub.refreshCalls), stub.refreshCalls)
+	}
+	if stub.refreshCalls[0] != station.ID {
+		t.Fatalf("expected refresh(%q), got %q", station.ID, stub.refreshCalls[0])
+	}
 }

--- a/internal/web/templates/pages/dashboard/schedule/calendar.html
+++ b/internal/web/templates/pages/dashboard/schedule/calendar.html
@@ -120,6 +120,43 @@
             -45deg, transparent, transparent 6px, rgba(255,255,255,0.12) 6px, rgba(255,255,255,0.12) 12px
         ) !important;
     }
+    /* Schedule conflicts: reuse the overlap danger language but split
+       the provisional winner (airing) from the flagged-not-airing entries. */
+    .fc-event.event-has-conflict {
+        box-shadow: 0 0 0 2px rgba(var(--bs-danger-rgb), 0.35);
+    }
+    .fc-event.event-conflict-airing {
+        border-color: #8b1a1a !important;
+        box-shadow: 0 0 0 2px rgba(var(--bs-danger-rgb), 0.55);
+    }
+    .fc-event.event-conflict-flagged {
+        opacity: 0.72;
+        border-style: dashed !important;
+        border-color: #8b1a1a !important;
+        background-image: repeating-linear-gradient(
+            45deg, transparent, transparent 5px, rgba(0,0,0,0.14) 5px, rgba(0,0,0,0.14) 10px
+        ) !important;
+    }
+    .event-conflict-badge {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 14px;
+        height: 14px;
+        margin-right: 4px;
+        border-radius: 50%;
+        background: rgba(220,53,69,0.95);
+        color: #fff;
+        font-size: 0.62rem;
+        font-weight: 700;
+        line-height: 1;
+        vertical-align: middle;
+        flex-shrink: 0;
+        cursor: help;
+    }
+    .event-conflict-remove {
+        margin-left: auto;
+    }
     /* Badge for purple/clock type */
     .badge.bg-purple { background-color: var(--calendar-color-clock) !important; }
     .badge.bg-pink { background-color: var(--calendar-color-show) !important; }
@@ -1515,12 +1552,20 @@ document.addEventListener('DOMContentLoaded', function() {
                 if (props.status === 'cancelled') classes.push('event-cancelled');
                 if (props.exception_type) classes.push('event-exception');
                 if (props.overlap_highlight || overlapEventIDs.has(arg.event.id)) classes.push('event-overlap');
+                if (props.conflict) {
+                    classes.push('event-has-conflict');
+                    classes.push(props.provisional_winner ? 'event-conflict-airing' : 'event-conflict-flagged');
+                }
                 return classes;
             }
             const type = props.source_type;
             const classes = ['event-' + (type || 'media')];
             if (props.overlap_highlight || overlapEventIDs.has(arg.event.id)) classes.push('event-overlap');
             if (props.runtime_mismatch) classes.push('event-runtime-mismatch');
+            if (props.conflict) {
+                classes.push('event-has-conflict');
+                classes.push(props.provisional_winner ? 'event-conflict-airing' : 'event-conflict-flagged');
+            }
             return classes;
         },
 
@@ -1609,6 +1654,38 @@ document.addEventListener('DOMContentLoaded', function() {
             }
             if (info.event.extendedProps?.runtime_mismatch) {
                 info.el.title = info.event.extendedProps.runtime_mismatch_reason || info.event.extendedProps.status_reason || 'Runtime does not match the scheduled source.';
+            }
+            // Schedule conflict: warning badge + inline remove. Only touch
+            // conflict_ids AFTER confirming conflict is true (nil serializes to
+            // JSON null for non-conflicting events, not []).
+            if (props.conflict) {
+                const airing = !!props.provisional_winner;
+                const otherCount = (props.conflict_ids || []).length;
+                const badge = document.createElement('span');
+                badge.className = 'event-conflict-badge';
+                badge.textContent = '!';
+                badge.title = airing
+                    ? 'Airing (newest); overlaps ' + otherCount + ' other ' + (otherCount === 1 ? 'entry' : 'entries')
+                    : 'Conflict, not airing (overlaps ' + otherCount + ' other ' + (otherCount === 1 ? 'entry' : 'entries') + ')';
+                const badgeHost = info.el.querySelector('.fc-event-title, .fc-list-event-title')
+                    || info.el.querySelector('.fc-event-main') || info.el;
+                badgeHost.prepend(badge);
+
+                // Inline remove control: reuses the existing deleteEvent() path,
+                // which prompts recurrence scope and DELETEs the entry so the
+                // backend self-heals the surviving entry on refetch.
+                const remove = document.createElement('button');
+                remove.type = 'button';
+                remove.className = 'btn btn-sm btn-link p-0 event-conflict-remove text-white';
+                remove.textContent = 'Remove';
+                remove.title = 'Remove this entry to clear the conflict';
+                remove.addEventListener('click', function(e) {
+                    e.preventDefault();
+                    e.stopPropagation();
+                    deleteEvent(info.event);
+                });
+                const removeHost = info.el.querySelector('.fc-event-main') || info.el;
+                removeHost.appendChild(remove);
             }
         },
 
@@ -3507,11 +3584,10 @@ document.addEventListener('DOMContentLoaded', function() {
         const url = `/dashboard/schedule/entries/${event.id}` + (scope ? `?scope=${scope}` : '');
         fetch(url, { method: 'DELETE' }).then(response => {
             if (response.ok) {
-                if (isRecurring) {
-                    calendar.refetchEvents();
-                } else {
-                    event.remove();
-                }
+                // Always refetch: deleting one entry can clear a conflict on a
+                // surviving overlapping entry, so re-pull to pick up the
+                // backend self-heal instead of a local event.remove().
+                calendar.refetchEvents();
                 eventModal.hide();
                 grimnirUtils.showToast('Entry deleted', 'success');
             } else {


### PR DESCRIPTION
## Summary

Overlapping schedule entries used to drop airtime. The smart-block materializer skipped an entire block when any part of its window was already covered, which left dead air on high-transition channels. This surfaces overlaps as operator-resolvable conflicts instead of silently dropping them, airs the newest entry provisionally, & self-heals a station's materialized horizon once the operator fixes the config. No new DB columns; conflicts are computed at read time.

## What changed

Four coordinated areas across 7 commits:

- **Materializer gap-fill** (`internal/scheduler`): a new `subtractCovered` interval helper fills a block's uncovered sub-windows instead of skipping the whole block. Coverage counts same-mount occupying rows (playlists, webstreams, media instances) plus cross-mount media, & excludes only unmaterialized `smart_block` parent templates. Gaps entirely in the past aren't materialized.
- **Newest-wins ordering**: the Pass 2 recurring-parent query now orders `created_at DESC`, so the newest recurring block claims a contested span & older parents fill the remainder via coverage subtraction. The playout director gets a matching `created_at DESC` tiebreak plus a guard that stops an older overlapping instance from overwriting a newer one at play time.
- **Station-scoped self-heal**: `InvalidateStationInstances` deletes a station's future plain expansions (`series_id IS NULL`) while preserving per-occurrence operator overrides (which carry a non-nil `series_id`), then `RefreshStation` repopulates. It's wired into the delete handler (forward/occurrence/all scopes) & recurrence-changing edits, & is never platform-wide.
- **Schedule UI**: `ScheduleEvents` emits `conflict`, `conflict_ids`, & `provisional_winner` per event, with expanded track rows excluded so a block never conflicts with its own tracks. The calendar double-stacks conflicting entries with a badge, marks the airing (newest) entry distinctly from the flagged one, & adds a Remove control wired to the existing delete endpoint so resolving a conflict triggers the self-heal.

## Test plan

- `go test ./internal/...` passes as a full regression (web package ~55s).
- New tests: interval-subtraction table tests; materializer fills 17:00 to 00:00 when 16:00 to 17:00 is already covered; the newest recurring parent wins a 14:00 to 16:00 contested span; director newest-instance-wins, including a guard sub-case that fails if the guard is removed; invalidate preserves overrides & leaves other stations untouched; the delete endpoint invokes invalidate + refresh; conflict metadata on genuine overlaps; & a regression test proving one normal smart block produces zero conflicts (the false-positive that an earlier draft shipped).
- [ ] Manual: open a station's schedule with a seeded overlap, confirm both entries stack with the badge, the newer is marked airing, & Remove clears the conflict so the freed window refills on the next refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
