### PR TITLE
fix(playout): stop the double-clutch — one pipeline launch per mount per tick

### DIFF
--- a/internal/playout/director.go
+++ b/internal/playout/director.go
@@ -307,10 +307,23 @@ func (d *Director) tick(ctx context.Context) error {
 		}
 	}
 
+	// At most one entry may launch per mount per tick. The overlap-winner check
+	// below only skips an instance when a STRICTLY newer one covers now, so two
+	// overlapping entries it can't separate (equal created_at, or non-instance
+	// rows) would otherwise both reach handleEntry in a single pass and build the
+	// pipeline twice back-to-back — the audible "double-clutch" at boundaries
+	// seen on air (e.g. mount rlmradioxyz). This guard collapses that to one
+	// launch; a legitimately newer entry still preempts on the next tick.
+	launchedThisTick := make(map[string]bool)
+
 	for _, rawEntry := range entries {
 		loc := d.getStationTimezone(ctx, rawEntry.StationID)
 		entry, playKey, playUntil, ok := resolveEntryForNow(rawEntry, now, loc)
 		if !ok {
+			continue
+		}
+
+		if launchedThisTick[entry.MountID] {
 			continue
 		}
 
@@ -382,6 +395,12 @@ func (d *Director) tick(ctx context.Context) error {
 			continue
 		}
 
+		// Only a still-current entry claims the mount's single launch. An entry
+		// resolved inside resolveEntryForNow's 2s end-grace has already ended and
+		// must not block its valid successor from preempting in the same tick.
+		if now.Before(entry.EndsAt) {
+			launchedThisTick[entry.MountID] = true
+		}
 		d.markPlayed(playKey, playUntil)
 	}
 

--- a/internal/playout/director_double_clutch_test.go
+++ b/internal/playout/director_double_clutch_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package playout
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+	"github.com/google/uuid"
+)
+
+// TestTick_NoDoubleClutchOnEqualCreatedAtOverlap reproduces the on-air
+// "double-clutch": two overlapping media instances on one mount whose created_at
+// the overlap-winner check can't separate (they're equal) both reached
+// handleEntry in a single tick, building the broadcast pipeline twice back-to-back
+// (observed on mount rlmradioxyz / RLMradio.xyz-M). The tick must launch the mount
+// exactly once per pass.
+func TestTick_NoDoubleClutchOnEqualCreatedAtOverlap(t *testing.T) {
+	now := time.Now().UTC()
+	d, mgr := newMockDirector(t, &models.ScheduleEntry{})
+	ctx := context.Background()
+
+	stationID := uuid.NewString()
+	mountID := uuid.NewString()
+
+	mount := models.Mount{
+		ID:         mountID,
+		StationID:  stationID,
+		Name:       "double-clutch-" + mountID[:8],
+		Format:     "mp3",
+		Bitrate:    128,
+		SampleRate: 44100,
+		Channels:   2,
+	}
+	if err := d.db.Create(&mount).Error; err != nil {
+		t.Fatalf("seed mount: %v", err)
+	}
+
+	mediaA := uuid.NewString()
+	mediaB := uuid.NewString()
+	for _, m := range []models.MediaItem{
+		{ID: mediaA, StationID: stationID, Title: "Track A", Path: "/tmp/a.mp3", Duration: 4 * time.Minute, AnalysisState: models.AnalysisComplete},
+		{ID: mediaB, StationID: stationID, Title: "Track B", Path: "/tmp/b.mp3", Duration: 4 * time.Minute, AnalysisState: models.AnalysisComplete},
+	} {
+		if err := d.db.Create(&m).Error; err != nil {
+			t.Fatalf("seed media: %v", err)
+		}
+	}
+
+	// Two instances on the SAME mount, both covering now, with the SAME created_at
+	// so the overlap-winner check (skips only a STRICTLY newer instance) can't
+	// drop either. Before the fix, both launch -> two pipeline builds.
+	created := now.Add(-1 * time.Hour)
+	for _, e := range []models.ScheduleEntry{
+		{ID: uuid.NewString(), StationID: stationID, MountID: mountID, SourceType: "media", SourceID: mediaA, IsInstance: true, StartsAt: now.Add(-2 * time.Minute), EndsAt: now.Add(5 * time.Minute), CreatedAt: created},
+		{ID: uuid.NewString(), StationID: stationID, MountID: mountID, SourceType: "media", SourceID: mediaB, IsInstance: true, StartsAt: now.Add(-2 * time.Minute), EndsAt: now.Add(5 * time.Minute), CreatedAt: created},
+	} {
+		if err := d.db.Create(&e).Error; err != nil {
+			t.Fatalf("seed entry: %v", err)
+		}
+	}
+
+	d.markScheduleDirty()
+	if err := d.tick(ctx); err != nil {
+		t.Fatalf("tick returned error: %v", err)
+	}
+
+	if got := mgr.ensureCalls[mountID]; got != 1 {
+		t.Errorf("pipeline builds for mount = %d, want exactly 1 (double-clutch)", got)
+	}
+	d.mu.Lock()
+	_, active := d.active[mountID]
+	d.mu.Unlock()
+	if !active {
+		t.Error("expected the mount to be active after tick")
+	}
+}

--- a/internal/playout/mock_test.go
+++ b/internal/playout/mock_test.go
@@ -48,14 +48,23 @@ type mockManager struct {
 	ensureErr   error
 	stopErr     error
 	stdinWriter io.WriteCloser
-	stopCalls   int // number of StopPipeline invocations (preemption assertions)
+	stopCalls   int            // number of StopPipeline invocations (preemption assertions)
+	ensureCalls map[string]int // per-mount EnsurePipeline* invocations (double-launch assertions)
 }
 
 func newMockManager() *mockManager {
-	return &mockManager{pipelines: make(map[string]*mockPipeline)}
+	return &mockManager{pipelines: make(map[string]*mockPipeline), ensureCalls: make(map[string]int)}
+}
+
+func (m *mockManager) countEnsure(mountID string) {
+	if m.ensureCalls == nil {
+		m.ensureCalls = make(map[string]int)
+	}
+	m.ensureCalls[mountID]++
 }
 
 func (m *mockManager) EnsurePipeline(ctx context.Context, mountID, launch string) error {
+	m.countEnsure(mountID)
 	if _, ok := m.pipelines[mountID]; !ok {
 		m.pipelines[mountID] = newMockPipeline()
 	}
@@ -63,6 +72,7 @@ func (m *mockManager) EnsurePipeline(ctx context.Context, mountID, launch string
 }
 
 func (m *mockManager) EnsurePipelineWithOutput(ctx context.Context, mountID, launch string, outputHandler func(io.Reader)) error {
+	m.countEnsure(mountID)
 	if _, ok := m.pipelines[mountID]; !ok {
 		m.pipelines[mountID] = newMockPipeline()
 	}
@@ -70,6 +80,7 @@ func (m *mockManager) EnsurePipelineWithOutput(ctx context.Context, mountID, lau
 }
 
 func (m *mockManager) EnsurePipelineWithDualOutput(ctx context.Context, mountID, launch string, seekFile *os.File, hqHandler, lqHandler func(io.Reader)) error {
+	m.countEnsure(mountID)
 	if _, ok := m.pipelines[mountID]; !ok {
 		m.pipelines[mountID] = newMockPipeline()
 	}
@@ -77,6 +88,7 @@ func (m *mockManager) EnsurePipelineWithDualOutput(ctx context.Context, mountID,
 }
 
 func (m *mockManager) EnsurePipelineWithDualOutputAndInput(ctx context.Context, mountID, launch string, hqHandler, lqHandler func(io.Reader)) (io.WriteCloser, error) {
+	m.countEnsure(mountID)
 	if _, ok := m.pipelines[mountID]; !ok {
 		m.pipelines[mountID] = newMockPipeline()
 	}


### PR DESCRIPTION
## Symptom

On air, a track starts, hits EOF within seconds, and the *same* track rebuilds; an audible stutter at boundaries (the "double-clutch"). Caught in prod on mount `rlmradioxyz` (RLMradio.xyz-M) at 1:52 PM Central: the valid ~4.5 min track `SMM Remix` was built, `feed started`, EOF'd instantly, and rebuilt. It's fleet-wide, ~15 times in 5 hours across many mounts. On a radio station even a couple seconds is a failure.

## Cause

The `tick()` loop can hand off more than one entry to the same mount in a single pass. The overlap-winner check only skips a **strictly newer** instance (`winner.After(rawEntry.CreatedAt)`), so two overlapping entries it can't separate (equal `created_at`, or non-instance rows) both reach `handleEntry` and build the broadcast pipeline twice back-to-back. The prod logs showed two `schedule entry ended` lines and two identical pipeline builds in the same tick.

## Fix

Guard the loop so at most one **still-current** entry launches per mount per tick. An entry resolved inside `resolveEntryForNow`'s 2-second end-grace has already ended and does not claim the launch, so a valid successor can still preempt in the same tick (the hard-boundary handoff is preserved).

## Test

`TestTick_NoDoubleClutchOnEqualCreatedAtOverlap` drives `tick()` with two equal-`created_at` overlapping instances on one mount and asserts exactly one pipeline build. Verified it builds twice with the guard removed. The existing `TestTick_HardBoundaryPreemption...` and `TestTick_NewestInstanceWins` still pass, so preemption and newest-wins are intact.

No prod changes; the earlier overlap that triggered it has already cleared itself. Test-plus-one-guard, no behavior change outside the double-launch case.