### PR TITLE
test(mediaengine): raise supervisor, service & client coverage (#255)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,17 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - name: Install media tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            ffmpeg \
+            gstreamer1.0-tools \
+            gstreamer1.0-plugins-base \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-libav
+
       - name: Tidy (must be clean)
         run: |
           go mod tidy

--- a/internal/mediaengine/client/client_connected_test.go
+++ b/internal/mediaengine/client/client_connected_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package client
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"google.golang.org/grpc"
+
+	pb "github.com/friendsincode/grimnir_radio/proto/mediaengine/v1"
+)
+
+// fakeEngine is a minimal in-process MediaEngine server. It returns canned
+// success responses so the client's connected code paths (Connect plus each RPC
+// wrapper's request build and response handling) run without GStreamer.
+type fakeEngine struct {
+	pb.UnimplementedMediaEngineServer
+}
+
+func (fakeEngine) LoadGraph(context.Context, *pb.LoadGraphRequest) (*pb.LoadGraphResponse, error) {
+	return &pb.LoadGraphResponse{Success: true, GraphHandle: "h1"}, nil
+}
+func (fakeEngine) Play(context.Context, *pb.PlayRequest) (*pb.PlayResponse, error) {
+	return &pb.PlayResponse{Success: true, PlaybackId: "p1"}, nil
+}
+func (fakeEngine) Stop(context.Context, *pb.StopRequest) (*pb.StopResponse, error) {
+	return &pb.StopResponse{Success: true}, nil
+}
+func (fakeEngine) Fade(context.Context, *pb.FadeRequest) (*pb.FadeResponse, error) {
+	return &pb.FadeResponse{Success: true, FadeId: "f1", EstimatedDurationMs: 100}, nil
+}
+func (fakeEngine) InsertEmergency(context.Context, *pb.InsertEmergencyRequest) (*pb.InsertEmergencyResponse, error) {
+	return &pb.InsertEmergencyResponse{Success: true, EmergencyId: "e1"}, nil
+}
+func (fakeEngine) RouteLive(context.Context, *pb.RouteLiveRequest) (*pb.RouteLiveResponse, error) {
+	return &pb.RouteLiveResponse{Success: true, SessionId: "s1"}, nil
+}
+func (fakeEngine) GetStatus(context.Context, *pb.StatusRequest) (*pb.StatusResponse, error) {
+	return &pb.StatusResponse{Running: true}, nil
+}
+func (fakeEngine) AnalyzeMedia(context.Context, *pb.AnalyzeMediaRequest) (*pb.AnalyzeMediaResponse, error) {
+	return &pb.AnalyzeMediaResponse{Success: true}, nil
+}
+func (fakeEngine) ExtractArtwork(context.Context, *pb.ExtractArtworkRequest) (*pb.ExtractArtworkResponse, error) {
+	return &pb.ExtractArtworkResponse{}, nil
+}
+func (fakeEngine) GenerateWaveform(context.Context, *pb.GenerateWaveformRequest) (*pb.GenerateWaveformResponse, error) {
+	return &pb.GenerateWaveformResponse{}, nil
+}
+func (fakeEngine) StartRecording(context.Context, *pb.StartRecordingRequest) (*pb.StartRecordingResponse, error) {
+	return &pb.StartRecordingResponse{Success: true}, nil
+}
+func (fakeEngine) StopRecording(context.Context, *pb.StopRecordingRequest) (*pb.StopRecordingResponse, error) {
+	return &pb.StopRecordingResponse{Success: true, RecordingId: "r1", FileSizeBytes: 10, DurationMs: 20}, nil
+}
+
+// startFakeEngine starts the fake server on a random port and returns a
+// connected client plus a cleanup func.
+func startFakeEngine(t *testing.T) (*Client, func()) {
+	t.Helper()
+
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	pb.RegisterMediaEngineServer(srv, fakeEngine{})
+	go func() { _ = srv.Serve(lis) }()
+
+	c := New(DefaultConfig(lis.Addr().String()), zerolog.Nop())
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := c.Connect(ctx); err != nil {
+		srv.Stop()
+		t.Fatalf("Connect: %v", err)
+	}
+
+	cleanup := func() {
+		_ = c.Close()
+		srv.Stop()
+	}
+	return c, cleanup
+}
+
+func TestConnectAndIsConnected(t *testing.T) {
+	c, cleanup := startFakeEngine(t)
+	defer cleanup()
+
+	if !c.IsConnected() {
+		t.Error("client should report connected after Connect")
+	}
+	// A second Connect on an already-connected client is a no-op that succeeds.
+	if err := c.Connect(context.Background()); err != nil {
+		t.Errorf("second Connect() = %v, want nil", err)
+	}
+}
+
+func TestConnectedRPCWrappers(t *testing.T) {
+	c, cleanup := startFakeEngine(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	if h, err := c.LoadGraph(ctx, "s", "m", &pb.DSPGraph{}); err != nil || h != "h1" {
+		t.Errorf("LoadGraph = %q, %v; want h1, nil", h, err)
+	}
+	if id, err := c.Play(ctx, &pb.PlayRequest{}); err != nil || id != "p1" {
+		t.Errorf("Play = %q, %v; want p1, nil", id, err)
+	}
+	if err := c.Stop(ctx, "s", "m", true); err != nil {
+		t.Errorf("Stop = %v, want nil", err)
+	}
+	if fid, dur, err := c.Fade(ctx, &pb.FadeRequest{}); err != nil || fid != "f1" || dur != 100 {
+		t.Errorf("Fade = %q, %d, %v; want f1, 100, nil", fid, dur, err)
+	}
+	if eid, err := c.InsertEmergency(ctx, "s", "m", &pb.SourceConfig{}); err != nil || eid != "e1" {
+		t.Errorf("InsertEmergency = %q, %v; want e1, nil", eid, err)
+	}
+	if sid, err := c.RouteLive(ctx, &RouteLiveRequest{}); err != nil || sid != "s1" {
+		t.Errorf("RouteLive = %q, %v; want s1, nil", sid, err)
+	}
+	if st, err := c.GetStatus(ctx, "s", "m"); err != nil || !st.Running {
+		t.Errorf("GetStatus running=%v, %v; want true, nil", st.GetRunning(), err)
+	}
+	if _, err := c.AnalyzeMedia(ctx, "/f.mp3"); err != nil {
+		t.Errorf("AnalyzeMedia = %v, want nil", err)
+	}
+	if _, err := c.ExtractArtwork(ctx, "/f.mp3", 0, 0, "jpeg", 0); err != nil {
+		t.Errorf("ExtractArtwork = %v, want nil", err)
+	}
+	if _, err := c.GenerateWaveform(ctx, "/f.mp3", 10, pb.WaveformType(0)); err != nil {
+		t.Errorf("GenerateWaveform = %v, want nil", err)
+	}
+	if err := c.StartRecording(ctx, &StartRecordingRequest{}); err != nil {
+		t.Errorf("StartRecording = %v, want nil", err)
+	}
+	if res, err := c.StopRecording(ctx, "s", "r1"); err != nil || res.RecordingID != "r1" {
+		t.Errorf("StopRecording = %+v, %v; want r1, nil", res, err)
+	}
+}

--- a/internal/mediaengine/client/client_connected_test.go
+++ b/internal/mediaengine/client/client_connected_test.go
@@ -61,6 +61,15 @@ func (fakeEngine) StartRecording(context.Context, *pb.StartRecordingRequest) (*p
 func (fakeEngine) StopRecording(context.Context, *pb.StopRecordingRequest) (*pb.StopRecordingResponse, error) {
 	return &pb.StopRecordingResponse{Success: true, RecordingId: "r1", FileSizeBytes: 10, DurationMs: 20}, nil
 }
+func (fakeEngine) StreamTelemetry(_ *pb.TelemetryRequest, stream pb.MediaEngine_StreamTelemetryServer) error {
+	// Send two updates then return; the client loop should see both and then EOF.
+	for i := 0; i < 2; i++ {
+		if err := stream.Send(&pb.TelemetryData{}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
 
 // startFakeEngine starts the fake server on a random port and returns a
 // connected client plus a cleanup func.
@@ -143,5 +152,34 @@ func TestConnectedRPCWrappers(t *testing.T) {
 	}
 	if res, err := c.StopRecording(ctx, "s", "r1"); err != nil || res.RecordingID != "r1" {
 		t.Errorf("StopRecording = %+v, %v; want r1, nil", res, err)
+	}
+}
+
+func TestConnectedStreamTelemetry(t *testing.T) {
+	c, cleanup := startFakeEngine(t)
+	defer cleanup()
+
+	got := 0
+	err := c.StreamTelemetry(context.Background(), "s", "m", 100, func(*pb.TelemetryData) error {
+		got++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("StreamTelemetry() = %v, want nil", err)
+	}
+	if got != 2 {
+		t.Errorf("callback fired %d times, want 2", got)
+	}
+}
+
+func TestConnect_Failure(t *testing.T) {
+	c := New(DefaultConfig("127.0.0.1:1"), zerolog.Nop())
+	// A cancelled context makes the readiness wait fail fast instead of blocking
+	// on the (unreachable) address for the full 5s.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := c.Connect(ctx); err == nil {
+		t.Error("Connect to an unreachable address with a cancelled context should error")
+		_ = c.Close()
 	}
 }

--- a/internal/mediaengine/client/client_test.go
+++ b/internal/mediaengine/client/client_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	pb "github.com/friendsincode/grimnir_radio/proto/mediaengine/v1"
 )
 
 func TestDefaultConfig(t *testing.T) {
@@ -38,6 +40,38 @@ func TestNewClient_NotConnected(t *testing.T) {
 	// Close with no underlying connection is a no-op that returns nil.
 	if err := c.Close(); err != nil {
 		t.Errorf("Close() on unconnected client = %v, want nil", err)
+	}
+}
+
+// Every RPC wrapper guards on a nil client, so on an unconnected client they
+// all return a "not connected" error instead of panicking on the nil gRPC stub.
+func TestRPCMethods_NotConnected(t *testing.T) {
+	c := New(DefaultConfig("localhost:9091"), zerolog.Nop())
+	ctx := context.Background()
+
+	checks := map[string]func() error{
+		"LoadGraph":       func() error { _, err := c.LoadGraph(ctx, "s", "m", &pb.DSPGraph{}); return err },
+		"Play":            func() error { _, err := c.Play(ctx, &pb.PlayRequest{}); return err },
+		"Stop":            func() error { return c.Stop(ctx, "s", "m", true) },
+		"Fade":            func() error { _, _, err := c.Fade(ctx, &pb.FadeRequest{}); return err },
+		"InsertEmergency": func() error { _, err := c.InsertEmergency(ctx, "s", "m", &pb.SourceConfig{}); return err },
+		"RouteLive":       func() error { _, err := c.RouteLive(ctx, &RouteLiveRequest{}); return err },
+		"GetStatus":       func() error { _, err := c.GetStatus(ctx, "s", "m"); return err },
+		"StreamTelemetry": func() error { return c.StreamTelemetry(ctx, "s", "m", 100, nil) },
+		"AnalyzeMedia":    func() error { _, err := c.AnalyzeMedia(ctx, "/f.mp3"); return err },
+		"ExtractArtwork":  func() error { _, err := c.ExtractArtwork(ctx, "/f.mp3", 0, 0, "jpeg", 0); return err },
+		"GenerateWaveform": func() error {
+			_, err := c.GenerateWaveform(ctx, "/f.mp3", 10, pb.WaveformType(0))
+			return err
+		},
+		"StartRecording": func() error { return c.StartRecording(ctx, &StartRecordingRequest{}) },
+		"StopRecording":  func() error { _, err := c.StopRecording(ctx, "s", "r"); return err },
+	}
+
+	for name, call := range checks {
+		if err := call(); err == nil {
+			t.Errorf("%s on an unconnected client: expected an error, got nil", name)
+		}
 	}
 }
 

--- a/internal/mediaengine/service_gst_test.go
+++ b/internal/mediaengine/service_gst_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package mediaengine
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	pb "github.com/friendsincode/grimnir_radio/proto/mediaengine/v1"
+)
+
+// makeAudioFixture writes a one-second stereo WAV via ffmpeg and returns its
+// path. The test is skipped if ffmpeg is unavailable.
+func makeAudioFixture(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("ffmpeg"); err != nil {
+		t.Skip("ffmpeg not available")
+	}
+	path := filepath.Join(t.TempDir(), "fixture.wav")
+	cmd := exec.Command("ffmpeg", "-y", "-f", "lavfi", "-i", "sine=frequency=440:duration=1", "-ac", "2", path)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Skipf("ffmpeg fixture generation failed: %v\n%s", err, out)
+	}
+	return path
+}
+
+func loadedGraph() *pb.DSPGraph {
+	return &pb.DSPGraph{
+		Nodes: []*pb.DSPNode{
+			{Id: "input", Type: pb.NodeType_NODE_TYPE_INPUT},
+			{Id: "output", Type: pb.NodeType_NODE_TYPE_OUTPUT},
+		},
+		Connections: []*pb.DSPConnection{{FromNode: "input", ToNode: "output"}},
+	}
+}
+
+func TestService_AnalyzerMethods(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns gst-discoverer/ffprobe")
+	}
+	file := makeAudioFixture(t)
+	svc := New(&Config{}, zerolog.Nop())
+	defer func() { _ = svc.Shutdown(context.Background()) }()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	if _, err := svc.AnalyzeMedia(ctx, &pb.AnalyzeMediaRequest{FilePath: file}); err != nil {
+		t.Errorf("AnalyzeMedia() error: %v", err)
+	}
+	// Artwork extraction runs its code path even though this fixture has no art.
+	if _, err := svc.ExtractArtwork(ctx, &pb.ExtractArtworkRequest{FilePath: file, Format: "jpeg"}); err != nil {
+		t.Errorf("ExtractArtwork() error: %v", err)
+	}
+	if _, err := svc.GenerateWaveform(ctx, &pb.GenerateWaveformRequest{FilePath: file, SamplesPerSecond: 10}); err != nil {
+		t.Errorf("GenerateWaveform() error: %v", err)
+	}
+}
+
+func TestService_PlaybackLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns gst-launch")
+	}
+	if _, err := exec.LookPath("gst-launch-1.0"); err != nil {
+		t.Skip("gst-launch not available")
+	}
+	file := makeAudioFixture(t)
+	svc := New(&Config{}, zerolog.Nop())
+	defer func() { _ = svc.Shutdown(context.Background()) }()
+	ctx := context.Background()
+
+	if _, err := svc.LoadGraph(ctx, &pb.LoadGraphRequest{StationId: "st1", MountId: "mt1", Graph: loadedGraph()}); err != nil {
+		t.Fatalf("LoadGraph() error: %v", err)
+	}
+
+	src := &pb.SourceConfig{SourceId: "s1", Type: pb.SourceType_SOURCE_TYPE_MEDIA, Path: file}
+	if resp, err := svc.Play(ctx, &pb.PlayRequest{StationId: "st1", MountId: "mt1", Source: src}); err != nil || !resp.Success {
+		t.Fatalf("Play() err=%v resp=%+v", err, resp)
+	}
+
+	next := &pb.SourceConfig{SourceId: "s2", Type: pb.SourceType_SOURCE_TYPE_MEDIA, Path: file}
+	fadeReq := &pb.FadeRequest{StationId: "st1", MountId: "mt1", NextSource: next, FadeConfig: &pb.FadeConfig{FadeInMs: 100, FadeOutMs: 100}}
+	if resp, err := svc.Fade(ctx, fadeReq); err != nil || !resp.Success {
+		t.Errorf("Fade() err=%v resp=%+v", err, resp)
+	}
+
+	emg := &pb.SourceConfig{SourceId: "e1", Type: pb.SourceType_SOURCE_TYPE_MEDIA, Path: file}
+	if resp, err := svc.InsertEmergency(ctx, &pb.InsertEmergencyRequest{StationId: "st1", MountId: "mt1", Source: emg}); err != nil || !resp.Success {
+		t.Errorf("InsertEmergency() err=%v resp=%+v", err, resp)
+	}
+
+	if resp, err := svc.Stop(ctx, &pb.StopRequest{StationId: "st1", MountId: "mt1"}); err != nil || !resp.Success {
+		t.Errorf("Stop() err=%v resp=%+v", err, resp)
+	}
+}
+
+func TestService_RecordingLifecycle(t *testing.T) {
+	if testing.Short() {
+		t.Skip("spawns gst-launch")
+	}
+	if _, err := exec.LookPath("gst-launch-1.0"); err != nil {
+		t.Skip("gst-launch not available")
+	}
+	svc := New(&Config{}, zerolog.Nop())
+	defer func() { _ = svc.Shutdown(context.Background()) }()
+	ctx := context.Background()
+
+	out := filepath.Join(t.TempDir(), "rec.flac")
+	start, err := svc.StartRecording(ctx, &pb.StartRecordingRequest{
+		StationId: "st1", MountId: "mt1", RecordingId: "rec1", OutputPath: out, Codec: "flac",
+	})
+	if err != nil || !start.Success {
+		t.Fatalf("StartRecording() err=%v resp=%+v", err, start)
+	}
+
+	stop, err := svc.StopRecording(ctx, &pb.StopRecordingRequest{StationId: "st1", RecordingId: "rec1"})
+	if err != nil || !stop.Success {
+		t.Errorf("StopRecording() err=%v resp=%+v", err, stop)
+	}
+}

--- a/internal/mediaengine/service_test.go
+++ b/internal/mediaengine/service_test.go
@@ -112,6 +112,54 @@ func TestService_GetOrCreateStation(t *testing.T) {
 	}
 }
 
+func TestService_LoadGraph_Success(t *testing.T) {
+	svc := New(&Config{}, zerolog.Nop())
+	defer func() { _ = svc.Shutdown(context.Background()) }()
+
+	// A minimal valid graph (input -> loudness -> output). CreatePipeline builds
+	// the pipeline struct without spawning GStreamer, so the whole path runs.
+	graph := &pb.DSPGraph{
+		Nodes: []*pb.DSPNode{
+			{Id: "input", Type: pb.NodeType_NODE_TYPE_INPUT},
+			{Id: "loudness", Type: pb.NodeType_NODE_TYPE_LOUDNESS_NORMALIZE},
+			{Id: "output", Type: pb.NodeType_NODE_TYPE_OUTPUT},
+		},
+		Connections: []*pb.DSPConnection{
+			{FromNode: "input", ToNode: "loudness"},
+			{FromNode: "loudness", ToNode: "output"},
+		},
+	}
+
+	resp, err := svc.LoadGraph(context.Background(), &pb.LoadGraphRequest{StationId: "st1", MountId: "mt1", Graph: graph})
+	if err != nil {
+		t.Fatalf("LoadGraph() error: %v", err)
+	}
+	if !resp.Success {
+		t.Fatalf("LoadGraph() success=false, error=%q", resp.Error)
+	}
+	if resp.GraphHandle == "" {
+		t.Error("expected a non-empty graph handle")
+	}
+}
+
+func TestService_LoadGraph_BuildFailure(t *testing.T) {
+	svc := New(&Config{}, zerolog.Nop())
+	defer func() { _ = svc.Shutdown(context.Background()) }()
+
+	// An empty node list is rejected by the DSP builder, so LoadGraph reports a
+	// failure response rather than an error.
+	resp, err := svc.LoadGraph(context.Background(), &pb.LoadGraphRequest{StationId: "st1", MountId: "mt1", Graph: &pb.DSPGraph{Nodes: []*pb.DSPNode{}}})
+	if err != nil {
+		t.Fatalf("LoadGraph() returned a transport error, want a failure response: %v", err)
+	}
+	if resp.Success {
+		t.Error("expected Success=false for an invalid graph")
+	}
+	if resp.Error == "" {
+		t.Error("expected an error message on the failure response")
+	}
+}
+
 func TestService_GetStatus(t *testing.T) {
 	svc := New(&Config{}, zerolog.Nop())
 	defer func() { _ = svc.Shutdown(context.Background()) }()

--- a/internal/mediaengine/service_test.go
+++ b/internal/mediaengine/service_test.go
@@ -225,6 +225,21 @@ func TestService_Recording_ValidationBranches(t *testing.T) {
 	}
 }
 
+func TestService_RouteLive_Error(t *testing.T) {
+	svc := New(&Config{}, zerolog.Nop())
+	defer func() { _ = svc.Shutdown(context.Background()) }()
+
+	// An empty session_id makes the live input manager reject the request, so
+	// RouteLive returns a failure response and a transport error.
+	resp, err := svc.RouteLive(context.Background(), &pb.RouteLiveRequest{StationId: "st1", MountId: "mt1"})
+	if err == nil {
+		t.Error("expected an error for a missing session_id")
+	}
+	if resp.Success {
+		t.Error("expected Success=false")
+	}
+}
+
 func TestService_GetStatus(t *testing.T) {
 	svc := New(&Config{}, zerolog.Nop())
 	defer func() { _ = svc.Shutdown(context.Background()) }()

--- a/internal/mediaengine/service_test.go
+++ b/internal/mediaengine/service_test.go
@@ -240,6 +240,23 @@ func TestService_RouteLive_Error(t *testing.T) {
 	}
 }
 
+func TestService_RouteLive_Success(t *testing.T) {
+	svc := New(&Config{}, zerolog.Nop())
+	defer func() { _ = svc.Shutdown(context.Background()) }()
+
+	// Seed an already-connected live input so the manager returns success
+	// without opening a real input, exercising RouteLive's success path.
+	svc.liveInputMgr.inputs["sess-1"] = &LiveInput{SessionID: "sess-1", Connected: true}
+
+	resp, err := svc.RouteLive(context.Background(), &pb.RouteLiveRequest{StationId: "st1", MountId: "mt1", SessionId: "sess-1"})
+	if err != nil {
+		t.Fatalf("RouteLive() error: %v", err)
+	}
+	if !resp.Success {
+		t.Error("expected Success=true for an already-connected session")
+	}
+}
+
 func TestService_GetStatus(t *testing.T) {
 	svc := New(&Config{}, zerolog.Nop())
 	defer func() { _ = svc.Shutdown(context.Background()) }()

--- a/internal/mediaengine/service_test.go
+++ b/internal/mediaengine/service_test.go
@@ -160,6 +160,71 @@ func TestService_LoadGraph_BuildFailure(t *testing.T) {
 	}
 }
 
+func TestService_PlayFadeEmergency_NoPipeline(t *testing.T) {
+	svc := New(&Config{}, zerolog.Nop())
+	defer func() { _ = svc.Shutdown(context.Background()) }()
+
+	// With no pipeline loaded, each of these fails fast at GetPipeline and
+	// returns a failure response rather than reaching GStreamer.
+	src := &pb.SourceConfig{SourceId: "x"}
+	if resp, _ := svc.Play(context.Background(), &pb.PlayRequest{StationId: "none", Source: src}); resp.Success {
+		t.Error("Play with no pipeline should report failure")
+	}
+	if resp, _ := svc.Fade(context.Background(), &pb.FadeRequest{StationId: "none", NextSource: src}); resp.Success {
+		t.Error("Fade with no pipeline should report failure")
+	}
+	if resp, _ := svc.InsertEmergency(context.Background(), &pb.InsertEmergencyRequest{StationId: "none", Source: src}); resp.Success {
+		t.Error("InsertEmergency with no pipeline should report failure")
+	}
+}
+
+func TestService_Stop(t *testing.T) {
+	svc := New(&Config{}, zerolog.Nop())
+	defer func() { _ = svc.Shutdown(context.Background()) }()
+
+	// Unknown station: no pipeline, failure response.
+	if resp, _ := svc.Stop(context.Background(), &pb.StopRequest{StationId: "none"}); resp.Success {
+		t.Error("Stop with no pipeline should report failure")
+	}
+
+	// Load a graph so a (never-started) pipeline exists, then Stop succeeds:
+	// Pipeline.Stop() on a process that was never started is a no-op.
+	graph := &pb.DSPGraph{
+		Nodes: []*pb.DSPNode{
+			{Id: "input", Type: pb.NodeType_NODE_TYPE_INPUT},
+			{Id: "output", Type: pb.NodeType_NODE_TYPE_OUTPUT},
+		},
+		Connections: []*pb.DSPConnection{{FromNode: "input", ToNode: "output"}},
+	}
+	if _, err := svc.LoadGraph(context.Background(), &pb.LoadGraphRequest{StationId: "st1", MountId: "mt1", Graph: graph}); err != nil {
+		t.Fatalf("LoadGraph() error: %v", err)
+	}
+	resp, err := svc.Stop(context.Background(), &pb.StopRequest{StationId: "st1", MountId: "mt1"})
+	if err != nil {
+		t.Fatalf("Stop() error: %v", err)
+	}
+	if !resp.Success {
+		t.Errorf("Stop() on a loaded station failed: %s", resp.Error)
+	}
+}
+
+func TestService_Recording_ValidationBranches(t *testing.T) {
+	svc := New(&Config{}, zerolog.Nop())
+	defer func() { _ = svc.Shutdown(context.Background()) }()
+
+	// StartRecording rejects missing required fields before any gst work.
+	if resp, _ := svc.StartRecording(context.Background(), &pb.StartRecordingRequest{StationId: "s1"}); resp.Success {
+		t.Error("StartRecording without output_path should fail")
+	}
+	// StopRecording rejects an empty id and reports unknown ids as failures.
+	if resp, _ := svc.StopRecording(context.Background(), &pb.StopRecordingRequest{}); resp.Success {
+		t.Error("StopRecording with empty id should fail")
+	}
+	if resp, _ := svc.StopRecording(context.Background(), &pb.StopRecordingRequest{RecordingId: "ghost"}); resp.Success {
+		t.Error("StopRecording for an unknown id should fail")
+	}
+}
+
 func TestService_GetStatus(t *testing.T) {
 	svc := New(&Config{}, zerolog.Nop())
 	defer func() { _ = svc.Shutdown(context.Background()) }()

--- a/internal/mediaengine/supervisor_test.go
+++ b/internal/mediaengine/supervisor_test.go
@@ -7,7 +7,9 @@ SPDX-License-Identifier: AGPL-3.0-or-later
 package mediaengine
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 )
@@ -74,4 +76,95 @@ func TestSupervisor_StartStop(t *testing.T) {
 	// Stop cancels the context immediately, so the health loop exits via
 	// ctx.Done before the 5s ticker ever fires checkPipeline.
 	s.Stop()
+}
+
+// The next tests use a real (empty) PipelineManager. CreatePipeline builds a
+// struct without spawning GStreamer, and Stop/Destroy on a never-started
+// pipeline is a no-op, so the check/restart paths run without any process.
+
+func TestSupervisor_CheckPipeline_UnmonitorsWhenMissing(t *testing.T) {
+	pm := NewPipelineManager(&Config{}, zerolog.Nop())
+	s := NewSupervisor(&Config{}, zerolog.Nop(), pm)
+	s.MonitorPipeline("st1") // monitored, but pm has no such pipeline
+
+	s.checkPipeline("st1")
+
+	if _, ok := s.GetHealth("st1"); ok {
+		t.Error("checkPipeline should unmonitor a station with no pipeline in the manager")
+	}
+}
+
+func TestSupervisor_CheckPipeline_HealthyKeepsMonitored(t *testing.T) {
+	pm := NewPipelineManager(&Config{}, zerolog.Nop())
+	if _, err := pm.CreatePipeline(context.Background(), "st1", "mt1", nil, nil); err != nil {
+		t.Fatalf("CreatePipeline() error: %v", err)
+	}
+	s := NewSupervisor(&Config{}, zerolog.Nop(), pm)
+	s.MonitorPipeline("st1") // MonitorPipeline sets a fresh heartbeat
+
+	s.checkPipeline("st1")
+
+	h, ok := s.GetHealth("st1")
+	if !ok {
+		t.Fatal("healthy pipeline should stay monitored")
+	}
+	if h.ConsecutiveFails != 0 {
+		t.Errorf("ConsecutiveFails = %d, want 0 for a fresh heartbeat", h.ConsecutiveFails)
+	}
+}
+
+func TestSupervisor_CheckPipeline_RestartsOnHeartbeatTimeout(t *testing.T) {
+	pm := NewPipelineManager(&Config{}, zerolog.Nop())
+	if _, err := pm.CreatePipeline(context.Background(), "st1", "mt1", nil, nil); err != nil {
+		t.Fatalf("CreatePipeline() error: %v", err)
+	}
+	s := NewSupervisor(&Config{}, zerolog.Nop(), pm)
+	s.MonitorPipeline("st1")
+
+	// Force a stale heartbeat and prime the fail counter so this check crosses
+	// the restart threshold.
+	h := s.monitoredPipelines["st1"]
+	h.LastHeartbeat = time.Now().Add(-time.Hour)
+	h.ConsecutiveFails = maxConsecutiveFails - 1
+
+	s.checkPipeline("st1")
+
+	// restartPipeline destroys then recreates the pipeline from its saved graph.
+	if _, err := pm.GetPipeline("st1"); err != nil {
+		t.Errorf("pipeline should be recreated after restart: %v", err)
+	}
+	if got := s.monitoredPipelines["st1"].RestartCount; got != 1 {
+		t.Errorf("RestartCount = %d, want 1 after a restart", got)
+	}
+}
+
+func TestSupervisor_RestartRateLimited(t *testing.T) {
+	// The rate-limit branch returns before touching the pipeline manager, so a
+	// nil manager is safe here.
+	s := newSupervisor()
+	s.MonitorPipeline("st1")
+	h := s.monitoredPipelines["st1"]
+	h.RestartCount = maxRestartsInWindow
+	h.LastRestart = time.Now()
+
+	s.restartPipeline("st1", "test")
+
+	if got := s.monitoredPipelines["st1"].RestartCount; got != maxRestartsInWindow {
+		t.Errorf("RestartCount = %d, want %d unchanged (rate limited)", got, maxRestartsInWindow)
+	}
+}
+
+func TestSupervisor_PerformHealthCheck(t *testing.T) {
+	pm := NewPipelineManager(&Config{}, zerolog.Nop())
+	if _, err := pm.CreatePipeline(context.Background(), "st1", "mt1", nil, nil); err != nil {
+		t.Fatalf("CreatePipeline() error: %v", err)
+	}
+	s := NewSupervisor(&Config{}, zerolog.Nop(), pm)
+	s.MonitorPipeline("st1")
+
+	s.performHealthCheck() // iterates monitored stations and checks each
+
+	if _, ok := s.GetHealth("st1"); !ok {
+		t.Error("healthy station should remain monitored after a health check pass")
+	}
 }


### PR DESCRIPTION
## Why

Follow-up to #277. supervisor, service & client were the lowest files in the mediaengine tree (41% / 27% / 10%). This drives into the health-check, RPC-guard, and connected-client paths. Continues #255.

## What changed

Test-only. Two techniques keep GStreamer & real networking out of it:
- A real `PipelineManager` (`CreatePipeline` builds a struct, `Stop`/`Destroy` on a never-started pipeline is a no-op) exercises the supervisor and the service's pipeline-backed branches.
- An in-process fake `MediaEngine` gRPC server (embeds `UnimplementedMediaEngineServer`) on a random port lets the client connect and run every wrapper's success path.

**supervisor**: `checkPipeline` (missing/healthy/heartbeat-timeout-restart), `performHealthCheck`, restart rate-limit guard.

**service**: `LoadGraph` success + build-failure; `Stop` (unknown -> failure, loaded -> success); `Play`/`Fade`/`InsertEmergency` no-pipeline fast-fail; recording validation branches.

**client**: nil-guard error for all wrappers, plus Connect + LoadGraph/Play/Stop/Fade/InsertEmergency/RouteLive/GetStatus/AnalyzeMedia/ExtractArtwork/GenerateWaveform/StartRecording/StopRecording success paths against the fake.

## Coverage

| File | Before (#277) | After |
|---|---|---|
| supervisor.go | 41.0% | 87.6% |
| client/client.go | 10.4% | 77.9% |
| service.go | 26.7% | 51.2% |

mediaengine tree: 33.5% -> 48.3%. No production code touched.