### PR TITLE
test(mediaengine): cover previously-untested service-layer files (#255)

### DIFF
--- a/internal/mediaengine/client/client_test.go
+++ b/internal/mediaengine/client/client_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package client
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig("localhost:9091")
+	if cfg.Address != "localhost:9091" {
+		t.Errorf("Address = %q", cfg.Address)
+	}
+	if cfg.MaxRetries != 3 || cfg.RetryInterval != 2*time.Second || cfg.ConnectionTimeout != 10*time.Second {
+		t.Errorf("unexpected defaults: %+v", cfg)
+	}
+}
+
+func TestNewClient_NotConnected(t *testing.T) {
+	c := New(DefaultConfig("localhost:9091"), zerolog.Nop())
+	if c.addr != "localhost:9091" {
+		t.Errorf("addr = %q", c.addr)
+	}
+	if c.IsConnected() {
+		t.Error("a fresh client must not report connected")
+	}
+	// Close with no underlying connection is a no-op that returns nil.
+	if err := c.Close(); err != nil {
+		t.Errorf("Close() on unconnected client = %v, want nil", err)
+	}
+}
+
+func TestRetry_SucceedsFirstTry(t *testing.T) {
+	c := New(DefaultConfig("x"), zerolog.Nop())
+	calls := 0
+	err := c.Retry(context.Background(), func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("Retry() = %v, want nil", err)
+	}
+	if calls != 1 {
+		t.Errorf("operation called %d times, want 1", calls)
+	}
+}
+
+func TestRetry_DoesNotRetryTerminalCodes(t *testing.T) {
+	c := New(DefaultConfig("x"), zerolog.Nop())
+	calls := 0
+	want := status.Error(codes.InvalidArgument, "bad")
+	err := c.Retry(context.Background(), func() error {
+		calls++
+		return want
+	})
+	if !errors.Is(err, want) {
+		t.Fatalf("Retry() = %v, want the InvalidArgument error", err)
+	}
+	if calls != 1 {
+		t.Errorf("operation called %d times, want 1 (no retry on InvalidArgument)", calls)
+	}
+}
+
+func TestRetry_HonorsContextCancellation(t *testing.T) {
+	c := New(DefaultConfig("x"), zerolog.Nop())
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel up front so the backoff wait returns immediately
+
+	calls := 0
+	err := c.Retry(ctx, func() error {
+		calls++
+		return status.Error(codes.Unavailable, "retryable")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Retry() = %v, want context.Canceled", err)
+	}
+	// One attempt runs, then the cancelled context short-circuits the backoff.
+	if calls != 1 {
+		t.Errorf("operation called %d times, want 1", calls)
+	}
+}

--- a/internal/mediaengine/recording_test.go
+++ b/internal/mediaengine/recording_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package mediaengine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func newRecordingManager() *RecordingManager {
+	return NewRecordingManager(&Config{}, zerolog.Nop())
+}
+
+func TestBuildRecordingPipeline_Codecs(t *testing.T) {
+	rm := newRecordingManager()
+
+	cases := []struct {
+		name string
+		rec  *ActiveRecording
+		want []string
+	}{
+		{
+			name: "opus with explicit bitrate",
+			rec:  &ActiveRecording{StationID: "s1", OutputPath: "/rec/a.opus", Codec: "opus", Bitrate: 96},
+			want: []string{"interaudiosrc channel=s1-rec", "opusenc bitrate=96000", "oggmux", "filesink location=/rec/a.opus"},
+		},
+		{
+			name: "opus defaults bitrate to 192",
+			rec:  &ActiveRecording{StationID: "s2", OutputPath: "/rec/b.opus", Codec: "opus"},
+			want: []string{"opusenc bitrate=192000"},
+		},
+		{
+			name: "flac",
+			rec:  &ActiveRecording{StationID: "s3", OutputPath: "/rec/c.flac", Codec: "flac"},
+			want: []string{"flacenc", "filesink location=/rec/c.flac"},
+		},
+		{
+			name: "unknown codec defaults to flac and 44100/2",
+			rec:  &ActiveRecording{StationID: "s4", OutputPath: "/rec/d.out", Codec: "weird"},
+			want: []string{"flacenc", "rate=44100,channels=2"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := rm.buildRecordingPipeline(tc.rec)
+			if err != nil {
+				t.Fatalf("buildRecordingPipeline() error: %v", err)
+			}
+			for _, w := range tc.want {
+				if !strings.Contains(got, w) {
+					t.Errorf("pipeline missing %q; got %q", w, got)
+				}
+			}
+		})
+	}
+}
+
+func TestRecordingManager_StateHelpers(t *testing.T) {
+	rm := newRecordingManager()
+	if rm.IsRecording("s1") {
+		t.Error("IsRecording should be false with no recordings")
+	}
+	if id := rm.GetRecordingID("s1"); id != "" {
+		t.Errorf("GetRecordingID = %q, want empty", id)
+	}
+
+	// Seed the index directly to exercise the lookups without spawning gst.
+	rm.byStation["s1"] = "rec-1"
+	if !rm.IsRecording("s1") {
+		t.Error("IsRecording should be true after seeding")
+	}
+	if id := rm.GetRecordingID("s1"); id != "rec-1" {
+		t.Errorf("GetRecordingID = %q, want rec-1", id)
+	}
+}
+
+func TestStartRecording_RejectsDuplicateStation(t *testing.T) {
+	rm := newRecordingManager()
+	rm.byStation["s1"] = "existing"
+	// The duplicate guard returns before any directory or process work.
+	err := rm.StartRecording(context.Background(), &ActiveRecording{StationID: "s1", RecordingID: "new", OutputPath: "/rec/x.flac", Codec: "flac"})
+	if err == nil {
+		t.Fatal("expected error when station already has an active recording")
+	}
+}
+
+func TestStopRecording_NotFound(t *testing.T) {
+	rm := newRecordingManager()
+	if _, _, err := rm.StopRecording("nope"); err == nil {
+		t.Error("expected error stopping unknown recording")
+	}
+}
+
+func TestStopAll_Empty(t *testing.T) {
+	rm := newRecordingManager()
+	rm.StopAll() // must not panic with no recordings
+}

--- a/internal/mediaengine/service_test.go
+++ b/internal/mediaengine/service_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package mediaengine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	pb "github.com/friendsincode/grimnir_radio/proto/mediaengine/v1"
+)
+
+func TestOutputConfigFromGraph_Defaults(t *testing.T) {
+	// A nil graph, and a graph with no output node, both yield the MP3/test default.
+	for _, g := range []*pb.DSPGraph{nil, {Nodes: []*pb.DSPNode{{Type: pb.NodeType_NODE_TYPE_INPUT}}}} {
+		cfg := outputConfigFromGraph(g)
+		if cfg.OutputType != OutputTypeTest || cfg.Format != AudioFormatMP3 {
+			t.Errorf("defaults: got type=%v format=%v", cfg.OutputType, cfg.Format)
+		}
+		if cfg.Bitrate != 128 || cfg.SampleRate != 44100 || cfg.Channels != 2 {
+			t.Errorf("defaults: got bitrate=%d rate=%d ch=%d", cfg.Bitrate, cfg.SampleRate, cfg.Channels)
+		}
+	}
+}
+
+func TestOutputConfigFromGraph_MapsParams(t *testing.T) {
+	graph := &pb.DSPGraph{Nodes: []*pb.DSPNode{
+		{Type: pb.NodeType_NODE_TYPE_OUTPUT, Params: map[string]string{
+			"output_type": "http",
+			"format":      "opus",
+			"bitrate":     "256",
+			"sample_rate": "48000",
+			"channels":    "1",
+			"output_url":  "http://sink/x",
+		}},
+	}}
+	cfg := outputConfigFromGraph(graph)
+	if cfg.OutputType != OutputTypeHTTP {
+		t.Errorf("OutputType = %v, want http", cfg.OutputType)
+	}
+	if cfg.Format != AudioFormatOpus {
+		t.Errorf("Format = %v, want opus", cfg.Format)
+	}
+	if cfg.Bitrate != 256 || cfg.SampleRate != 48000 || cfg.Channels != 1 {
+		t.Errorf("got bitrate=%d rate=%d ch=%d", cfg.Bitrate, cfg.SampleRate, cfg.Channels)
+	}
+	if cfg.OutputURL != "http://sink/x" {
+		t.Errorf("OutputURL = %q", cfg.OutputURL)
+	}
+}
+
+func TestOutputConfigFromGraph_RTPAndFilePathFallback(t *testing.T) {
+	graph := &pb.DSPGraph{Nodes: []*pb.DSPNode{
+		{Type: pb.NodeType_NODE_TYPE_OUTPUT, Params: map[string]string{
+			"output_type": "rtp",
+			"rtp_host":    "127.0.0.1",
+			"rtp_port":    "5004",
+			"pt":          "111",
+			"file_path":   "/tmp/out.mp3", // used when output_url is absent
+		}},
+	}}
+	cfg := outputConfigFromGraph(graph)
+	if cfg.OutputType != OutputTypeRTP {
+		t.Errorf("OutputType = %v, want rtp", cfg.OutputType)
+	}
+	if cfg.RTPHost != "127.0.0.1" || cfg.RTPPort != 5004 || cfg.RTPPayloadType != 111 {
+		t.Errorf("rtp fields: host=%q port=%d pt=%d", cfg.RTPHost, cfg.RTPPort, cfg.RTPPayloadType)
+	}
+	if cfg.OutputURL != "/tmp/out.mp3" {
+		t.Errorf("OutputURL fallback = %q, want /tmp/out.mp3", cfg.OutputURL)
+	}
+}
+
+func TestGetSourceID(t *testing.T) {
+	if got := getSourceID(nil); got != "" {
+		t.Errorf("getSourceID(nil) = %q, want empty", got)
+	}
+	if got := getSourceID(&pb.SourceConfig{SourceId: "src-9"}); got != "src-9" {
+		t.Errorf("getSourceID = %q, want src-9", got)
+	}
+}
+
+func TestService_NewAndShutdown(t *testing.T) {
+	svc := New(&Config{}, zerolog.Nop())
+	if svc == nil {
+		t.Fatal("New() returned nil")
+	}
+	if err := svc.Shutdown(context.Background()); err != nil {
+		t.Fatalf("Shutdown() error: %v", err)
+	}
+}
+
+func TestService_GetOrCreateStation(t *testing.T) {
+	svc := New(&Config{}, zerolog.Nop())
+	defer func() { _ = svc.Shutdown(context.Background()) }()
+
+	if svc.getStation("none") != nil {
+		t.Error("getStation should return nil for unknown station")
+	}
+	e1 := svc.getOrCreateStation("st1", "mt1")
+	e2 := svc.getOrCreateStation("st1", "mt1")
+	if e1 != e2 {
+		t.Error("getOrCreateStation should return the same engine on repeat")
+	}
+	if e1.MountID != "mt1" {
+		t.Errorf("engine MountID = %q, want mt1", e1.MountID)
+	}
+}
+
+func TestService_GetStatus(t *testing.T) {
+	svc := New(&Config{}, zerolog.Nop())
+	defer func() { _ = svc.Shutdown(context.Background()) }()
+
+	resp, err := svc.GetStatus(context.Background(), &pb.StatusRequest{StationId: "unknown"})
+	if err != nil {
+		t.Fatalf("GetStatus() error: %v", err)
+	}
+	if resp.Running {
+		t.Error("expected Running=false for unknown station")
+	}
+
+	svc.getOrCreateStation("st1", "mt1")
+	resp, err = svc.GetStatus(context.Background(), &pb.StatusRequest{StationId: "st1"})
+	if err != nil {
+		t.Fatalf("GetStatus() error: %v", err)
+	}
+	if !resp.Running {
+		t.Error("expected Running=true for known station")
+	}
+}

--- a/internal/mediaengine/supervisor_test.go
+++ b/internal/mediaengine/supervisor_test.go
@@ -1,0 +1,77 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package mediaengine
+
+import (
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func newSupervisor() *Supervisor {
+	// A nil pipeline manager is safe here: the tests never reach checkPipeline,
+	// which is the only method that dereferences it.
+	return NewSupervisor(&Config{}, zerolog.Nop(), nil)
+}
+
+func TestSupervisor_MonitorUnmonitor(t *testing.T) {
+	s := newSupervisor()
+	s.MonitorPipeline("st1")
+	if _, ok := s.GetHealth("st1"); !ok {
+		t.Fatal("expected st1 to be monitored")
+	}
+	// Monitoring the same station twice is idempotent.
+	s.MonitorPipeline("st1")
+	if len(s.GetAllHealth()) != 1 {
+		t.Errorf("GetAllHealth size = %d, want 1", len(s.GetAllHealth()))
+	}
+
+	s.UnmonitorPipeline("st1")
+	if _, ok := s.GetHealth("st1"); ok {
+		t.Error("expected st1 removed after unmonitor")
+	}
+}
+
+func TestSupervisor_UpdateHeartbeatResetsFails(t *testing.T) {
+	s := newSupervisor()
+	s.MonitorPipeline("st1")
+	s.monitoredPipelines["st1"].ConsecutiveFails = 5
+
+	s.UpdateHeartbeat("st1")
+	if got := s.monitoredPipelines["st1"].ConsecutiveFails; got != 0 {
+		t.Errorf("ConsecutiveFails = %d, want 0 after heartbeat", got)
+	}
+
+	// Heartbeat for an unmonitored station is a no-op, not a panic.
+	s.UpdateHeartbeat("ghost")
+}
+
+func TestSupervisor_GetHealthReturnsCopy(t *testing.T) {
+	s := newSupervisor()
+	if _, ok := s.GetHealth("missing"); ok {
+		t.Error("GetHealth should report not-found for unknown station")
+	}
+
+	s.MonitorPipeline("st1")
+	h, ok := s.GetHealth("st1")
+	if !ok {
+		t.Fatal("expected health for st1")
+	}
+	// Mutating the returned copy must not affect the internal record.
+	h.RestartCount = 99
+	if s.monitoredPipelines["st1"].RestartCount == 99 {
+		t.Error("GetHealth returned a live reference, expected a copy")
+	}
+}
+
+func TestSupervisor_StartStop(t *testing.T) {
+	s := newSupervisor()
+	s.Start()
+	// Stop cancels the context immediately, so the health loop exits via
+	// ctx.Done before the 5s ticker ever fires checkPipeline.
+	s.Stop()
+}

--- a/internal/mediaengine/webstream_test.go
+++ b/internal/mediaengine/webstream_test.go
@@ -1,0 +1,153 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package mediaengine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestFindURLIndex(t *testing.T) {
+	urls := []string{"a", "b", "c"}
+	if got := findURLIndex(urls, "b"); got != 1 {
+		t.Errorf("findURLIndex(b) = %d, want 1", got)
+	}
+	// A miss falls back to 0 (the primary) rather than -1.
+	if got := findURLIndex(urls, "zzz"); got != 0 {
+		t.Errorf("findURLIndex(miss) = %d, want 0", got)
+	}
+	if got := findURLIndex(nil, "a"); got != 0 {
+		t.Errorf("findURLIndex(nil) = %d, want 0", got)
+	}
+}
+
+func TestPlayWebstream_RequiresID(t *testing.T) {
+	wm := NewWebstreamManager(zerolog.Nop())
+	err := wm.PlayWebstream(context.Background(), &WebstreamPlayRequest{URLs: []string{"http://x"}})
+	if err == nil {
+		t.Fatal("expected error for empty webstream_id")
+	}
+}
+
+func TestPlayWebstream_RequiresURL(t *testing.T) {
+	wm := NewWebstreamManager(zerolog.Nop())
+	err := wm.PlayWebstream(context.Background(), &WebstreamPlayRequest{WebstreamID: "ws1"})
+	if err == nil {
+		t.Fatal("expected error when no URL is provided")
+	}
+}
+
+func TestPlayWebstream_BuildsPipelineAndStores(t *testing.T) {
+	wm := NewWebstreamManager(zerolog.Nop())
+	req := &WebstreamPlayRequest{
+		WebstreamID:     "ws1",
+		StationID:       "st1",
+		MountID:         "mt1",
+		URLs:            []string{"http://a/1", "http://a/2"},
+		ExtractMetadata: true,
+		BufferSizeMS:    500,
+		DSPGraphHandle:  "g1",
+		FadeInMS:        1000,
+	}
+	if err := wm.PlayWebstream(context.Background(), req); err != nil {
+		t.Fatalf("PlayWebstream() error: %v", err)
+	}
+
+	players := wm.GetActivePlayers()
+	p, ok := players["ws1"]
+	if !ok {
+		t.Fatal("player ws1 not registered")
+	}
+	if !p.Connected {
+		t.Error("expected player marked connected")
+	}
+	if p.CurrentURL != "http://a/1" {
+		t.Errorf("CurrentURL = %q, want first URL", p.CurrentURL)
+	}
+	for _, want := range []string{"souphttpsrc", "iradio-mode=true", "queue max-size-time=500000000", "decodebin", "audioconvert ! audioresample", "volumeenvelope"} {
+		if !strings.Contains(p.Pipeline, want) {
+			t.Errorf("pipeline missing %q; got %q", want, p.Pipeline)
+		}
+	}
+}
+
+func TestPlayWebstream_AlreadyPlaying(t *testing.T) {
+	wm := NewWebstreamManager(zerolog.Nop())
+	req := &WebstreamPlayRequest{WebstreamID: "ws1", URLs: []string{"http://a"}}
+	if err := wm.PlayWebstream(context.Background(), req); err != nil {
+		t.Fatalf("first PlayWebstream() error: %v", err)
+	}
+	if err := wm.PlayWebstream(context.Background(), req); err == nil {
+		t.Fatal("expected error for a webstream that is already playing")
+	}
+}
+
+func TestStopWebstream(t *testing.T) {
+	wm := NewWebstreamManager(zerolog.Nop())
+	if err := wm.StopWebstream(context.Background(), "missing"); err == nil {
+		t.Error("expected error stopping unknown webstream")
+	}
+
+	req := &WebstreamPlayRequest{WebstreamID: "ws1", URLs: []string{"http://a"}}
+	_ = wm.PlayWebstream(context.Background(), req)
+	if err := wm.StopWebstream(context.Background(), "ws1"); err != nil {
+		t.Fatalf("StopWebstream() error: %v", err)
+	}
+	if _, ok := wm.GetActivePlayers()["ws1"]; ok {
+		t.Error("player should be removed after stop")
+	}
+}
+
+func TestFailoverWebstream(t *testing.T) {
+	wm := NewWebstreamManager(zerolog.Nop())
+	if err := wm.FailoverWebstream(context.Background(), "missing", "http://b"); err == nil {
+		t.Error("expected error for unknown webstream failover")
+	}
+
+	req := &WebstreamPlayRequest{WebstreamID: "ws1", URLs: []string{"http://a", "http://b"}}
+	_ = wm.PlayWebstream(context.Background(), req)
+	if err := wm.FailoverWebstream(context.Background(), "ws1", "http://b"); err != nil {
+		t.Fatalf("FailoverWebstream() error: %v", err)
+	}
+	p := wm.GetActivePlayers()["ws1"]
+	if p.CurrentURL != "http://b" || p.CurrentIndex != 1 {
+		t.Errorf("after failover CurrentURL=%q CurrentIndex=%d, want http://b/1", p.CurrentURL, p.CurrentIndex)
+	}
+}
+
+func TestGetWebstreamMetadata(t *testing.T) {
+	wm := NewWebstreamManager(zerolog.Nop())
+	if _, err := wm.GetWebstreamMetadata("missing"); err == nil {
+		t.Error("expected error for unknown webstream metadata")
+	}
+
+	req := &WebstreamPlayRequest{WebstreamID: "ws1", URLs: []string{"http://a"}}
+	_ = wm.PlayWebstream(context.Background(), req)
+	wm.GetActivePlayers()["ws1"].Metadata["StreamTitle"] = "Song"
+	md, err := wm.GetWebstreamMetadata("ws1")
+	if err != nil {
+		t.Fatalf("GetWebstreamMetadata() error: %v", err)
+	}
+	if md["StreamTitle"] != "Song" {
+		t.Errorf("metadata StreamTitle = %q, want Song", md["StreamTitle"])
+	}
+}
+
+func TestWebstreamShutdown(t *testing.T) {
+	wm := NewWebstreamManager(zerolog.Nop())
+	_ = wm.PlayWebstream(context.Background(), &WebstreamPlayRequest{WebstreamID: "ws1", URLs: []string{"http://a"}})
+	_ = wm.PlayWebstream(context.Background(), &WebstreamPlayRequest{WebstreamID: "ws2", URLs: []string{"http://b"}})
+	if err := wm.Shutdown(); err != nil {
+		t.Fatalf("Shutdown() error: %v", err)
+	}
+	if len(wm.GetActivePlayers()) != 0 {
+		t.Error("expected no active players after shutdown")
+	}
+}


### PR DESCRIPTION
## Why

`service.go`, `client/client.go`, `supervisor.go`, `webstream.go` & `recording.go` in `internal/mediaengine` were all at 0% statement coverage. That is the gRPC surface the v2.0 MediaEngine split depends on, so the least-tested code was also the code that carries audio between containers. This chips at #255.

## What changed

Test-only. ~40 cases across 5 new `_test.go` files, hitting the branches that don't spawn GStreamer or open a gRPC connection:

- Pure helpers: `findURLIndex`, `buildRecordingPipeline` (opus/flac/default codecs & defaults), `outputConfigFromGraph` (param mapping, RTP, file_path fallback), `getSourceID`.
- In-memory managers: webstream play/stop/failover/metadata/shutdown, recording state + duplicate-station guard, supervisor monitor/heartbeat/health + start-stop.
- Service constructor + `GetStatus` (known & unknown station).
- Client `DefaultConfig`, constructor, `IsConnected`/`Close` while unconnected, and `Retry` (first-try success, terminal-code short-circuit, context cancellation during backoff).

## Coverage

| File | Before | After |
|---|---|---|
| webstream.go | 0% | 93.2% |
| recording.go | 0% | 56.2% |
| supervisor.go | 0% | 41.0% |
| service.go | 0% | 26.7% |
| client/client.go | 0% | 10.4% |

mediaengine tree: 24.7% -> 33.5%. No production code touched.