### PR TITLE
perf/fix(scheduler,playout): hole-recovery review follow-ups (#74)

### DIFF
--- a/internal/playout/dark_mount_test.go
+++ b/internal/playout/dark_mount_test.go
@@ -8,6 +8,7 @@ package playout
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -89,6 +90,37 @@ func TestPlayoutActivePipelinesGauge(t *testing.T) {
 
 	if got := testutil.ToFloat64(telemetry.PlayoutActivePipelines.WithLabelValues(stationID, mountID)); got != 0 {
 		t.Fatalf("active-pipelines gauge after stop = %v, want 0", got)
+	}
+}
+
+// TestStopMountPipeline_GaugeUnchangedOnError proves that stopMountPipeline
+// leaves the active-pipelines gauge unchanged when StopPipeline returns an error.
+// The gauge is seeded to 1, the mock manager is configured to return an error,
+// and after the call the gauge must still read 1 and the error must be returned.
+func TestStopMountPipeline_GaugeUnchangedOnError(t *testing.T) {
+	d, mgr := newMockDirector(t)
+
+	stationID := uuid.NewString()
+	mountID := uuid.NewString()
+
+	// Isolate this gauge series from any other test that might touch it.
+	telemetry.PlayoutActivePipelines.DeleteLabelValues(stationID, mountID)
+
+	// Seed the gauge to 1, simulating a running pipeline.
+	telemetry.PlayoutActivePipelines.WithLabelValues(stationID, mountID).Set(1)
+
+	// Make StopPipeline return an error (pipeline may still be running).
+	mgr.stopErr = errors.New("gstreamer: stop timed out")
+
+	err := d.stopMountPipeline(stationID, mountID)
+	if err == nil {
+		t.Fatal("stopMountPipeline returned nil, want the StopPipeline error")
+	}
+
+	// Gauge must remain 1: the pipeline may still be alive, and the
+	// checkDeadAir reconciler will correct the gauge on the next tick.
+	if got := testutil.ToFloat64(telemetry.PlayoutActivePipelines.WithLabelValues(stationID, mountID)); got != 1 {
+		t.Errorf("active-pipelines gauge = %v after failed stop, want 1 (gauge must not be zeroed on error)", got)
 	}
 }
 

--- a/internal/playout/director.go
+++ b/internal/playout/director.go
@@ -1947,13 +1947,18 @@ func (d *Director) startMountPipelineDualInput(ctx context.Context, stationID, m
 }
 
 // stopMountPipeline is the single chokepoint for stopping a mount pipeline. It
-// clears the per-mount active-pipelines gauge to 0 and forwards the Manager's
-// StopPipeline result. stationID is passed by the caller (it isn't uniformly in
-// scope at every stop site, but is always derivable from the entry/mount/state
-// there) (#74).
+// calls StopPipeline first; if that succeeds, it clears the per-mount
+// active-pipelines gauge to 0 and returns nil. On error it returns the error
+// and leaves the gauge unchanged (the checkDeadAir tick reconciler corrects
+// it from actual pipeline liveness). stationID is passed by the caller (it
+// isn't uniformly in scope at every stop site, but is always derivable from
+// the entry/mount/state there) (#74).
 func (d *Director) stopMountPipeline(stationID, mountID string) error {
+	if err := d.manager.StopPipeline(mountID); err != nil {
+		return err
+	}
 	telemetry.PlayoutActivePipelines.WithLabelValues(stationID, mountID).Set(0)
-	return d.manager.StopPipeline(mountID)
+	return nil
 }
 
 // buildWebstreamBroadcastPipeline creates a GStreamer pipeline that relays a webstream

--- a/internal/scheduler/fill_test.go
+++ b/internal/scheduler/fill_test.go
@@ -249,6 +249,89 @@ func TestFillPass_Idempotent(t *testing.T) {
 	}
 }
 
+// TestFillPass_DryBlockNotRetriedPerGap proves that a pool block which produces no fill rows
+// on its first attempt (dry) is not retried for subsequent gaps in the same pass. Two 1-hour
+// gaps are carved for a station whose pool contains two recurring smart-block parents, neither
+// of which has analyzed media (so both are dry). The pass must return nil and produce zero fill
+// rows. The O(N) bound is enforced by construction: the dry set in fillStationHoles ensures
+// each block is attempted at most once per pass. Because s.engine is a concrete
+// *smartblock.Engine (not an interface), a call-count spy would require invasive harness
+// changes, so this test asserts correctness (nil error, zero fill rows, two gaps handled) and
+// relies on code inspection for the perf bound.
+func TestFillPass_DryBlockNotRetriedPerGap(t *testing.T) {
+	svc, db := newRunTestService(t)
+	stationID, mountID := "st-dry", "mt-dry"
+	if err := db.Create(&models.Station{ID: stationID, Name: "Test", Timezone: "UTC"}).Error; err != nil {
+		t.Fatalf("create station: %v", err)
+	}
+	if err := db.Create(&models.Mount{
+		ID: mountID, StationID: stationID, Name: "Main",
+		URL: "https://example.invalid/main.mp3", Format: "mp3",
+	}).Error; err != nil {
+		t.Fatalf("create mount: %v", err)
+	}
+
+	// Two recurring pool parents whose smart blocks have a playlist but NO analyzed
+	// media items. The engine will produce nothing for either block (dry).
+	seedDrySmartBlock := func(sbID string) {
+		t.Helper()
+		plID := uuid.NewString()
+		sb := models.SmartBlock{
+			ID: sbID, StationID: stationID, Name: sbID,
+			Rules: map[string]any{"targetMinutes": 60, "sourcePlaylists": []string{plID}},
+		}
+		if err := db.Create(&sb).Error; err != nil {
+			t.Fatalf("seed dry smart block %s: %v", sbID, err)
+		}
+		if err := db.Create(&models.Playlist{ID: plID, StationID: stationID, Name: sbID + " PL"}).Error; err != nil {
+			t.Fatalf("seed playlist for %s: %v", sbID, err)
+		}
+		// No media items seeded: the playlist exists but is empty, so the engine
+		// resolves the block but has nothing to schedule.
+		p := models.ScheduleEntry{
+			ID: "parent-dry-" + sbID, StationID: stationID, MountID: mountID,
+			SourceType: "smart_block", SourceID: sbID,
+			StartsAt:       time.Now().UTC().Add(-24 * time.Hour),
+			EndsAt:         time.Now().UTC().Add(-23 * time.Hour),
+			RecurrenceType: models.RecurrenceDaily, IsInstance: false,
+			CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		}
+		if err := db.Create(&p).Error; err != nil {
+			t.Fatalf("create pool parent %s: %v", sbID, err)
+		}
+	}
+	seedDrySmartBlock("sb-dry-a")
+	seedDrySmartBlock("sb-dry-b")
+
+	// Two 1-hour holes separated by a real entry so subtractCovered yields two
+	// distinct gaps.
+	day := time.Now().UTC().Add(24 * time.Hour).Truncate(24 * time.Hour)
+	hole1End := day.Add(13 * time.Hour)
+	hole2Start := day.Add(14 * time.Hour)
+
+	bridge := models.ScheduleEntry{
+		ID: uuid.NewString(), StationID: stationID, MountID: mountID,
+		SourceType: "media", SourceID: uuid.NewString(), IsInstance: true,
+		StartsAt: hole1End, EndsAt: hole2Start,
+	}
+	if err := db.Create(&bridge).Error; err != nil {
+		t.Fatalf("create bridge entry: %v", err)
+	}
+
+	if err := svc.fillStationHoles(context.Background(), stationID, day.Add(11*time.Hour), day.Add(16*time.Hour)); err != nil {
+		t.Fatalf("fillStationHoles returned error: %v", err)
+	}
+
+	// No fill rows: both blocks are dry, so neither hole is covered.
+	var n int64
+	db.Model(&models.ScheduleEntry{}).
+		Where("station_id = ? AND source_type = 'media' AND metadata->>'fill' = 'true'", stationID).
+		Count(&n)
+	if n != 0 {
+		t.Errorf("fill row count = %d, want 0 (all blocks are dry)", n)
+	}
+}
+
 // TestFillPass_RoundRobinLRU proves fillStationHoles rotates across the recurring pool by
 // least-recently-used order instead of always using pool[0]. Two future holes must be
 // filled by DIFFERENT pool blocks; a never-filled block outranks a previously-filled one;

--- a/internal/scheduler/service.go
+++ b/internal/scheduler/service.go
@@ -625,6 +625,12 @@ func (s *Service) fillStationHoles(ctx context.Context, stationID string, start,
 		return ordered
 	}
 
+	// countFillRows counts ALL fill rows in [from, to) for the station. The
+	// before/after delta correctly attributes production to the block just
+	// materialized only under the single-writer assumption: one station is
+	// materialized at a time and at most one block fills each gap (the inner loop
+	// breaks on the first success). Concurrent fill for the same station and window
+	// would misattribute the count delta.
 	countFillRows := func(from, to time.Time) (int64, error) {
 		var n int64
 		err := s.db.WithContext(ctx).Model(&models.ScheduleEntry{}).
@@ -634,11 +640,22 @@ func (s *Service) fillStationHoles(ctx context.Context, stationID string, start,
 		return n, err
 	}
 
+	// dry tracks blocks that produced no fill rows (or errored) on their first
+	// attempt this pass. Because materializeSmartBlock output depends only on the
+	// block's rules and the analyzed track pool (not on the specific gap's time
+	// window), a block that is dry for one gap is dry for every gap in the same
+	// pass. Skipping it after its first empty result keeps total attempts O(N)
+	// instead of O(N*M) for N pool blocks and M gaps.
+	dry := map[string]bool{}
+
 	for _, g := range gaps {
 		// Try pool blocks in LRU order; a block that produces nothing (dry) is skipped
 		// and the next-LRU block is tried. If every block is dry the hole is left
 		// uncovered and the pass moves on.
 		for _, lb := range orderPool() {
+			if dry[lb.blockID] {
+				continue
+			}
 			mountID := lb.entry.MountID
 			if mountID == "" {
 				mountID = s.getDefaultMountID(ctx, stationID)
@@ -667,6 +684,7 @@ func (s *Service) fillStationHoles(ctx context.Context, stationID string, start,
 					Time("gap_end", g.End).
 					Msg("failed to fill horizon hole from recurring block")
 				// treat as dry and try the next block rather than abort the pass
+				dry[lb.blockID] = true
 				continue
 			}
 			after, err := countFillRows(g.Start, g.End)
@@ -674,6 +692,7 @@ func (s *Service) fillStationHoles(ctx context.Context, stationID string, start,
 				return err
 			}
 			if after <= before {
+				dry[lb.blockID] = true
 				continue // dry block, produced nothing; try the next-LRU block
 			}
 			// Filled: this block is now most-recently-used for the next hole.


### PR DESCRIPTION
## Summary

Three deferred findings from the #74 (PR #274) final review. No behavior change to the fill output or the gauges; these bound wasted work and tighten two edge cases.

- **Dry-block retry is now O(N), not O(N·M).** `fillStationHoles` keeps a per-pass `dry` set: a pool block that produces nothing (or errors) on its first attempt is skipped for the rest of the pass instead of being re-tried for every remaining gap. Safe because a block's dryness comes from its rules and the analyzed-track pool, not the gap's time window, so a block dry for one gap is dry for every gap in the same pass. A station with a fully-dry pool no longer pays N·M `materializeSmartBlock` calls plus 2·N·M count queries per scheduler tick.
- **`countFillRows` attribution is documented.** The before/after delta attributes a fill row to the block just materialized only under the single-writer assumption (one station materialized at a time, one block per gap). Comment only.
- **`stopMountPipeline` zeroes its gauge only after `StopPipeline` succeeds.** On a failed stop the pipeline may still be running, so the gauge stays at its prior value and the error propagates; the `checkDeadAir` tick reconciler corrects it from actual liveness.

## Test plan

- New: `TestFillPass_DryBlockNotRetriedPerGap` (dry multi-gap pool fills nothing, no error) and `TestStopMountPipeline_GaugeUnchangedOnError` (failed stop leaves the gauge at 1).
- `go test ./internal/... -count=1` green; `internal/playout` race-clean under `-race`; gofmt clean; `go build ./...` clean.

Follow-up to #274. GitLab MR to follow once that host is reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)