### PR TITLE
fix(mediaengine): guard nil current track in crossfade monitor

### DIFF
--- a/internal/mediaengine/pipeline.go
+++ b/internal/mediaengine/pipeline.go
@@ -367,10 +367,17 @@ func (p *Pipeline) monitorCrossfadeCompletion() {
 				p.CurrentTrack = p.crossfadeMgr.GetCurrentTrack()
 				p.NextTrack = nil
 				p.State = pb.PlaybackState_PLAYBACK_STATE_PLAYING
+				// GetCurrentTrack returns nil when the crossfade was torn down
+				// before it produced a track; guard the log so this background
+				// goroutine can't panic and take the process down with it.
+				sourceID := ""
+				if p.CurrentTrack != nil {
+					sourceID = p.CurrentTrack.SourceID
+				}
 				p.mu.Unlock()
 
 				p.logger.Info().
-					Str("current_track", p.CurrentTrack.SourceID).
+					Str("current_track", sourceID).
 					Msg("crossfade completed, transition successful")
 				return
 			}


### PR DESCRIPTION
## Problem

`Pipeline.monitorCrossfadeCompletion` runs in a background goroutine. On completion it does:

```go
p.CurrentTrack = p.crossfadeMgr.GetCurrentTrack()
...
p.logger.Info().Str("current_track", p.CurrentTrack.SourceID)
```

`GetCurrentTrack()` returns nil when the crossfade is torn down before it produced a track, so `p.CurrentTrack.SourceID` nil-dereferences. Because it is a bare goroutine with no recover, the panic takes the whole media-engine process down.

This surfaced on `main` right after #278: the new `Fade` coverage test drove a short crossfade to completion, `GetCurrentTrack()` came back nil, and the coverage run crashed (the plain `go test` pass got lucky on timing).

## Fix

Guard the log with a nil check; the monitor records an empty source id instead of panicking. One-goroutine crash no longer escalates to a process exit.

Verified with `go test -covermode=atomic -count=5` on the playback/recording/analyzer tests (61s, clean).