### PR TITLE
feat(scheduler,playout): hole-recovery fill + dark-mount telemetry (#74)

### DIFF
--- a/deploy/prometheus/alerts.yml
+++ b/deploy/prometheus/alerts.yml
@@ -44,6 +44,16 @@ groups:
           summary: "Playout buffer critically low for station {{ $labels.station_id }}"
           description: "Buffer depth is {{ $value }} samples ({{ $value | humanize }}ms @ 48kHz) for station {{ $labels.station_id }}. Risk of dropout."
 
+      - alert: PlayoutMountDark
+        expr: grimnir_playout_mount_dark == 1
+        for: 2m
+        labels:
+          severity: critical
+          component: playout
+        annotations:
+          summary: "Playout mount dark on station {{ $labels.station_id }}"
+          description: "Mount {{ $labels.mount_id }} on station {{ $labels.station_id }} has had no producer pipeline past the grace window; the station is dark."
+
       # Schedule Health
       - alert: ScheduleGap
         expr: grimnir_schedule_entries_total == 0

--- a/internal/playout/dark_mount_test.go
+++ b/internal/playout/dark_mount_test.go
@@ -249,3 +249,88 @@ func TestDarkMountGauge_DeadButPresentPipelineIsDark(t *testing.T) {
 		t.Fatalf("dark gauge past grace (dead-but-present) = %v, want 1", got)
 	}
 }
+
+// TestActivePipelinesGauge_ReconciledOnTick proves checkDeadAir's reconciler
+// corrects the active-pipelines gauge each tick. A self-exited pipeline lingers
+// non-nil in the manager map without a StopPipeline call, so the chokepoint-set
+// gauge stays stuck at 1; the tick must pull it back to 0. Descheduling the mount
+// must then delete the series entirely.
+func TestActivePipelinesGauge_ReconciledOnTick(t *testing.T) {
+	d, mgr := newMockDirector(t, &models.ScheduleEntry{})
+	ctx := context.Background()
+
+	stationID := uuid.NewString()
+	mountID := uuid.NewString()
+
+	telemetry.PlayoutActivePipelines.DeleteLabelValues(stationID, mountID)
+	telemetry.PlayoutMountDark.DeleteLabelValues(stationID, mountID)
+
+	base := time.Now().UTC()
+
+	entry := models.ScheduleEntry{
+		ID:         uuid.NewString(),
+		StationID:  stationID,
+		MountID:    mountID,
+		SourceType: "media",
+		SourceID:   uuid.NewString(),
+		StartsAt:   base.Add(-1 * time.Minute),
+		EndsAt:     base.Add(10 * time.Minute),
+	}
+	if err := d.db.Create(&entry).Error; err != nil {
+		t.Fatalf("seed schedule entry: %v", err)
+	}
+
+	d.mu.Lock()
+	d.active[mountID] = playoutState{
+		MediaID:    entry.SourceID,
+		EntryID:    entry.ID,
+		StationID:  stationID,
+		SourceType: "media",
+		Started:    base,
+		Ends:       base.Add(10 * time.Minute),
+	}
+	d.mu.Unlock()
+
+	// Simulate the start chokepoint having set the gauge to 1, then a self-exit:
+	// the pipeline lingers in the map (non-nil) with a closed Done() and no
+	// StopPipeline (which would have cleared the gauge). Gauge is stuck at 1.
+	telemetry.PlayoutActivePipelines.WithLabelValues(stationID, mountID).Set(1)
+	mgr.pipelines[mountID] = newDeadMockPipeline()
+
+	active := func() float64 {
+		return testutil.ToFloat64(telemetry.PlayoutActivePipelines.WithLabelValues(stationID, mountID))
+	}
+	if got := active(); got != 1 {
+		t.Fatalf("active gauge before reconcile = %v, want 1 (stuck)", got)
+	}
+
+	// A tick reconciles the stale 1 down to 0 using the same liveness check.
+	d.checkDeadAir(ctx, base)
+	if got := active(); got != 0 {
+		t.Fatalf("active gauge after reconcile tick = %v, want 0", got)
+	}
+
+	// Now flip to a LIVE pipeline so the reconciler drives it back to 1, proving
+	// the same path also corrects upward drift.
+	mgr.pipelines[mountID] = newMockPipeline()
+	d.checkDeadAir(ctx, base.Add(1*time.Second))
+	if got := active(); got != 1 {
+		t.Fatalf("active gauge after live reconcile = %v, want 1", got)
+	}
+
+	// Deschedule: remove the entry and drop the active mount, then tick. The
+	// active series must be deleted (reads 0), not linger at its last value —
+	// even though this mount was live and never had a darkSince entry.
+	if err := d.db.Where("id = ?", entry.ID).Delete(&models.ScheduleEntry{}).Error; err != nil {
+		t.Fatalf("delete schedule entry: %v", err)
+	}
+	d.markScheduleDirty()
+	d.mu.Lock()
+	delete(d.active, mountID)
+	d.mu.Unlock()
+
+	d.checkDeadAir(ctx, base.Add(2*time.Second))
+	if got := active(); got != 0 {
+		t.Fatalf("active gauge after deschedule = %v, want 0 (stale series)", got)
+	}
+}

--- a/internal/playout/dark_mount_test.go
+++ b/internal/playout/dark_mount_test.go
@@ -1,0 +1,93 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package playout
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+	"github.com/friendsincode/grimnir_radio/internal/telemetry"
+	"github.com/google/uuid"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+)
+
+// TestPlayoutActivePipelinesGauge drives the director through a real start
+// (playMedia → EnsurePipelineWithDualOutput) and stop (StopStation →
+// StopPipeline) and asserts the per-mount gauge tracks the pipeline lifecycle.
+func TestPlayoutActivePipelinesGauge(t *testing.T) {
+	d, _ := newMockDirector(t)
+	ctx := context.Background()
+
+	stationID := uuid.NewString()
+	mountID := uuid.NewString()
+	mediaID := uuid.NewString()
+
+	// Isolate this gauge series so a stale value from another test can't leak in.
+	telemetry.PlayoutActivePipelines.DeleteLabelValues(stationID, mountID)
+
+	mount := models.Mount{
+		ID:         mountID,
+		StationID:  stationID,
+		Name:       "dark-mount-gauge-main",
+		Format:     "mp3",
+		Bitrate:    128,
+		SampleRate: 44100,
+		Channels:   2,
+	}
+	if err := d.db.Create(&mount).Error; err != nil {
+		t.Fatalf("seed mount: %v", err)
+	}
+
+	media := models.MediaItem{
+		ID:            mediaID,
+		StationID:     stationID,
+		Title:         "Gauge Track",
+		Path:          "/tmp/test-gauge.mp3",
+		Duration:      3 * time.Minute,
+		AnalysisState: models.AnalysisComplete,
+	}
+	if err := d.db.Create(&media).Error; err != nil {
+		t.Fatalf("seed media: %v", err)
+	}
+
+	entry := models.ScheduleEntry{
+		ID:        uuid.NewString(),
+		StationID: stationID,
+		MountID:   mountID,
+		StartsAt:  time.Now().UTC().Add(-1 * time.Second),
+		EndsAt:    time.Now().UTC().Add(5 * time.Minute),
+	}
+
+	if err := d.playMedia(ctx, entry, media, nil); err != nil {
+		t.Fatalf("playMedia returned error: %v", err)
+	}
+
+	if got := testutil.ToFloat64(telemetry.PlayoutActivePipelines.WithLabelValues(stationID, mountID)); got != 1 {
+		t.Fatalf("active-pipelines gauge after start = %v, want 1", got)
+	}
+
+	// Active state is required for StopStation to count and stop the mount.
+	d.mu.Lock()
+	d.active[mountID] = playoutState{
+		MediaID:   mediaID,
+		EntryID:   entry.ID,
+		StationID: stationID,
+		Started:   time.Now().UTC(),
+		Ends:      time.Now().UTC().Add(5 * time.Minute),
+	}
+	d.mu.Unlock()
+
+	if _, err := d.StopStation(ctx, stationID); err != nil {
+		t.Fatalf("StopStation returned error: %v", err)
+	}
+
+	if got := testutil.ToFloat64(telemetry.PlayoutActivePipelines.WithLabelValues(stationID, mountID)); got != 0 {
+		t.Fatalf("active-pipelines gauge after stop = %v, want 0", got)
+	}
+}

--- a/internal/playout/dark_mount_test.go
+++ b/internal/playout/dark_mount_test.go
@@ -166,8 +166,26 @@ func TestDarkMountGauge_FiresAfterGrace(t *testing.T) {
 	}
 
 	// Past the 45s grace measured from the re-darkening: gauge flips to 1.
-	d.checkDeadAir(ctx, base.Add(20*time.Second).Add(46*time.Second))
+	darkNow := base.Add(20 * time.Second).Add(46 * time.Second)
+	d.checkDeadAir(ctx, darkNow)
 	if got := dark(); got != 1 {
 		t.Fatalf("dark gauge past grace = %v, want 1", got)
+	}
+
+	// Deschedule the mount: remove the entry so no station should drive it, then
+	// force a schedule refresh. The dark gauge series must be reset to 0 rather
+	// than reading 1 forever for a mount that is no longer scheduled.
+	if err := d.db.Where("id = ?", entry.ID).Delete(&models.ScheduleEntry{}).Error; err != nil {
+		t.Fatalf("delete schedule entry: %v", err)
+	}
+	d.markScheduleDirty()
+	// Drop the active mount too so the entry is fully gone from the director's view.
+	d.mu.Lock()
+	delete(d.active, mountID)
+	d.mu.Unlock()
+
+	d.checkDeadAir(ctx, darkNow.Add(1*time.Second))
+	if got := dark(); got != 0 {
+		t.Fatalf("dark gauge after deschedule = %v, want 0 (stale series)", got)
 	}
 }

--- a/internal/playout/dark_mount_test.go
+++ b/internal/playout/dark_mount_test.go
@@ -91,3 +91,83 @@ func TestPlayoutActivePipelinesGauge(t *testing.T) {
 		t.Fatalf("active-pipelines gauge after stop = %v, want 0", got)
 	}
 }
+
+// TestDarkMountGauge_FiresAfterGrace drives checkDeadAir with a station that has
+// an entry that should be playing but whose mount has no running pipeline
+// (Manager.GetPipeline returns nil). The dark gauge must stay 0 within the 45s
+// grace window and flip to 1 once the mount has been dark past it. Time is
+// injected via the `now` argument — no wall-clock sleep. A pipeline that
+// reappears before the grace elapses must keep the gauge at 0.
+func TestDarkMountGauge_FiresAfterGrace(t *testing.T) {
+	d, mgr := newMockDirector(t, &models.ScheduleEntry{})
+	ctx := context.Background()
+
+	stationID := uuid.NewString()
+	mountID := uuid.NewString()
+
+	// Isolate this gauge series so a stale value from another test can't leak in.
+	telemetry.PlayoutMountDark.DeleteLabelValues(stationID, mountID)
+
+	base := time.Now().UTC()
+
+	// A media entry that should be playing: started well before the dead-air
+	// grace so checkDeadAir considers it live, and ends far in the future.
+	entry := models.ScheduleEntry{
+		ID:         uuid.NewString(),
+		StationID:  stationID,
+		MountID:    mountID,
+		SourceType: "media",
+		SourceID:   uuid.NewString(),
+		StartsAt:   base.Add(-1 * time.Minute),
+		EndsAt:     base.Add(10 * time.Minute),
+	}
+	if err := d.db.Create(&entry).Error; err != nil {
+		t.Fatalf("seed schedule entry: %v", err)
+	}
+
+	// Mark the mount active so checkDeadAir's own dead-air recovery treats the
+	// station as playing and does NOT try to restart the entry. The dark-mount
+	// tracking is driven purely by Manager.GetPipeline, which we control below.
+	d.mu.Lock()
+	d.active[mountID] = playoutState{
+		MediaID:    entry.SourceID,
+		EntryID:    entry.ID,
+		StationID:  stationID,
+		SourceType: "media",
+		Started:    base,
+		Ends:       base.Add(10 * time.Minute),
+	}
+	d.mu.Unlock()
+
+	// No pipeline registered → GetPipeline returns nil → mount is dark.
+	dark := func() float64 {
+		return testutil.ToFloat64(telemetry.PlayoutMountDark.WithLabelValues(stationID, mountID))
+	}
+
+	// First observation: within grace, gauge must be 0.
+	d.checkDeadAir(ctx, base)
+	if got := dark(); got != 0 {
+		t.Fatalf("dark gauge within grace = %v, want 0", got)
+	}
+
+	// A pipeline reappears well before the grace elapses → dark-since cleared,
+	// gauge stays 0.
+	mgr.pipelines[mountID] = newMockPipeline()
+	d.checkDeadAir(ctx, base.Add(10*time.Second))
+	if got := dark(); got != 0 {
+		t.Fatalf("dark gauge after transient recovery = %v, want 0", got)
+	}
+
+	// Pipeline goes away again; a fresh dark-since window starts.
+	delete(mgr.pipelines, mountID)
+	d.checkDeadAir(ctx, base.Add(20*time.Second))
+	if got := dark(); got != 0 {
+		t.Fatalf("dark gauge after re-darkening (within grace) = %v, want 0", got)
+	}
+
+	// Past the 45s grace measured from the re-darkening: gauge flips to 1.
+	d.checkDeadAir(ctx, base.Add(20*time.Second).Add(46*time.Second))
+	if got := dark(); got != 1 {
+		t.Fatalf("dark gauge past grace = %v, want 1", got)
+	}
+}

--- a/internal/playout/dark_mount_test.go
+++ b/internal/playout/dark_mount_test.go
@@ -96,7 +96,7 @@ func TestPlayoutActivePipelinesGauge(t *testing.T) {
 // an entry that should be playing but whose mount has no running pipeline
 // (Manager.GetPipeline returns nil). The dark gauge must stay 0 within the 45s
 // grace window and flip to 1 once the mount has been dark past it. Time is
-// injected via the `now` argument — no wall-clock sleep. A pipeline that
+// injected via the `now` argument, no wall-clock sleep. A pipeline that
 // reappears before the grace elapses must keep the gauge at 0.
 func TestDarkMountGauge_FiresAfterGrace(t *testing.T) {
 	d, mgr := newMockDirector(t, &models.ScheduleEntry{})

--- a/internal/playout/dark_mount_test.go
+++ b/internal/playout/dark_mount_test.go
@@ -189,3 +189,63 @@ func TestDarkMountGauge_FiresAfterGrace(t *testing.T) {
 		t.Fatalf("dark gauge after deschedule = %v, want 0 (stale series)", got)
 	}
 }
+
+// TestDarkMountGauge_DeadButPresentPipelineIsDark proves the gauge treats a
+// self-exited pipeline as dark. Manager.GetPipeline stays non-nil for a pipeline
+// that crashed or hit EOS until StopPipeline removes it from the map, so a bare
+// non-nil check would miss genuine dead air. The mount here has a pipeline whose
+// Done() channel is already closed; the gauge must still flip to 1 past grace.
+func TestDarkMountGauge_DeadButPresentPipelineIsDark(t *testing.T) {
+	d, mgr := newMockDirector(t, &models.ScheduleEntry{})
+	ctx := context.Background()
+
+	stationID := uuid.NewString()
+	mountID := uuid.NewString()
+
+	telemetry.PlayoutMountDark.DeleteLabelValues(stationID, mountID)
+
+	base := time.Now().UTC()
+
+	entry := models.ScheduleEntry{
+		ID:         uuid.NewString(),
+		StationID:  stationID,
+		MountID:    mountID,
+		SourceType: "media",
+		SourceID:   uuid.NewString(),
+		StartsAt:   base.Add(-1 * time.Minute),
+		EndsAt:     base.Add(10 * time.Minute),
+	}
+	if err := d.db.Create(&entry).Error; err != nil {
+		t.Fatalf("seed schedule entry: %v", err)
+	}
+
+	d.mu.Lock()
+	d.active[mountID] = playoutState{
+		MediaID:    entry.SourceID,
+		EntryID:    entry.ID,
+		StationID:  stationID,
+		SourceType: "media",
+		Started:    base,
+		Ends:       base.Add(10 * time.Minute),
+	}
+	d.mu.Unlock()
+
+	// Present-but-exited pipeline: non-nil, Done() already closed.
+	mgr.pipelines[mountID] = newDeadMockPipeline()
+
+	dark := func() float64 {
+		return testutil.ToFloat64(telemetry.PlayoutMountDark.WithLabelValues(stationID, mountID))
+	}
+
+	// Within grace: dark tracking has started but gauge is still 0.
+	d.checkDeadAir(ctx, base)
+	if got := dark(); got != 0 {
+		t.Fatalf("dark gauge within grace (dead-but-present) = %v, want 0", got)
+	}
+
+	// Past the 45s grace: a lingering dead pipeline must read as dark.
+	d.checkDeadAir(ctx, base.Add(46*time.Second))
+	if got := dark(); got != 1 {
+		t.Fatalf("dark gauge past grace (dead-but-present) = %v, want 1", got)
+	}
+}

--- a/internal/playout/director.go
+++ b/internal/playout/director.go
@@ -85,6 +85,14 @@ type playoutState struct {
 	MountName   string // mount name for logging in watchdog path
 }
 
+// darkState tracks, per mount, when it first went dark (0 pipelines while its
+// station should be driving it) along with the station id so the dark-mount
+// gauge series can be reset when the mount later leaves the schedule. (#74)
+type darkState struct {
+	stationID string
+	since     time.Time
+}
+
 type playbackResumeContext struct {
 	Offset        time.Duration
 	LogicalStart  time.Time
@@ -149,7 +157,7 @@ type Director struct {
 	played       map[string]time.Time
 	active       map[string]playoutState
 	sbGeneration map[string]int       // regeneration counter per entry; incremented on sequence exhaustion so each cycle uses a different shuffle seed
-	darkSince    map[string]time.Time // mountID -> when the mount first had 0 pipelines while its station was active; drives the dark-mount gauge (#74)
+	darkSince    map[string]darkState // mountID -> station id + when the mount first had 0 pipelines while its station was active; drives the dark-mount gauge (#74)
 
 	policyMu    sync.Mutex
 	policyCache map[string]cachedScheduleBoundaryPolicy
@@ -194,7 +202,7 @@ func NewDirector(db *gorm.DB, cfg *config.Config, manager ManagerInterface, bus 
 		played:        make(map[string]time.Time),
 		active:        make(map[string]playoutState),
 		sbGeneration:  make(map[string]int),
-		darkSince:     make(map[string]time.Time),
+		darkSince:     make(map[string]darkState),
 		policyCache:   make(map[string]cachedScheduleBoundaryPolicy),
 		webrtcCache:   make(map[string]cachedWebRTCPort),
 		xfadeSessions: make(map[string]*pcmCrossfadeSession),
@@ -463,9 +471,12 @@ func (d *Director) updateDarkMountGauge(entries []models.ScheduleEntry, now time
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	// Drop dark-since state for mounts a station is no longer expected to drive.
-	for mountID := range d.darkSince {
+	// Drop dark-since state for mounts a station is no longer expected to drive,
+	// and remove the gauge series so a mount that was dark (gauge 1) doesn't read
+	// 1 forever once it leaves the schedule. Uses the stored station id label.
+	for mountID, st := range d.darkSince {
 		if _, ok := shouldDrive[mountID]; !ok {
+			telemetry.PlayoutMountDark.DeleteLabelValues(st.stationID, mountID)
 			delete(d.darkSince, mountID)
 		}
 	}
@@ -477,12 +488,12 @@ func (d *Director) updateDarkMountGauge(entries []models.ScheduleEntry, now time
 			telemetry.PlayoutMountDark.WithLabelValues(stationID, mountID).Set(0)
 			continue
 		}
-		since, tracking := d.darkSince[mountID]
+		st, tracking := d.darkSince[mountID]
 		if !tracking {
-			since = now
-			d.darkSince[mountID] = since
+			st = darkState{stationID: stationID, since: now}
+			d.darkSince[mountID] = st
 		}
-		if now.Sub(since) >= darkGrace {
+		if now.Sub(st.since) >= darkGrace {
 			telemetry.PlayoutMountDark.WithLabelValues(stationID, mountID).Set(1)
 		} else {
 			telemetry.PlayoutMountDark.WithLabelValues(stationID, mountID).Set(0)

--- a/internal/playout/director.go
+++ b/internal/playout/director.go
@@ -158,6 +158,7 @@ type Director struct {
 	active       map[string]playoutState
 	sbGeneration map[string]int       // regeneration counter per entry; incremented on sequence exhaustion so each cycle uses a different shuffle seed
 	darkSince    map[string]darkState // mountID -> station id + when the mount first had 0 pipelines while its station was active; drives the dark-mount gauge (#74)
+	darkGaugeSet map[string]string    // mountID -> station id for every mount whose dark/active gauge the reconciler has set; used to delete both series on deschedule (#74)
 
 	policyMu    sync.Mutex
 	policyCache map[string]cachedScheduleBoundaryPolicy
@@ -203,6 +204,7 @@ func NewDirector(db *gorm.DB, cfg *config.Config, manager ManagerInterface, bus 
 		active:        make(map[string]playoutState),
 		sbGeneration:  make(map[string]int),
 		darkSince:     make(map[string]darkState),
+		darkGaugeSet:  make(map[string]string),
 		policyCache:   make(map[string]cachedScheduleBoundaryPolicy),
 		webrtcCache:   make(map[string]cachedWebRTCPort),
 		xfadeSessions: make(map[string]*pcmCrossfadeSession),
@@ -489,18 +491,36 @@ func (d *Director) updateDarkMountGauge(entries []models.ScheduleEntry, now time
 	d.mu.Lock()
 	defer d.mu.Unlock()
 
-	// Drop dark-since state for mounts a station is no longer expected to drive,
-	// and remove the gauge series so a mount that was dark (gauge 1) doesn't read
-	// 1 forever once it leaves the schedule. Uses the stored station id label.
-	for mountID, st := range d.darkSince {
+	// Drop reconciler state for mounts a station is no longer expected to drive,
+	// and remove both gauge series so a mount that was dark (dark=1) or active
+	// (active=1) doesn't read its last value forever once it leaves the schedule.
+	// darkGaugeSet covers every mount this reconciler has touched — including
+	// always-live mounts that never got a darkSince entry — so the active series
+	// is cleared too. Uses the stored station id label.
+	for mountID, stationID := range d.darkGaugeSet {
 		if _, ok := shouldDrive[mountID]; !ok {
-			telemetry.PlayoutMountDark.DeleteLabelValues(st.stationID, mountID)
+			telemetry.PlayoutMountDark.DeleteLabelValues(stationID, mountID)
+			telemetry.PlayoutActivePipelines.DeleteLabelValues(stationID, mountID)
 			delete(d.darkSince, mountID)
+			delete(d.darkGaugeSet, mountID)
 		}
 	}
 
 	for mountID, stationID := range shouldDrive {
-		if mountPipelineLive(d.manager.GetPipeline(mountID)) {
+		// One liveness read drives both gauges. GetPipeline reflects map-presence
+		// only, so a self-exited pipeline lingers non-nil until StopPipeline;
+		// mountPipelineLive checks Done() so a crashed/EOS'd pipeline reads dead.
+		// Reconciling active-pipelines here each tick corrects any self-exit drift
+		// the start/stop chokepoints can't see.
+		d.darkGaugeSet[mountID] = stationID
+		live := mountPipelineLive(d.manager.GetPipeline(mountID))
+		if live {
+			telemetry.PlayoutActivePipelines.WithLabelValues(stationID, mountID).Set(1)
+		} else {
+			telemetry.PlayoutActivePipelines.WithLabelValues(stationID, mountID).Set(0)
+		}
+
+		if live {
 			// Pipeline present and running → not dark. Clear window and reset.
 			delete(d.darkSince, mountID)
 			telemetry.PlayoutMountDark.WithLabelValues(stationID, mountID).Set(0)

--- a/internal/playout/director.go
+++ b/internal/playout/director.go
@@ -476,7 +476,7 @@ func (d *Director) checkStuckTracks(now time.Time) {
 			Str("entry", s.entry.ID).
 			Msg("watchdog: track overdue — forcing pipeline restart")
 		// Stop the stuck pipeline so the next track can start cleanly.
-		if err := d.manager.StopPipeline(s.mountID); err != nil {
+		if err := d.stopMountPipeline(s.entry.StationID, s.mountID); err != nil {
 			d.logger.Warn().Err(err).Str("mount", s.mountID).Msg("watchdog: stop pipeline failed")
 		}
 		go d.handleTrackEnded(s.entry, s.mountName)
@@ -1227,7 +1227,7 @@ func (d *Director) startWebstreamEntry(ctx context.Context, entry models.Schedul
 	d.persistMountState(ctx, entry.MountID, s)
 
 	// Stop previous pipeline
-	if err := d.manager.StopPipeline(entry.MountID); err != nil {
+	if err := d.stopMountPipeline(entry.StationID, entry.MountID); err != nil {
 		d.logger.Debug().Err(err).Str("mount", entry.MountID).Msg("stop pipeline failed")
 	}
 
@@ -1286,7 +1286,7 @@ func (d *Director) startWebstreamEntry(ctx context.Context, entry models.Schedul
 		return fmt.Errorf("build webstream pipeline: %w", err)
 	}
 
-	if err := d.manager.EnsurePipelineWithDualOutput(ctx, entry.MountID, pipeline, nil, hqHandler, lqHandler); err != nil {
+	if err := d.startMountPipelineDual(ctx, entry.StationID, entry.MountID, pipeline, nil, hqHandler, lqHandler); err != nil {
 		d.logger.Warn().Err(err).Str("mount", entry.MountID).Msg("failed to start webstream pipeline")
 		return err
 	}
@@ -1476,7 +1476,7 @@ func (d *Director) watchWebstreamPipeline(ctx context.Context, entry models.Sche
 		d.broadcast.GetMount(mountName),
 		doneCh,
 		webstreamStallGrace, webstreamStallTimeout, webstreamStallCheckTick,
-		func() { _ = d.manager.StopPipeline(entry.MountID) },
+		func() { _ = d.stopMountPipeline(entry.StationID, entry.MountID) },
 	)
 
 	baseDelay := time.Duration(ws.ReconnectDelayMS) * time.Millisecond
@@ -1608,7 +1608,7 @@ func (d *Director) watchWebstreamPipeline(ctx context.Context, entry models.Sche
 				}
 			}
 
-			if err := d.manager.EnsurePipelineWithDualOutput(ctx, entry.MountID, pipelineStr, nil, hqHandler, lqHandler); err != nil {
+			if err := d.startMountPipelineDual(ctx, entry.StationID, entry.MountID, pipelineStr, nil, hqHandler, lqHandler); err != nil {
 				d.logger.Warn().Err(err).Int("attempt", attempt).Msg("reconnect attempt failed")
 				delay *= 2
 				continue
@@ -1749,12 +1749,12 @@ func (d *Director) watchWebstreamPipeline(ctx context.Context, entry models.Sche
 				// Stop the fill pipeline so EnsurePipelineWithDualOutput can claim
 				// the mount slot for the webstream. Only needed if we're actually filling.
 				if isFilling {
-					if stopErr := d.manager.StopPipeline(entry.MountID); stopErr != nil {
+					if stopErr := d.stopMountPipeline(entry.StationID, entry.MountID); stopErr != nil {
 						d.logger.Debug().Err(stopErr).Msg("slow-retry: stop fill pipeline")
 					}
 				}
 
-				if err := d.manager.EnsurePipelineWithDualOutput(ctx, entry.MountID, pipelineStr, nil, hqHandler, lqHandler); err != nil {
+				if err := d.startMountPipelineDual(ctx, entry.StationID, entry.MountID, pipelineStr, nil, hqHandler, lqHandler); err != nil {
 					d.logger.Warn().Err(err).Msg("slow-retry: reconnect attempt failed")
 					// Only fill if we're past the startup grace period to avoid
 					// playing wrong-station content during a startup ordering race.
@@ -1801,7 +1801,7 @@ func (d *Director) watchWebstreamPipeline(ctx context.Context, entry models.Sche
 			d.broadcast.GetMount(mountName),
 			doneCh,
 			webstreamStallGrace, webstreamStallTimeout, webstreamStallCheckTick,
-			func() { _ = d.manager.StopPipeline(entry.MountID) },
+			func() { _ = d.stopMountPipeline(entry.StationID, entry.MountID) },
 		)
 	}
 }
@@ -1814,6 +1814,40 @@ func (d *Director) stopICYPoller(mountID string) {
 		delete(d.icyPollers, mountID)
 	}
 	d.icyPollerMu.Unlock()
+}
+
+// startMountPipelineDual is the single chokepoint for starting a mount pipeline
+// via EnsurePipelineWithDualOutput. On a successful start it sets the per-mount
+// active-pipelines gauge to 1. Every EnsurePipelineWithDualOutput call site in
+// this file routes through here so the gauge can't drift from reality (#74).
+func (d *Director) startMountPipelineDual(ctx context.Context, stationID, mountID, launch string, seekFile *os.File, hqHandler, lqHandler func(io.Reader)) error {
+	if err := d.manager.EnsurePipelineWithDualOutput(ctx, mountID, launch, seekFile, hqHandler, lqHandler); err != nil {
+		return err
+	}
+	telemetry.PlayoutActivePipelines.WithLabelValues(stationID, mountID).Set(1)
+	return nil
+}
+
+// startMountPipelineDualInput is the chokepoint for the input-carrying start
+// variant (EnsurePipelineWithDualOutputAndInput). On success it sets the
+// per-mount active-pipelines gauge to 1 and returns the encoder stdin (#74).
+func (d *Director) startMountPipelineDualInput(ctx context.Context, stationID, mountID, launch string, hqHandler, lqHandler func(io.Reader)) (io.WriteCloser, error) {
+	stdin, err := d.manager.EnsurePipelineWithDualOutputAndInput(ctx, mountID, launch, hqHandler, lqHandler)
+	if err != nil {
+		return stdin, err
+	}
+	telemetry.PlayoutActivePipelines.WithLabelValues(stationID, mountID).Set(1)
+	return stdin, nil
+}
+
+// stopMountPipeline is the single chokepoint for stopping a mount pipeline. It
+// clears the per-mount active-pipelines gauge to 0 and forwards the Manager's
+// StopPipeline result. stationID is passed by the caller (it isn't uniformly in
+// scope at every stop site, but is always derivable from the entry/mount/state
+// there) (#74).
+func (d *Director) stopMountPipeline(stationID, mountID string) error {
+	telemetry.PlayoutActivePipelines.WithLabelValues(stationID, mountID).Set(0)
+	return d.manager.StopPipeline(mountID)
 }
 
 // buildWebstreamBroadcastPipeline creates a GStreamer pipeline that relays a webstream
@@ -2608,10 +2642,10 @@ func (d *Director) playMedia(ctx context.Context, entry models.ScheduleEntry, me
 		_, hasSess := d.xfadeSessions[entry.MountID]
 		d.xfadeMu.Unlock()
 		if !hasSess {
-			_ = d.manager.StopPipeline(entry.MountID)
+			_ = d.stopMountPipeline(entry.StationID, entry.MountID)
 		}
 	} else {
-		if err := d.manager.StopPipeline(entry.MountID); err != nil {
+		if err := d.stopMountPipeline(entry.StationID, entry.MountID); err != nil {
 			d.logger.Debug().Err(err).Str("mount", entry.MountID).Msg("stop pipeline failed")
 		}
 	}
@@ -2669,7 +2703,7 @@ func (d *Director) playMedia(ctx context.Context, entry models.ScheduleEntry, me
 			return fmt.Errorf("build pcm encoder pipeline: %w", err)
 		}
 
-		stdin, err := d.manager.EnsurePipelineWithDualOutputAndInput(ctx, entry.MountID, launch, hqHandler, lqHandler)
+		stdin, err := d.startMountPipelineDualInput(ctx, entry.StationID, entry.MountID, launch, hqHandler, lqHandler)
 		if err != nil {
 			return fmt.Errorf("start pcm encoder pipeline: %w", err)
 		}
@@ -2727,7 +2761,7 @@ func (d *Director) playMedia(ctx context.Context, entry models.ScheduleEntry, me
 			}
 			d.handleTrackEnded(entry, mount.Name)
 		}
-		if err := d.manager.EnsurePipelineWithDualOutput(ctx, entry.MountID, launch, seekFile, hqHandlerWithEnd, lqHandler); err != nil {
+		if err := d.startMountPipelineDual(ctx, entry.StationID, entry.MountID, launch, seekFile, hqHandlerWithEnd, lqHandler); err != nil {
 			d.logger.Warn().Err(err).Str("mount", entry.MountID).Msg("failed to start dual pipeline")
 		}
 	}
@@ -2838,10 +2872,10 @@ func (d *Director) playMediaWithState(ctx context.Context, entry models.Schedule
 		_, hasSess := d.xfadeSessions[entry.MountID]
 		d.xfadeMu.Unlock()
 		if !hasSess {
-			_ = d.manager.StopPipeline(entry.MountID)
+			_ = d.stopMountPipeline(entry.StationID, entry.MountID)
 		}
 	} else {
-		if err := d.manager.StopPipeline(entry.MountID); err != nil {
+		if err := d.stopMountPipeline(entry.StationID, entry.MountID); err != nil {
 			d.logger.Debug().Err(err).Str("mount", entry.MountID).Msg("stop pipeline failed")
 		}
 	}
@@ -2896,7 +2930,7 @@ func (d *Director) playMediaWithState(ctx context.Context, entry models.Schedule
 		if err != nil {
 			return fmt.Errorf("build pcm encoder pipeline: %w", err)
 		}
-		stdin, err := d.manager.EnsurePipelineWithDualOutputAndInput(ctx, entry.MountID, launch, hqHandler, lqHandler)
+		stdin, err := d.startMountPipelineDualInput(ctx, entry.StationID, entry.MountID, launch, hqHandler, lqHandler)
 		if err != nil {
 			return fmt.Errorf("start pcm encoder pipeline: %w", err)
 		}
@@ -2953,7 +2987,7 @@ func (d *Director) playMediaWithState(ctx context.Context, entry models.Schedule
 			}
 			d.handleTrackEnded(entry, mount.Name)
 		}
-		if err := d.manager.EnsurePipelineWithDualOutput(ctx, entry.MountID, launch, seekFile, hqHandlerWithEnd, lqHandler); err != nil {
+		if err := d.startMountPipelineDual(ctx, entry.StationID, entry.MountID, launch, seekFile, hqHandlerWithEnd, lqHandler); err != nil {
 			d.logger.Warn().Err(err).Str("mount", entry.MountID).Msg("failed to start dual pipeline")
 		}
 	}
@@ -3573,7 +3607,7 @@ func (d *Director) playNextFromState(entry models.ScheduleEntry, state playoutSt
 			d.logger.Warn().Err(err).Msg("failed to build pcm encoder pipeline")
 			return
 		}
-		stdin, err := d.manager.EnsurePipelineWithDualOutputAndInput(ctx, entry.MountID, encLaunch, hqHandler, lqHandler)
+		stdin, err := d.startMountPipelineDualInput(ctx, entry.StationID, entry.MountID, encLaunch, hqHandler, lqHandler)
 		if err != nil {
 			d.logger.Warn().Err(err).Str("mount", entry.MountID).Msg("failed to start pcm encoder pipeline")
 			return
@@ -3612,7 +3646,7 @@ func (d *Director) playNextFromState(entry models.ScheduleEntry, state playoutSt
 			}
 			d.handleTrackEnded(entry, mount.Name)
 		}
-		if err := d.manager.EnsurePipelineWithDualOutput(ctx, entry.MountID, launch, seekFile, hqHandlerWithEnd, lqHandler); err != nil {
+		if err := d.startMountPipelineDual(ctx, entry.StationID, entry.MountID, launch, seekFile, hqHandlerWithEnd, lqHandler); err != nil {
 			d.logger.Warn().Err(err).Str("mount", entry.MountID).Msg("failed to start next track pipeline")
 		}
 	}
@@ -3711,7 +3745,7 @@ func (d *Director) playQueuedTrack(entry models.ScheduleEntry, state playoutStat
 			d.logger.Warn().Err(err).Msg("failed to build pcm encoder pipeline for queued track")
 			return
 		}
-		stdin, err := d.manager.EnsurePipelineWithDualOutputAndInput(ctx, entry.MountID, encLaunch, hqHandler, lqHandler)
+		stdin, err := d.startMountPipelineDualInput(ctx, entry.StationID, entry.MountID, encLaunch, hqHandler, lqHandler)
 		if err != nil {
 			d.logger.Warn().Err(err).Str("mount", entry.MountID).Msg("failed to start pcm encoder pipeline for queued track")
 			return
@@ -3744,7 +3778,7 @@ func (d *Director) playQueuedTrack(entry models.ScheduleEntry, state playoutStat
 			d.logger.Warn().Err(err).Msg("failed to build pipeline for queued track")
 			return
 		}
-		if err := d.manager.EnsurePipelineWithDualOutput(ctx, entry.MountID, launch, seekFile, hqHandler, lqHandler); err != nil {
+		if err := d.startMountPipelineDual(ctx, entry.StationID, entry.MountID, launch, seekFile, hqHandler, lqHandler); err != nil {
 			d.logger.Warn().Err(err).Str("mount", entry.MountID).Msg("failed to start queued track pipeline")
 		}
 	}
@@ -3854,7 +3888,7 @@ func (d *Director) playRandomNextTrack(entry models.ScheduleEntry, mountName str
 		}
 	}
 
-	if err := d.manager.EnsurePipelineWithDualOutput(ctx, entry.MountID, launch, seekFile, hqHandler, lqHandler); err != nil {
+	if err := d.startMountPipelineDual(ctx, entry.StationID, entry.MountID, launch, seekFile, hqHandler, lqHandler); err != nil {
 		d.logger.Warn().Err(err).Str("mount", entry.MountID).Msg("failed to start next track dual pipeline")
 	}
 
@@ -3897,7 +3931,7 @@ func (d *Director) scheduleStop(ctx context.Context, stationID, mountID string, 
 		// In crossfade mode we keep a persistent encoder pipeline per-mount so transitions can overlap.
 		// We only stop the pipeline when explicitly requested (emergency stop/skip/etc.).
 		if !(xfade.Enabled && xfade.Duration > 0) {
-			if err := d.manager.StopPipeline(mountID); err != nil {
+			if err := d.stopMountPipeline(stationID, mountID); err != nil {
 				d.logger.Debug().Err(err).Str("mount", mountID).Msg("scheduled stop failed")
 			}
 		}
@@ -4188,7 +4222,7 @@ func (d *Director) StopStation(ctx context.Context, stationID string) (int, erro
 
 		// Stop pipeline and ICY poller for this mount
 		d.stopICYPoller(mount.ID)
-		if err := d.manager.StopPipeline(mount.ID); err != nil {
+		if err := d.stopMountPipeline(mount.StationID, mount.ID); err != nil {
 			d.logger.Warn().Err(err).Str("mount", mount.ID).Msg("failed to stop pipeline")
 			continue
 		}
@@ -4268,7 +4302,7 @@ func (d *Director) SkipStation(ctx context.Context, stationID string) (int, erro
 		}
 
 		d.stopICYPoller(mount.ID)
-		if err := d.manager.StopPipeline(mount.ID); err != nil {
+		if err := d.stopMountPipeline(mount.StationID, mount.ID); err != nil {
 			d.logger.Warn().Err(err).Str("mount", mount.ID).Msg("failed to stop pipeline for skip")
 		}
 
@@ -4317,7 +4351,7 @@ func (d *Director) ReloadStation(ctx context.Context, stationID string) (int, er
 	defer d.mu.Unlock()
 	for _, mount := range mounts {
 		d.stopICYPoller(mount.ID)
-		if err := d.manager.StopPipeline(mount.ID); err != nil {
+		if err := d.stopMountPipeline(mount.StationID, mount.ID); err != nil {
 			d.logger.Warn().Err(err).Str("mount", mount.ID).Msg("failed to stop pipeline during reload")
 		}
 		if _, ok := d.active[mount.ID]; ok {
@@ -4365,7 +4399,7 @@ func (d *Director) InjectLiveSource(ctx context.Context, stationID, mountID stri
 	d.logger.Info().Msg("InjectLiveSource: stopping existing pipeline")
 	// Stop any existing pipeline and ICY poller to start fresh.
 	d.stopICYPoller(mount.ID)
-	_ = d.manager.StopPipeline(mount.ID)
+	_ = d.stopMountPipeline(stationID, mount.ID)
 	d.logger.Info().Msg("InjectLiveSource: pipeline stopped, building PCM encoder")
 
 	mountBitrate := mount.Bitrate
@@ -4416,7 +4450,7 @@ func (d *Director) InjectLiveSource(ctx context.Context, stationID, mountID stri
 	}
 	d.logger.Info().Str("launch", launch).Msg("InjectLiveSource: starting encoder pipeline")
 
-	stdin, err := d.manager.EnsurePipelineWithDualOutputAndInput(ctx, mount.ID, launch, hqHandler, lqHandler)
+	stdin, err := d.startMountPipelineDualInput(ctx, stationID, mount.ID, launch, hqHandler, lqHandler)
 	if err != nil {
 		return nil, nil, fmt.Errorf("start pcm encoder pipeline: %w", err)
 	}
@@ -4449,7 +4483,7 @@ func (d *Director) InjectLiveSource(ctx context.Context, stationID, mountID stri
 			Str("mount_id", mount.ID).
 			Msg("live source released, resuming automation")
 
-		_ = d.manager.StopPipeline(mount.ID)
+		_ = d.stopMountPipeline(stationID, mount.ID)
 
 		// Clear active state so the director tick picks up the schedule again.
 		d.mu.Lock()

--- a/internal/playout/director.go
+++ b/internal/playout/director.go
@@ -445,6 +445,24 @@ func (d *Director) checkDeadAir(ctx context.Context, now time.Time) {
 	d.updateDarkMountGauge(entries, now)
 }
 
+// mountPipelineLive reports whether the manager holds a RUNNING pipeline for the
+// mount. GetPipeline stays non-nil for a self-exited pipeline (it lingers in the
+// manager's map until StopPipeline), so a bare non-nil check would treat a
+// crashed-and-unrestarted pipeline as alive and never mark the mount dark —
+// exactly the failure the dark gauge must catch (#74). A pipeline whose Done()
+// channel has closed is not live.
+func mountPipelineLive(p PipelineInterface) bool {
+	if p == nil {
+		return false
+	}
+	select {
+	case <-p.Done():
+		return false
+	default:
+		return true
+	}
+}
+
 // updateDarkMountGauge maintains grimnir_playout_mount_dark: for every mount a
 // station should currently be driving, it is "dark" when the playout Manager
 // has no running pipeline for that mount. The gauge flips to 1 only once the
@@ -482,8 +500,8 @@ func (d *Director) updateDarkMountGauge(entries []models.ScheduleEntry, now time
 	}
 
 	for mountID, stationID := range shouldDrive {
-		if d.manager.GetPipeline(mountID) != nil {
-			// Pipeline present → not dark. Clear any pending window and reset.
+		if mountPipelineLive(d.manager.GetPipeline(mountID)) {
+			// Pipeline present and running → not dark. Clear window and reset.
 			delete(d.darkSince, mountID)
 			telemetry.PlayoutMountDark.WithLabelValues(stationID, mountID).Set(0)
 			continue

--- a/internal/playout/director.go
+++ b/internal/playout/director.go
@@ -448,8 +448,8 @@ func (d *Director) checkDeadAir(ctx context.Context, now time.Time) {
 // mountPipelineLive reports whether the manager holds a RUNNING pipeline for the
 // mount. GetPipeline stays non-nil for a self-exited pipeline (it lingers in the
 // manager's map until StopPipeline), so a bare non-nil check would treat a
-// crashed-and-unrestarted pipeline as alive and never mark the mount dark —
-// exactly the failure the dark gauge must catch (#74). A pipeline whose Done()
+// crashed-and-unrestarted pipeline as alive and never mark the mount dark,
+// the exact failure the dark gauge must catch (#74). A pipeline whose Done()
 // channel has closed is not live.
 func mountPipelineLive(p PipelineInterface) bool {
 	if p == nil {
@@ -468,7 +468,7 @@ func mountPipelineLive(p PipelineInterface) bool {
 // has no running pipeline for that mount. The gauge flips to 1 only once the
 // mount has been continuously dark for darkGrace; a pipeline reappearing clears
 // the dark-since timestamp and resets the gauge to 0. This tracks a distinct
-// concern from checkDeadAir's 15s dead-air recovery — its own grace, its own
+// concern from checkDeadAir's 15s dead-air recovery: its own grace, its own
 // per-mount state (d.darkSince) under the same d.mu lock. (#74)
 func (d *Director) updateDarkMountGauge(entries []models.ScheduleEntry, now time.Time) {
 	const darkGrace = 45 * time.Second

--- a/internal/playout/director.go
+++ b/internal/playout/director.go
@@ -148,7 +148,8 @@ type Director struct {
 	mu           sync.Mutex
 	played       map[string]time.Time
 	active       map[string]playoutState
-	sbGeneration map[string]int // regeneration counter per entry; incremented on sequence exhaustion so each cycle uses a different shuffle seed
+	sbGeneration map[string]int       // regeneration counter per entry; incremented on sequence exhaustion so each cycle uses a different shuffle seed
+	darkSince    map[string]time.Time // mountID -> when the mount first had 0 pipelines while its station was active; drives the dark-mount gauge (#74)
 
 	policyMu    sync.Mutex
 	policyCache map[string]cachedScheduleBoundaryPolicy
@@ -193,6 +194,7 @@ func NewDirector(db *gorm.DB, cfg *config.Config, manager ManagerInterface, bus 
 		played:        make(map[string]time.Time),
 		active:        make(map[string]playoutState),
 		sbGeneration:  make(map[string]int),
+		darkSince:     make(map[string]time.Time),
 		policyCache:   make(map[string]cachedScheduleBoundaryPolicy),
 		webrtcCache:   make(map[string]cachedWebRTCPort),
 		xfadeSessions: make(map[string]*pcmCrossfadeSession),
@@ -429,6 +431,61 @@ func (d *Director) checkDeadAir(ctx context.Context, now time.Time) {
 			d.logger.Warn().Err(err).Str("entry", rawEntry.ID).Msg("dead air recovery failed")
 		} else {
 			d.markPlayed(playbackKey(rawEntry.ID, rawEntry.StartsAt), rawEntry.EndsAt)
+		}
+	}
+
+	d.updateDarkMountGauge(entries, now)
+}
+
+// updateDarkMountGauge maintains grimnir_playout_mount_dark: for every mount a
+// station should currently be driving, it is "dark" when the playout Manager
+// has no running pipeline for that mount. The gauge flips to 1 only once the
+// mount has been continuously dark for darkGrace; a pipeline reappearing clears
+// the dark-since timestamp and resets the gauge to 0. This tracks a distinct
+// concern from checkDeadAir's 15s dead-air recovery — its own grace, its own
+// per-mount state (d.darkSince) under the same d.mu lock. (#74)
+func (d *Director) updateDarkMountGauge(entries []models.ScheduleEntry, now time.Time) {
+	const darkGrace = 45 * time.Second
+
+	// Collapse to one station per mount for entries that are currently in their
+	// play window (live entries are still valid air, but a live mount with no
+	// pipeline is genuine dead air, so it is monitored like any other).
+	shouldDrive := make(map[string]string, len(entries))
+	for _, e := range entries {
+		if now.Before(e.StartsAt) || now.After(e.EndsAt) {
+			continue
+		}
+		if _, ok := shouldDrive[e.MountID]; !ok {
+			shouldDrive[e.MountID] = e.StationID
+		}
+	}
+
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	// Drop dark-since state for mounts a station is no longer expected to drive.
+	for mountID := range d.darkSince {
+		if _, ok := shouldDrive[mountID]; !ok {
+			delete(d.darkSince, mountID)
+		}
+	}
+
+	for mountID, stationID := range shouldDrive {
+		if d.manager.GetPipeline(mountID) != nil {
+			// Pipeline present → not dark. Clear any pending window and reset.
+			delete(d.darkSince, mountID)
+			telemetry.PlayoutMountDark.WithLabelValues(stationID, mountID).Set(0)
+			continue
+		}
+		since, tracking := d.darkSince[mountID]
+		if !tracking {
+			since = now
+			d.darkSince[mountID] = since
+		}
+		if now.Sub(since) >= darkGrace {
+			telemetry.PlayoutMountDark.WithLabelValues(stationID, mountID).Set(1)
+		} else {
+			telemetry.PlayoutMountDark.WithLabelValues(stationID, mountID).Set(0)
 		}
 	}
 }

--- a/internal/playout/director_mock_test.go
+++ b/internal/playout/director_mock_test.go
@@ -60,6 +60,7 @@ func newMockDirector(t *testing.T, tables ...any) (*Director, *mockManager) {
 		active:        make(map[string]playoutState),
 		played:        make(map[string]time.Time),
 		sbGeneration:  make(map[string]int),
+		darkSince:     make(map[string]time.Time),
 		policyCache:   make(map[string]cachedScheduleBoundaryPolicy),
 		webrtcCache:   make(map[string]cachedWebRTCPort),
 		xfadeSessions: make(map[string]*pcmCrossfadeSession),

--- a/internal/playout/director_mock_test.go
+++ b/internal/playout/director_mock_test.go
@@ -61,6 +61,7 @@ func newMockDirector(t *testing.T, tables ...any) (*Director, *mockManager) {
 		played:        make(map[string]time.Time),
 		sbGeneration:  make(map[string]int),
 		darkSince:     make(map[string]darkState),
+		darkGaugeSet:  make(map[string]string),
 		policyCache:   make(map[string]cachedScheduleBoundaryPolicy),
 		webrtcCache:   make(map[string]cachedWebRTCPort),
 		xfadeSessions: make(map[string]*pcmCrossfadeSession),

--- a/internal/playout/director_mock_test.go
+++ b/internal/playout/director_mock_test.go
@@ -60,7 +60,7 @@ func newMockDirector(t *testing.T, tables ...any) (*Director, *mockManager) {
 		active:        make(map[string]playoutState),
 		played:        make(map[string]time.Time),
 		sbGeneration:  make(map[string]int),
-		darkSince:     make(map[string]time.Time),
+		darkSince:     make(map[string]darkState),
 		policyCache:   make(map[string]cachedScheduleBoundaryPolicy),
 		webrtcCache:   make(map[string]cachedWebRTCPort),
 		xfadeSessions: make(map[string]*pcmCrossfadeSession),

--- a/internal/playout/mock_test.go
+++ b/internal/playout/mock_test.go
@@ -23,6 +23,15 @@ func newMockPipeline() *mockPipeline {
 	return &mockPipeline{done: ch}
 }
 
+// newDeadMockPipeline returns a pipeline that is present but has already exited:
+// its Done() channel is pre-closed, modeling a GStreamer process that self-exited
+// (EOS/crash) and lingers in the manager's map until StopPipeline runs.
+func newDeadMockPipeline() *mockPipeline {
+	ch := make(chan struct{})
+	close(ch)
+	return &mockPipeline{done: ch}
+}
+
 func (m *mockPipeline) Done() <-chan struct{} { return m.done }
 func (m *mockPipeline) Stop() error {
 	select {

--- a/internal/scheduler/fill_test.go
+++ b/internal/scheduler/fill_test.go
@@ -175,7 +175,7 @@ func TestFillPass_TagsFillRows(t *testing.T) {
 
 // TestFillPass_Idempotent proves that running fillStationHoles twice over the same window
 // adds zero new fill rows on the second pass. The coverage query in fillStationHoles loads
-// ALL overlapping rows — including rows already tagged fill=true — so the first pass's
+// ALL overlapping rows, including rows already tagged fill=true, so the first pass's
 // output is treated as coverage on the second pass and no gaps remain.
 func TestFillPass_Idempotent(t *testing.T) {
 	svc, db := newRunTestService(t)

--- a/internal/scheduler/fill_test.go
+++ b/internal/scheduler/fill_test.go
@@ -173,6 +173,82 @@ func TestFillPass_TagsFillRows(t *testing.T) {
 	}
 }
 
+// TestFillPass_Idempotent proves that running fillStationHoles twice over the same window
+// adds zero new fill rows on the second pass. The coverage query in fillStationHoles loads
+// ALL overlapping rows — including rows already tagged fill=true — so the first pass's
+// output is treated as coverage on the second pass and no gaps remain.
+func TestFillPass_Idempotent(t *testing.T) {
+	svc, db := newRunTestService(t)
+	stationID, mountID := "st-idem", "mt-idem"
+	if err := db.Create(&models.Station{ID: stationID, Name: "Test", Timezone: "UTC"}).Error; err != nil {
+		t.Fatalf("create station: %v", err)
+	}
+	if err := db.Create(&models.Mount{
+		ID: mountID, StationID: stationID, Name: "Main",
+		URL: "https://example.invalid/main.mp3", Format: "mp3",
+	}).Error; err != nil {
+		t.Fatalf("create mount: %v", err)
+	}
+
+	// Single recurring smart-block parent forms the fill pool. seedNamedSmartBlock gives it
+	// loopToFill + 40 analyzed tracks so it can physically cover the 2 h hole.
+	poolBlockID := seedNamedSmartBlock(t, db, stationID, "sb-idem")
+	parent := models.ScheduleEntry{
+		ID: "parent-idem", StationID: stationID, MountID: mountID,
+		SourceType: "smart_block", SourceID: poolBlockID,
+		StartsAt:       time.Now().UTC().Add(-24 * time.Hour),
+		EndsAt:         time.Now().UTC().Add(-24 * time.Hour).Add(time.Hour),
+		RecurrenceType: models.RecurrenceDaily, IsInstance: false,
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	if err := db.Create(&parent).Error; err != nil {
+		t.Fatalf("create pool parent: %v", err)
+	}
+
+	// Horizon hole: no real entry covers [start, start+2h).
+	start := time.Now().UTC().Truncate(time.Minute)
+	horizonEnd := start.Add(2 * time.Hour)
+
+	// First pass: should fill the hole.
+	if err := svc.fillStationHoles(context.Background(), stationID, start, horizonEnd); err != nil {
+		t.Fatalf("fillStationHoles (pass 1): %v", err)
+	}
+
+	// Count fill rows after the first pass.
+	var after1 []models.ScheduleEntry
+	db.Where("station_id = ? AND source_type = 'media'", stationID).
+		Order("starts_at ASC").Find(&after1)
+	fillCount1 := 0
+	for _, m := range after1 {
+		if m.Metadata["fill"] == "true" {
+			fillCount1++
+		}
+	}
+	if fillCount1 == 0 {
+		t.Fatal("fill pass 1 produced no fill rows in the 2 h hole")
+	}
+
+	// Second pass over the same window: existing fill rows count as coverage so no new
+	// fill rows should appear.
+	if err := svc.fillStationHoles(context.Background(), stationID, start, horizonEnd); err != nil {
+		t.Fatalf("fillStationHoles (pass 2): %v", err)
+	}
+
+	var after2 []models.ScheduleEntry
+	db.Where("station_id = ? AND source_type = 'media'", stationID).
+		Order("starts_at ASC").Find(&after2)
+	fillCount2 := 0
+	for _, m := range after2 {
+		if m.Metadata["fill"] == "true" {
+			fillCount2++
+		}
+	}
+	if fillCount2 != fillCount1 {
+		t.Errorf("fill row count after pass 2 = %d, want %d (idempotent: second pass must add zero rows)",
+			fillCount2, fillCount1)
+	}
+}
+
 // TestFillPass_RoundRobinLRU proves fillStationHoles rotates across the recurring pool by
 // least-recently-used order instead of always using pool[0]. Two future holes must be
 // filled by DIFFERENT pool blocks; a never-filled block outranks a previously-filled one;

--- a/internal/scheduler/fill_test.go
+++ b/internal/scheduler/fill_test.go
@@ -112,3 +112,62 @@ func TestSweepFillWindow(t *testing.T) {
 		t.Errorf("st-2 fill %s should survive (station scope)", st2Fill)
 	}
 }
+
+// TestFillPass_TagsFillRows seeds a station whose recurring smart-block pool has ONE
+// parent (a pool of 1) backed by analyzed media, then carves a horizon HOLE with no
+// real entry covering [start, start+2h). fillStationHoles must expand the pool block
+// into that hole and tag every produced media row with metadata["fill"]=="true" (the
+// STRING) and a non-empty smart_block_id.
+func TestFillPass_TagsFillRows(t *testing.T) {
+	svc, db := newRunTestService(t)
+	stationID, mountID := "st-fillpass", "mt-fillpass"
+	if err := db.Create(&models.Station{ID: stationID, Name: "Test", Timezone: "UTC"}).Error; err != nil {
+		t.Fatalf("create station: %v", err)
+	}
+	if err := db.Create(&models.Mount{
+		ID: mountID, StationID: stationID, Name: "Main",
+		URL: "https://example.invalid/main.mp3", Format: "mp3",
+	}).Error; err != nil {
+		t.Fatalf("create mount: %v", err)
+	}
+
+	// A single recurring smart-block parent forms the fill pool. seedNamedSmartBlock
+	// gives it loopToFill + 40 analyzed tracks so it can physically fill a 2h hole.
+	poolBlockID := seedNamedSmartBlock(t, db, stationID, "sb-pool")
+	parent := models.ScheduleEntry{
+		ID: "parent-pool", StationID: stationID, MountID: mountID,
+		SourceType: "smart_block", SourceID: poolBlockID,
+		// Recurring parent template (is_instance=false). Its own window is irrelevant
+		// to the hole; the pool query only needs it to be a live recurring parent.
+		StartsAt:       time.Now().UTC().Add(-24 * time.Hour),
+		EndsAt:         time.Now().UTC().Add(-24 * time.Hour).Add(time.Hour),
+		RecurrenceType: models.RecurrenceDaily, IsInstance: false,
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+	if err := db.Create(&parent).Error; err != nil {
+		t.Fatalf("create pool parent: %v", err)
+	}
+
+	// Horizon hole: no real entry covers [start, start+2h).
+	start := time.Now().UTC().Truncate(time.Minute)
+	horizonEnd := start.Add(2 * time.Hour)
+
+	if err := svc.fillStationHoles(context.Background(), stationID, start, horizonEnd); err != nil {
+		t.Fatalf("fillStationHoles: %v", err)
+	}
+
+	var media []models.ScheduleEntry
+	db.Where("station_id = ? AND source_type = 'media'", stationID).
+		Order("starts_at ASC").Find(&media)
+	if len(media) == 0 {
+		t.Fatal("fill pass produced no media in the 2h hole")
+	}
+	for _, m := range media {
+		if got, _ := m.Metadata["fill"].(string); got != "true" {
+			t.Errorf("fill row %s: metadata[fill]=%v, want string \"true\"", m.ID, m.Metadata["fill"])
+		}
+		if sb, _ := m.Metadata["smart_block_id"].(string); sb == "" {
+			t.Errorf("fill row %s: missing smart_block_id", m.ID)
+		}
+	}
+}

--- a/internal/scheduler/fill_test.go
+++ b/internal/scheduler/fill_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+// TestSweepFillWindow verifies that SweepFillWindow deletes only the future
+// auto-fill rows for the target station that overlap [from, to), and leaves
+// non-fill instances, out-of-window fills, past fills, and other stations'
+// fills untouched.
+func TestSweepFillWindow(t *testing.T) {
+	svc, db := newRunTestService(t)
+
+	now := time.Now().UTC()
+	from := now.Add(1 * time.Hour)
+	to := from.Add(2 * time.Hour)
+
+	// The fill marker is stored as the JSON string "true" (not a JSON boolean):
+	// under the SQLite test driver metadata->>'fill' coerces a JSON boolean true
+	// to integer 1, so the production predicate metadata->>'fill' = 'true' would
+	// match zero rows. A JSON string "true" reads back as text 'true' on both
+	// SQLite and Postgres, keeping one predicate portable across backends.
+	fillMeta := func() map[string]any {
+		return map[string]any{"fill": "true", "smart_block_id": "sb-x"}
+	}
+
+	seed := func(id, station string, start, end time.Time, meta map[string]any) {
+		t.Helper()
+		e := models.ScheduleEntry{
+			ID:                 id,
+			StationID:          station,
+			StartsAt:           start,
+			EndsAt:             end,
+			SourceType:         "media",
+			IsInstance:         true,
+			RecurrenceParentID: nil,
+			SeriesID:           nil,
+			Metadata:           meta,
+		}
+		if err := db.Create(&e).Error; err != nil {
+			t.Fatalf("seed %s: %v", id, err)
+		}
+	}
+
+	// Two in-window future FILL rows for st-1 -> should be deleted.
+	inWin1 := "11111111-1111-1111-1111-111111111111"
+	inWin2 := "22222222-2222-2222-2222-222222222222"
+	seed(inWin1, "st-1", from, from.Add(30*time.Minute), fillMeta())
+	seed(inWin2, "st-1", from.Add(30*time.Minute), from.Add(1*time.Hour), fillMeta())
+
+	// Non-fill media instance inside the window for st-1 -> survives.
+	nonFill := "33333333-3333-3333-3333-333333333333"
+	seed(nonFill, "st-1", from.Add(15*time.Minute), from.Add(45*time.Minute), map[string]any{"smart_block_id": "sb-x"})
+
+	// Fill row OUTSIDE the window (future, starts after to) -> survives.
+	outWin := "44444444-4444-4444-4444-444444444444"
+	seed(outWin, "st-1", to.Add(1*time.Hour), to.Add(90*time.Minute), fillMeta())
+
+	// Past fill overlapping the window but excluded by the now-guard -> survives.
+	// StartsAt is before now, EndsAt lands inside the window so it overlaps
+	// (starts_at < to AND ends_at > from) but starts_at > now is false.
+	pastFill := "55555555-5555-5555-5555-555555555555"
+	seed(pastFill, "st-1", now.Add(-2*time.Hour), from.Add(10*time.Minute), fillMeta())
+
+	// st-2 fill inside the window (future) -> survives (station scope).
+	st2Fill := "66666666-6666-6666-6666-666666666666"
+	seed(st2Fill, "st-2", from, from.Add(30*time.Minute), fillMeta())
+
+	n, err := svc.SweepFillWindow(context.Background(), "st-1", from, to)
+	if err != nil {
+		t.Fatalf("SweepFillWindow: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("deleted count = %d, want 2", n)
+	}
+
+	exists := func(id string) bool {
+		t.Helper()
+		var c int64
+		if err := db.Model(&models.ScheduleEntry{}).Where("id = ?", id).Count(&c).Error; err != nil {
+			t.Fatalf("count %s: %v", id, err)
+		}
+		return c == 1
+	}
+
+	if exists(inWin1) {
+		t.Errorf("in-window fill %s should be deleted", inWin1)
+	}
+	if exists(inWin2) {
+		t.Errorf("in-window fill %s should be deleted", inWin2)
+	}
+	if !exists(nonFill) {
+		t.Errorf("non-fill instance %s should survive", nonFill)
+	}
+	if !exists(outWin) {
+		t.Errorf("out-of-window fill %s should survive", outWin)
+	}
+	if !exists(pastFill) {
+		t.Errorf("past fill %s should survive (now-guard)", pastFill)
+	}
+	if !exists(st2Fill) {
+		t.Errorf("st-2 fill %s should survive (station scope)", st2Fill)
+	}
+}

--- a/internal/scheduler/fill_test.go
+++ b/internal/scheduler/fill_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/friendsincode/grimnir_radio/internal/models"
+	"github.com/google/uuid"
 )
 
 // TestSweepFillWindow verifies that SweepFillWindow deletes only the future
@@ -170,4 +171,170 @@ func TestFillPass_TagsFillRows(t *testing.T) {
 			t.Errorf("fill row %s: missing smart_block_id", m.ID)
 		}
 	}
+}
+
+// TestFillPass_RoundRobinLRU proves fillStationHoles rotates across the recurring pool by
+// least-recently-used order instead of always using pool[0]. Two future holes must be
+// filled by DIFFERENT pool blocks; a never-filled block outranks a previously-filled one;
+// and with no prior fill, ties break deterministically by the lexicographically-smaller
+// block id.
+func TestFillPass_RoundRobinLRU(t *testing.T) {
+	// --- Scenario 1: two holes fill with two different pool blocks. ------------------
+	t.Run("two_holes_different_blocks", func(t *testing.T) {
+		svc, db := newRunTestService(t)
+		stationID, mountID := "st-rr", "mt-rr"
+		if err := db.Create(&models.Station{ID: stationID, Name: "Test", Timezone: "UTC"}).Error; err != nil {
+			t.Fatalf("create station: %v", err)
+		}
+		if err := db.Create(&models.Mount{
+			ID: mountID, StationID: stationID, Name: "Main",
+			URL: "https://example.invalid/main.mp3", Format: "mp3",
+		}).Error; err != nil {
+			t.Fatalf("create mount: %v", err)
+		}
+
+		// Two recurring pool parents, sb-a and sb-b.
+		for _, sbID := range []string{"sb-a", "sb-b"} {
+			seedNamedSmartBlock(t, db, stationID, sbID)
+			p := models.ScheduleEntry{
+				ID: "parent-" + sbID, StationID: stationID, MountID: mountID,
+				SourceType: "smart_block", SourceID: sbID,
+				StartsAt:       time.Now().UTC().Add(-24 * time.Hour),
+				EndsAt:         time.Now().UTC().Add(-23 * time.Hour),
+				RecurrenceType: models.RecurrenceDaily, IsInstance: false,
+				CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			}
+			if err := db.Create(&p).Error; err != nil {
+				t.Fatalf("create pool parent %s: %v", sbID, err)
+			}
+		}
+
+		// Fixed future date so both holes are ahead of the pass start. Anchor the day on
+		// tomorrow to guarantee 12:00 and 14:00 are in the future.
+		day := time.Now().UTC().Add(24 * time.Hour).Truncate(24 * time.Hour)
+		hole1Start := day.Add(12 * time.Hour)
+		hole1End := day.Add(13 * time.Hour)
+		hole2Start := day.Add(14 * time.Hour)
+		hole2End := day.Add(15 * time.Hour)
+
+		// A real entry occupies 13:00-14:00 between the two holes so subtractCovered
+		// yields two distinct gaps rather than one merged span.
+		bridge := models.ScheduleEntry{
+			ID: uuid.NewString(), StationID: stationID, MountID: mountID,
+			SourceType: "media", SourceID: uuid.NewString(), IsInstance: true,
+			StartsAt: hole1End, EndsAt: hole2Start,
+		}
+		if err := db.Create(&bridge).Error; err != nil {
+			t.Fatalf("create bridge entry: %v", err)
+		}
+
+		if err := svc.fillStationHoles(context.Background(), stationID, day.Add(11*time.Hour), day.Add(16*time.Hour)); err != nil {
+			t.Fatalf("fillStationHoles: %v", err)
+		}
+
+		blocksIn := func(from, to time.Time) map[string]bool {
+			var media []models.ScheduleEntry
+			db.Where("station_id = ? AND source_type = 'media' AND starts_at >= ? AND starts_at < ?",
+				stationID, from, to).Find(&media)
+			out := map[string]bool{}
+			for _, m := range media {
+				if m.Metadata["fill"] != "true" {
+					continue
+				}
+				if sb, _ := m.Metadata["smart_block_id"].(string); sb != "" {
+					out[sb] = true
+				}
+			}
+			return out
+		}
+
+		h1 := blocksIn(hole1Start, hole1End)
+		h2 := blocksIn(hole2Start, hole2End)
+		if len(h1) != 1 {
+			t.Fatalf("hole1 filled by %v blocks, want exactly 1", h1)
+		}
+		if len(h2) != 1 {
+			t.Fatalf("hole2 filled by %v blocks, want exactly 1", h2)
+		}
+		var b1, b2 string
+		for k := range h1 {
+			b1 = k
+		}
+		for k := range h2 {
+			b2 = k
+		}
+		if b1 == b2 {
+			t.Fatalf("both holes filled by the same block %q; round-robin LRU should differ", b1)
+		}
+		// Determinism: with no prior fill, both blocks are never-filled and tie; the tie
+		// breaks by the lexicographically-smaller block id, so hole1 (chronologically
+		// first) is filled by sb-a.
+		if b1 != "sb-a" {
+			t.Errorf("hole1 filled by %q, want deterministic tie winner sb-a", b1)
+		}
+	})
+
+	// --- Scenario 2: a pre-existing fill for sb-a makes sb-b (never filled) win. -----
+	t.Run("never_filled_block_wins", func(t *testing.T) {
+		svc, db := newRunTestService(t)
+		stationID, mountID := "st-rr2", "mt-rr2"
+		if err := db.Create(&models.Station{ID: stationID, Name: "Test", Timezone: "UTC"}).Error; err != nil {
+			t.Fatalf("create station: %v", err)
+		}
+		if err := db.Create(&models.Mount{
+			ID: mountID, StationID: stationID, Name: "Main",
+			URL: "https://example.invalid/main.mp3", Format: "mp3",
+		}).Error; err != nil {
+			t.Fatalf("create mount: %v", err)
+		}
+		for _, sbID := range []string{"sb-a", "sb-b"} {
+			seedNamedSmartBlock(t, db, stationID, sbID)
+			p := models.ScheduleEntry{
+				ID: "parent-" + sbID, StationID: stationID, MountID: mountID,
+				SourceType: "smart_block", SourceID: sbID,
+				StartsAt:       time.Now().UTC().Add(-24 * time.Hour),
+				EndsAt:         time.Now().UTC().Add(-23 * time.Hour),
+				RecurrenceType: models.RecurrenceDaily, IsInstance: false,
+				CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			}
+			if err := db.Create(&p).Error; err != nil {
+				t.Fatalf("create pool parent %s: %v", sbID, err)
+			}
+		}
+
+		day := time.Now().UTC().Add(24 * time.Hour).Truncate(24 * time.Hour)
+
+		// sb-a already has a fill row in the past. sb-b has none -> sb-b is LRU.
+		priorFill := models.ScheduleEntry{
+			ID: uuid.NewString(), StationID: stationID, MountID: mountID,
+			SourceType: "media", SourceID: uuid.NewString(), IsInstance: true,
+			StartsAt: day.Add(-2 * time.Hour), EndsAt: day.Add(-90 * time.Minute),
+			Metadata: map[string]any{"fill": "true", "smart_block_id": "sb-a"},
+		}
+		if err := db.Create(&priorFill).Error; err != nil {
+			t.Fatalf("create prior fill: %v", err)
+		}
+
+		holeStart := day.Add(12 * time.Hour)
+		holeEnd := day.Add(13 * time.Hour)
+		if err := svc.fillStationHoles(context.Background(), stationID, holeStart, holeEnd); err != nil {
+			t.Fatalf("fillStationHoles: %v", err)
+		}
+
+		var media []models.ScheduleEntry
+		db.Where("station_id = ? AND source_type = 'media' AND starts_at >= ? AND starts_at < ?",
+			stationID, holeStart, holeEnd).Find(&media)
+		got := map[string]bool{}
+		for _, m := range media {
+			if m.Metadata["fill"] != "true" {
+				continue
+			}
+			if sb, _ := m.Metadata["smart_block_id"].(string); sb != "" {
+				got[sb] = true
+			}
+		}
+		if len(got) != 1 || !got["sb-b"] {
+			t.Fatalf("fresh hole filled by %v, want only sb-b (never-filled sorts LRU)", got)
+		}
+	})
 }

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -1157,6 +1157,29 @@ func (s *Service) InvalidateStationInstances(ctx context.Context, stationID, par
 	return nil
 }
 
+// SweepFillWindow deletes future auto-generated fill rows for one station that
+// overlap [from, to). Fill rows are materialized media instances tagged
+// metadata->>'fill'='true'; they carry no recurrence_parent_id, so
+// InvalidateStationInstances (which filters recurrence_parent_id = ?) cannot
+// reach them. Callers sweep a window before inserting real content there so a
+// fill row never blocks the operator's edit via the overlap check or the
+// prevent_station_schedule_overlap trigger. Station-scoped; never touches past rows.
+func (s *Service) SweepFillWindow(ctx context.Context, stationID string, from, to time.Time) (int64, error) {
+	res := s.db.WithContext(ctx).
+		Where("station_id = ? AND source_type = 'media' AND is_instance = true", stationID).
+		Where("recurrence_parent_id IS NULL AND metadata->>'fill' = 'true'").
+		Where("starts_at < ? AND ends_at > ? AND starts_at > ?", to, from, time.Now().UTC()).
+		Delete(&models.ScheduleEntry{})
+	if res.Error != nil {
+		return 0, res.Error
+	}
+	if res.RowsAffected > 0 {
+		s.logger.Info().Str("station", stationID).Int64("deleted", res.RowsAffected).
+			Time("from", from).Time("to", to).Msg("swept fill rows before real entry")
+	}
+	return res.RowsAffected, nil
+}
+
 // Upcoming returns upcoming schedule entries within horizon.
 // Simulate returns slot plans calculated by the planner.
 func (s *Service) Simulate(ctx context.Context, stationID string, start time.Time, horizon time.Duration) ([]clock.SlotPlan, error) {

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -11,6 +11,7 @@ import (
 	"errors"
 	"fmt"
 	"hash/fnv"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -566,35 +567,119 @@ func (s *Service) fillStationHoles(ctx context.Context, stationID string, start,
 		return nil
 	}
 
-	// Task 2.1 uses a single pool block for all holes; round-robin LRU across the pool
-	// is Task 2.2. The pool is loaded as a set so that slot-in is a local change.
-	block := pool[0]
-	mountID := block.MountID
-	if mountID == "" {
-		mountID = s.getDefaultMountID(ctx, stationID)
+	// Round-robin LRU across the pool. Each block's LRU key is the max starts_at among
+	// existing fill rows carrying its source id in metadata->>'smart_block_id'. A block
+	// with no fill rows has no key and sorts oldest (highest fill priority). Holes are
+	// filled in chronological order; after a block fills a hole it becomes most-recently-
+	// used for the next hole (its key is bumped to that hole's end in-memory). The
+	// persisted authority remains the row starts_at, so a later pass recomputes the same
+	// ordering from the DB.
+	type lruBlock struct {
+		entry   models.ScheduleEntry
+		lruKey  time.Time // zero => never filled
+		hasFill bool
+		blockID string // SourceID; what fill rows record and what we sort ties by
+	}
+	lrus := make([]*lruBlock, 0, len(pool))
+	for i := range pool {
+		lb := &lruBlock{entry: pool[i], blockID: pool[i].SourceID}
+		// Max starts_at across this block's persisted fill rows for the station.
+		var maxStart *time.Time
+		var row models.ScheduleEntry
+		err := s.db.WithContext(ctx).
+			Where("station_id = ? AND source_type = 'media' AND metadata->>'fill' = 'true' AND metadata->>'smart_block_id' = ?",
+				stationID, lb.blockID).
+			Order("starts_at DESC").
+			Limit(1).
+			First(&row).Error
+		if err == nil {
+			ms := row.StartsAt
+			maxStart = &ms
+		} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+			return err
+		}
+		if maxStart != nil {
+			lb.lruKey = *maxStart
+			lb.hasFill = true
+		}
+		lrus = append(lrus, lb)
+	}
+
+	// less reports whether block a sorts before b (least-recently-used first):
+	// never-filled blocks first, then oldest fill first, ties broken by the
+	// lexicographically-smaller block id so the pass is deterministic and
+	// reproducible across ticks.
+	less := func(a, b *lruBlock) bool {
+		if a.hasFill != b.hasFill {
+			return !a.hasFill // never-filled sorts first
+		}
+		if a.hasFill && !a.lruKey.Equal(b.lruKey) {
+			return a.lruKey.Before(b.lruKey)
+		}
+		return a.blockID < b.blockID
+	}
+	orderPool := func() []*lruBlock {
+		ordered := make([]*lruBlock, len(lrus))
+		copy(ordered, lrus)
+		sort.SliceStable(ordered, func(i, j int) bool { return less(ordered[i], ordered[j]) })
+		return ordered
+	}
+
+	countFillRows := func(from, to time.Time) (int64, error) {
+		var n int64
+		err := s.db.WithContext(ctx).Model(&models.ScheduleEntry{}).
+			Where("station_id = ? AND source_type = 'media' AND metadata->>'fill' = 'true' AND starts_at >= ? AND starts_at < ?",
+				stationID, from, to).
+			Count(&n).Error
+		return n, err
 	}
 
 	for _, g := range gaps {
-		plan := clock.SlotPlan{
-			SlotID:   block.ID,
-			StartsAt: g.Start,
-			EndsAt:   g.End,
-			Duration: g.End.Sub(g.Start),
-			SlotType: string(models.SlotTypeSmartBlock),
-			Payload: map[string]any{
-				"smart_block_id": block.SourceID,
-				"mount_id":       mountID,
-				"fill":           true,
-			},
-		}
-		if err := s.materializeSmartBlock(ctx, stationID, plan); err != nil {
-			s.logger.Warn().Err(err).
-				Str("station", stationID).
-				Str("smart_block_id", block.SourceID).
-				Time("gap_start", g.Start).
-				Time("gap_end", g.End).
-				Msg("failed to fill horizon hole from recurring block")
-			// continue with remaining holes rather than abort the whole pass
+		// Try pool blocks in LRU order; a block that produces nothing (dry) is skipped
+		// and the next-LRU block is tried. If every block is dry the hole is left
+		// uncovered and the pass moves on.
+		for _, lb := range orderPool() {
+			mountID := lb.entry.MountID
+			if mountID == "" {
+				mountID = s.getDefaultMountID(ctx, stationID)
+			}
+			before, err := countFillRows(g.Start, g.End)
+			if err != nil {
+				return err
+			}
+			plan := clock.SlotPlan{
+				SlotID:   lb.entry.ID,
+				StartsAt: g.Start,
+				EndsAt:   g.End,
+				Duration: g.End.Sub(g.Start),
+				SlotType: string(models.SlotTypeSmartBlock),
+				Payload: map[string]any{
+					"smart_block_id": lb.blockID,
+					"mount_id":       mountID,
+					"fill":           true,
+				},
+			}
+			if err := s.materializeSmartBlock(ctx, stationID, plan); err != nil {
+				s.logger.Warn().Err(err).
+					Str("station", stationID).
+					Str("smart_block_id", lb.blockID).
+					Time("gap_start", g.Start).
+					Time("gap_end", g.End).
+					Msg("failed to fill horizon hole from recurring block")
+				// treat as dry and try the next block rather than abort the pass
+				continue
+			}
+			after, err := countFillRows(g.Start, g.End)
+			if err != nil {
+				return err
+			}
+			if after <= before {
+				continue // dry block, produced nothing — try the next-LRU block
+			}
+			// Filled: this block is now most-recently-used for the next hole.
+			lb.lruKey = g.End
+			lb.hasFill = true
+			break
 		}
 	}
 	return nil

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -323,6 +323,14 @@ func (s *Service) scheduleStation(ctx context.Context, stationID string) error {
 		telemetry.SchedulerErrorsTotal.WithLabelValues(stationID, "direct_schedule_entry").Inc()
 	}
 
+	// Final pass: fill any horizon window still uncovered by real content from the
+	// station's recurring smart-block pool. Runs strictly LAST so real entries (which
+	// already materialized above and count as coverage here) are never displaced.
+	if err := s.fillStationHoles(ctx, stationID, start, start.Add(s.lookahead)); err != nil {
+		s.logger.Warn().Err(err).Str("station", stationID).Msg("fill pass failed")
+		telemetry.SchedulerErrorsTotal.WithLabelValues(stationID, "fill_holes").Inc()
+	}
+
 	// Record metrics
 	duration := time.Since(startTime).Seconds()
 	telemetry.ScheduleBuildDuration.WithLabelValues(stationID).Observe(duration)
@@ -494,6 +502,99 @@ func (s *Service) materializeSmartBlockEntry(ctx context.Context, stationID stri
 				Time("gap_end", g.End).
 				Msg("failed to materialize smart block into gap")
 			// continue with remaining gaps rather than abort the whole block
+		}
+	}
+	return nil
+}
+
+// fillStationHoles is the final materialize pass: after every real entry (clock plans
+// and directly-placed entries) has materialized, any horizon window still uncovered is
+// filled from the station's recurring smart-block pool. Produced media rows are tagged
+// metadata["fill"]="true" so SweepFillWindow can reclaim them when real content later
+// takes the window.
+//
+// Coverage counts EVERY existing schedule row overlapping [start, horizonEnd) — real
+// entries AND prior fill rows. Counting prior fill as coverage is what makes the pass
+// idempotent: a re-run sees the fill it already produced and adds nothing. Real entries
+// always materialize first, so the fill pass never displaces real content.
+//
+// start is clamped to now (mirroring materializeSmartBlockEntry): holes entirely in the
+// past are dead air and are never filled.
+func (s *Service) fillStationHoles(ctx context.Context, stationID string, start, horizonEnd time.Time) error {
+	now := time.Now().UTC()
+	if start.Before(now) {
+		start = now
+	}
+	if !start.Before(horizonEnd) {
+		return nil
+	}
+	window := interval{start, horizonEnd}
+
+	// Coverage: all schedule rows overlapping the window. Recurring smart_block parent
+	// templates are excluded — they occupy no real playout time and would otherwise mask
+	// the very holes they are meant to fill.
+	var rows []models.ScheduleEntry
+	if err := s.db.WithContext(ctx).
+		Where("station_id = ? AND starts_at < ? AND ends_at > ?", stationID, horizonEnd, start).
+		Where("NOT (is_instance = false AND source_type = 'smart_block')").
+		Find(&rows).Error; err != nil {
+		return err
+	}
+	covered := make([]interval, 0, len(rows))
+	for _, r := range rows {
+		covered = append(covered, interval{r.StartsAt, r.EndsAt})
+	}
+
+	const minGap = time.Minute
+	gaps := subtractCovered(window, covered, minGap)
+	if len(gaps) == 0 {
+		return nil
+	}
+
+	// Pool: the station's recurring smart-block parents. Predicate mirrors the Pass 2
+	// recurringParents query in materializeDirectScheduleEntries, restricted to
+	// smart_block source_type. An empty pool means there is nothing to fill holes with.
+	var pool []models.ScheduleEntry
+	if err := s.db.WithContext(ctx).
+		Where("station_id = ? AND source_type = 'smart_block' AND recurrence_type != '' AND recurrence_type IS NOT NULL AND is_instance = false AND (recurrence_end_date IS NULL OR recurrence_end_date >= ?)",
+			stationID, start).
+		Order("created_at DESC").
+		Find(&pool).Error; err != nil {
+		return err
+	}
+	if len(pool) == 0 {
+		return nil
+	}
+
+	// Task 2.1 uses a single pool block for all holes; round-robin LRU across the pool
+	// is Task 2.2. The pool is loaded as a set so that slot-in is a local change.
+	block := pool[0]
+	mountID := block.MountID
+	if mountID == "" {
+		mountID = s.getDefaultMountID(ctx, stationID)
+	}
+
+	for _, g := range gaps {
+		plan := clock.SlotPlan{
+			SlotID:   block.ID,
+			StartsAt: g.Start,
+			EndsAt:   g.End,
+			Duration: g.End.Sub(g.Start),
+			SlotType: string(models.SlotTypeSmartBlock),
+			Payload: map[string]any{
+				"smart_block_id": block.SourceID,
+				"mount_id":       mountID,
+				"fill":           true,
+			},
+		}
+		if err := s.materializeSmartBlock(ctx, stationID, plan); err != nil {
+			s.logger.Warn().Err(err).
+				Str("station", stationID).
+				Str("smart_block_id", block.SourceID).
+				Time("gap_start", g.Start).
+				Time("gap_end", g.End).
+				Msg("failed to fill horizon hole from recurring block")
+			// continue with remaining holes rather than abort the whole pass
 		}
 	}
 	return nil
@@ -928,6 +1029,15 @@ func (s *Service) materializeSmartBlock(ctx context.Context, stationID string, p
 		}
 		if result.Exhausted && i == 0 {
 			meta["sequence_exhausted"] = true
+		}
+		// Fill-pass rows are tagged with the STRING "true" so the portable
+		// metadata->>'fill'='true' predicate (SQLite coerces a JSON boolean to
+		// integer 1) matches. Gated on a truthy bool payload flag so only the
+		// hole-fill pass tags rows; normal smart-block scheduling never does.
+		if f, ok := plan.Payload["fill"]; ok {
+			if b, isBool := f.(bool); isBool && b {
+				meta["fill"] = "true"
+			}
 		}
 		entry := models.ScheduleEntry{
 			ID:         uuid.NewString(),

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -514,7 +514,7 @@ func (s *Service) materializeSmartBlockEntry(ctx context.Context, stationID stri
 // metadata["fill"]="true" so SweepFillWindow can reclaim them when real content later
 // takes the window.
 //
-// Coverage counts EVERY existing schedule row overlapping [start, horizonEnd) — real
+// Coverage counts EVERY existing schedule row overlapping [start, horizonEnd): real
 // entries AND prior fill rows. Counting prior fill as coverage is what makes the pass
 // idempotent: a re-run sees the fill it already produced and adds nothing. Real entries
 // always materialize first, so the fill pass never displaces real content.
@@ -532,7 +532,7 @@ func (s *Service) fillStationHoles(ctx context.Context, stationID string, start,
 	window := interval{start, horizonEnd}
 
 	// Coverage: all schedule rows overlapping the window. Recurring smart_block parent
-	// templates are excluded — they occupy no real playout time and would otherwise mask
+	// templates are excluded; they occupy no real playout time and would otherwise mask
 	// the very holes they are meant to fill.
 	var rows []models.ScheduleEntry
 	if err := s.db.WithContext(ctx).
@@ -674,7 +674,7 @@ func (s *Service) fillStationHoles(ctx context.Context, stationID string, start,
 				return err
 			}
 			if after <= before {
-				continue // dry block, produced nothing — try the next-LRU block
+				continue // dry block, produced nothing; try the next-LRU block
 			}
 			// Filled: this block is now most-recently-used for the next hole.
 			lb.lruKey = g.End

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -199,6 +199,13 @@ var (
 		Name: "grimnir_playout_active_pipelines",
 		Help: "Running internal/playout gst-launch pipelines for a mount (0 or 1)",
 	}, []string{"station_id", "mount_id"})
+
+	// PlayoutMountDark is 1 when a mount's station is active but it has had no
+	// running pipeline for longer than the grace window (#74). Alert target.
+	PlayoutMountDark = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "grimnir_playout_mount_dark",
+		Help: "1 when an active station's mount has 0 pipelines past the grace window",
+	}, []string{"station_id", "mount_id"})
 )
 
 // API metrics

--- a/internal/telemetry/metrics.go
+++ b/internal/telemetry/metrics.go
@@ -191,6 +191,14 @@ var (
 		},
 		[]string{"station_id", "mount_id"},
 	)
+
+	// PlayoutActivePipelines is 1 when the internal/playout gst-launch Manager has a
+	// running pipeline for a mount, else 0. Distinct from MediaEngineActivePipelines
+	// (the mediaengine DSP path). Used to detect a dark mount (#74).
+	PlayoutActivePipelines = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "grimnir_playout_active_pipelines",
+		Help: "Running internal/playout gst-launch pipelines for a mount (0 or 1)",
+	}, []string{"station_id", "mount_id"})
 )
 
 // API metrics

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -48,6 +48,7 @@ type SchedulerService interface {
 	RefreshStation(ctx context.Context, stationID string) error
 	Materialize(ctx context.Context, req smartblock.GenerateRequest) (smartblock.GenerateResult, error)
 	InvalidateStationInstances(ctx context.Context, stationID, parentID string) error
+	SweepFillWindow(ctx context.Context, stationID string, from, to time.Time) (int64, error)
 }
 
 // WebstreamService defines the interface for webstream operations.

--- a/internal/web/pages_reports_test.go
+++ b/internal/web/pages_reports_test.go
@@ -527,6 +527,10 @@ func (m *mockScheduler) InvalidateStationInstances(ctx context.Context, stationI
 	return nil
 }
 
+func (m *mockScheduler) SweepFillWindow(_ context.Context, _ string, _, _ time.Time) (int64, error) {
+	return 0, nil
+}
+
 // ---------------------------------------------------------------------------
 // DayHealth coverage calculation (pure unit tests)
 // ---------------------------------------------------------------------------

--- a/internal/web/pages_schedule.go
+++ b/internal/web/pages_schedule.go
@@ -1057,6 +1057,12 @@ func (h *Handler) ScheduleCreateEntry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if h.scheduler != nil {
+		if _, err := h.scheduler.SweepFillWindow(r.Context(), station.ID, input.StartsAt, input.EndsAt); err != nil {
+			h.logger.Warn().Err(err).Str("station", station.ID).Msg("sweep fill before overlap check failed")
+		}
+	}
+
 	hasOverlap, err := h.scheduleOverlaps(station.ID, input.StartsAt, input.EndsAt, "")
 	if err != nil {
 		http.Error(w, "Failed to validate schedule", http.StatusInternalServerError)
@@ -1202,6 +1208,12 @@ func (h *Handler) ScheduleUpdateEntry(w http.ResponseWriter, r *http.Request) {
 
 	// If editing a single instance of a recurring entry, create an exception
 	if instanceDate != "" && input.EditMode == "single" {
+		if h.scheduler != nil {
+			if _, err := h.scheduler.SweepFillWindow(r.Context(), station.ID, input.StartsAt, input.EndsAt); err != nil {
+				h.logger.Warn().Err(err).Str("station", station.ID).Msg("sweep fill before overlap check failed")
+			}
+		}
+
 		hasOverlap, err := h.scheduleOverlaps(station.ID, input.StartsAt, input.EndsAt, realID)
 		if err != nil {
 			http.Error(w, "Failed to validate schedule", http.StatusInternalServerError)
@@ -1360,6 +1372,12 @@ func (h *Handler) ScheduleUpdateEntry(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(newEntry)
 		return
+	}
+
+	if h.scheduler != nil {
+		if _, err := h.scheduler.SweepFillWindow(r.Context(), station.ID, input.StartsAt, input.EndsAt); err != nil {
+			h.logger.Warn().Err(err).Str("station", station.ID).Msg("sweep fill before overlap check failed")
+		}
 	}
 
 	hasOverlap, err := h.scheduleOverlaps(station.ID, input.StartsAt, input.EndsAt, entry.ID)

--- a/internal/web/pages_schedule_endpoints_test.go
+++ b/internal/web/pages_schedule_endpoints_test.go
@@ -2265,11 +2265,6 @@ func TestScheduleSmartBlockTrustPreviewExposesBumperUsage(t *testing.T) {
 	})
 }
 
-// TestScheduleDeleteSelfHealsMaterializedHorizon guards the Remove-button round
-// trip (#75): deleting a recurring series must invalidate the station's stale
-// future instances for the parent and re-materialize via RefreshStation. Both
-// calls must fire exactly once with the station id and (for invalidate) the
-// parent id.
 func TestScheduleCreate_SweepsFillFirst(t *testing.T) {
 	h, db, _, station := newScheduleEndpointTestHandler(t)
 	if err := db.Create(&models.Mount{ID: "m1", StationID: station.ID, Name: "Main", Format: "mp3"}).Error; err != nil {
@@ -2320,6 +2315,11 @@ func TestScheduleCreate_SweepsFillFirst(t *testing.T) {
 	}
 }
 
+// TestScheduleDeleteSelfHealsMaterializedHorizon guards the Remove-button round
+// trip (#75): deleting a recurring series must invalidate the station's stale
+// future instances for the parent and re-materialize via RefreshStation. Both
+// calls must fire exactly once with the station id and (for invalidate) the
+// parent id.
 func TestScheduleDeleteSelfHealsMaterializedHorizon(t *testing.T) {
 	h, db, _, station := newScheduleEndpointTestHandler(t)
 	if err := db.Create(&models.Mount{ID: "m1", StationID: station.ID, Name: "Main", Format: "mp3"}).Error; err != nil {

--- a/internal/web/pages_schedule_endpoints_test.go
+++ b/internal/web/pages_schedule_endpoints_test.go
@@ -31,6 +31,14 @@ type stubSchedulerService struct {
 	// Recording fields for self-heal wiring assertions (#75).
 	refreshCalls    []string
 	invalidateCalls [][2]string // {stationID, parentID}
+
+	// Recording fields for hole-recovery wiring assertions (#74).
+	sweepCalls []sweepFillCall
+}
+
+type sweepFillCall struct {
+	stationID string
+	from, to  time.Time
 }
 
 func (s *stubSchedulerService) RefreshStation(_ context.Context, stationID string) error {
@@ -46,6 +54,11 @@ func (s *stubSchedulerService) Materialize(_ context.Context, _ smartblock.Gener
 func (s *stubSchedulerService) InvalidateStationInstances(_ context.Context, stationID, parentID string) error {
 	s.invalidateCalls = append(s.invalidateCalls, [2]string{stationID, parentID})
 	return nil
+}
+
+func (s *stubSchedulerService) SweepFillWindow(_ context.Context, stationID string, from, to time.Time) (int64, error) {
+	s.sweepCalls = append(s.sweepCalls, sweepFillCall{stationID: stationID, from: from, to: to})
+	return 0, nil
 }
 
 func newScheduleEndpointTestHandler(t *testing.T) (*Handler, *gorm.DB, models.User, models.Station) {

--- a/internal/web/pages_schedule_endpoints_test.go
+++ b/internal/web/pages_schedule_endpoints_test.go
@@ -2270,6 +2270,56 @@ func TestScheduleSmartBlockTrustPreviewExposesBumperUsage(t *testing.T) {
 // future instances for the parent and re-materialize via RefreshStation. Both
 // calls must fire exactly once with the station id and (for invalidate) the
 // parent id.
+func TestScheduleCreate_SweepsFillFirst(t *testing.T) {
+	h, db, _, station := newScheduleEndpointTestHandler(t)
+	if err := db.Create(&models.Mount{ID: "m1", StationID: station.ID, Name: "Main", Format: "mp3"}).Error; err != nil {
+		t.Fatalf("create mount: %v", err)
+	}
+
+	stub := &stubSchedulerService{}
+	h.scheduler = stub
+
+	startsAt := time.Date(2026, 4, 1, 10, 0, 0, 0, time.UTC)
+	endsAt := time.Date(2026, 4, 1, 11, 0, 0, 0, time.UTC)
+	body, _ := json.Marshal(map[string]any{
+		"mount_id":    "m1",
+		"starts_at":   startsAt,
+		"ends_at":     endsAt,
+		"source_type": "live",
+		"source_id":   "",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/dashboard/schedule/entries", bytes.NewReader(body))
+	req = req.WithContext(context.WithValue(req.Context(), ctxKeyStation, &station))
+	rr := httptest.NewRecorder()
+
+	h.ScheduleCreateEntry(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	var created models.ScheduleEntry
+	if err := json.NewDecoder(rr.Body).Decode(&created); err != nil {
+		t.Fatalf("decode create response: %v", err)
+	}
+	if created.ID == "" {
+		t.Fatalf("expected created entry to have an ID, got %+v", created)
+	}
+
+	if len(stub.sweepCalls) != 1 {
+		t.Fatalf("expected SweepFillWindow called once, got %d: %v", len(stub.sweepCalls), stub.sweepCalls)
+	}
+	got := stub.sweepCalls[0]
+	if got.stationID != station.ID {
+		t.Fatalf("expected sweep stationID=%q, got %q", station.ID, got.stationID)
+	}
+	if !got.from.Equal(startsAt) {
+		t.Fatalf("expected sweep from=%v, got %v", startsAt, got.from)
+	}
+	if !got.to.Equal(endsAt) {
+		t.Fatalf("expected sweep to=%v, got %v", endsAt, got.to)
+	}
+}
+
 func TestScheduleDeleteSelfHealsMaterializedHorizon(t *testing.T) {
 	h, db, _, station := newScheduleEndpointTestHandler(t)
 	if err := db.Create(&models.Mount{ID: "m1", StationID: station.ID, Name: "Main", Format: "mp3"}).Error; err != nil {


### PR DESCRIPTION
## Summary

Part B of #74. A station no longer sits dark on a schedule hole, and a mount that goes dark anyway becomes visible in telemetry.

- **Rolling fill.** The scheduler fills any uncovered horizon window from the station's own recurring smart blocks, round-robin by least-recently-used across the pool, tagging fill rows `metadata.fill="true"`. Fill counts as coverage, so the pass is idempotent across ticks and real entries always win their window. The marker is the string `"true"`, not a JSON bool: under SQLite `metadata->>'fill'` on a bool returns integer 1 and matches zero rows, so the string keeps the predicate portable across SQLite and Postgres.
- **Fill yields to operators.** `SweepFillWindow` deletes future fill in a window; `ScheduleCreateEntry` and both overlap-checked edit branches sweep before their overlap check, so auto-fill never blocks a real show going in (no false 409). Part A's `InvalidateStationInstances` can't reach fill rows (they carry no recurrence parent), which is why the dedicated sweep exists.
- **Dark-mount telemetry.** `grimnir_playout_active_pipelines` tracks per-mount pipeline liveness, set through three director chokepoint helpers that funnel all 27 start/stop sites. `grimnir_playout_mount_dark` is 1 when an active station's mount has no running pipeline past a 45s grace (separate from the existing 15s dead-air recovery). Both honor `Done()`, so a self-exited-but-still-mapped pipeline reads as dark rather than alive, and both series are reconciled each tick and cleared when a mount leaves the schedule. A `PlayoutMountDark` Prometheus alert fires after 2m.

## Test plan

- `go test ./internal/... -count=1` green; `internal/playout` is race-clean under `-race`.
- 15 commits, built task-by-task with spec + code-quality review; a final adversarial review caught the self-exited-pipeline gap and the stale-gauge-on-deschedule cases, all fixed here.
- [ ] Manual on prod-like data: a station with recurring blocks and a hole shows fill airing across the hole; adding a real show into a filled window succeeds without a 409 and airs; killing a mount's pipeline while its station is active raises `grimnir_playout_mount_dark` after ~45s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)