### PR TITLE
feat(playlist): randomized (shuffle) playback — playlist-level + per-slot override

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -205,6 +205,9 @@ type scheduleUpdateRequest struct {
 	EndsAt   string         `json:"ends_at"`
 	MountID  string         `json:"mount_id"`
 	Metadata map[string]any `json:"metadata"`
+	// Shuffle overrides a playlist entry's order for this slot (pointer so an
+	// omitted field leaves the entry untouched; send false to force in-order).
+	Shuffle *bool `json:"shuffle,omitempty"`
 }
 
 type liveAuthorizeRequest struct {
@@ -1254,6 +1257,11 @@ func (a *API) handleScheduleUpdate(w http.ResponseWriter, r *http.Request) {
 	if req.Metadata != nil {
 		entry.Metadata = req.Metadata
 		updates["metadata"] = req.Metadata
+	}
+
+	if req.Shuffle != nil {
+		entry.Shuffle = req.Shuffle
+		updates["shuffle"] = req.Shuffle
 	}
 
 	if entry.Metadata == nil {

--- a/internal/models/models.go
+++ b/internal/models/models.go
@@ -672,6 +672,11 @@ type ScheduleEntry struct {
 	SourceID   string         `gorm:"type:uuid"`
 	Metadata   map[string]any `gorm:"type:jsonb;serializer:json"`
 
+	// Shuffle overrides a playlist source's own Shuffle setting for this slot:
+	// nil inherits the playlist's setting, non-nil forces randomized (true) or
+	// in-order (false) playback. Only meaningful when SourceType == "playlist".
+	Shuffle *bool `gorm:"type:boolean"`
+
 	// Recurrence fields
 	RecurrenceType       RecurrenceType `gorm:"type:varchar(16)"`
 	RecurrenceDays       []int          `gorm:"type:jsonb;serializer:json"` // 0=Sun, 1=Mon, ..., 6=Sat
@@ -806,6 +811,10 @@ type Playlist struct {
 	CoverImage     []byte         `gorm:"type:bytea"`
 	CoverImageMime string         `gorm:"type:varchar(32)"`
 	Items          []PlaylistItem `gorm:"foreignKey:PlaylistID"`
+
+	// Shuffle plays the playlist's items in a randomized order rather than by
+	// position. A schedule entry can override this per slot (ScheduleEntry.Shuffle).
+	Shuffle bool `gorm:"default:false"`
 
 	// Import provenance (nullable for manually created items)
 	ImportJobID    *string `gorm:"type:uuid;index"`   // Which import job created this

--- a/internal/playout/director.go
+++ b/internal/playout/director.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"hash/fnv"
 	"io"
+	"math/rand"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -2130,6 +2131,7 @@ func (d *Director) startPlaylistEntry(ctx context.Context, entry models.Schedule
 	for i, item := range playlist.Items {
 		items[i] = item.MediaID
 	}
+	items = maybeShufflePlaylistItems(entry, playlist, items)
 	items = d.applyTrackOverrides(ctx, entry, items)
 	if len(items) == 0 {
 		d.logger.Warn().Str("playlist", playlist.ID).Msg("playlist has no items after track overrides")
@@ -2528,6 +2530,45 @@ func deterministicSmartBlockSeed(entry models.ScheduleEntry, blockID string, gen
 	return int64(h.Sum64() & 0x7fffffffffffffff)
 }
 
+// playlistShuffleEnabled reports whether this playlist entry should play in a
+// randomized order: the schedule entry's per-slot override if set, otherwise the
+// playlist's own Shuffle flag.
+func playlistShuffleEnabled(playlist models.Playlist, entry models.ScheduleEntry) bool {
+	if entry.Shuffle != nil {
+		return *entry.Shuffle
+	}
+	return playlist.Shuffle
+}
+
+// deterministicPlaylistSeed derives a stable shuffle seed from the entry and
+// playlist so a shuffled order is reproducible across a process restart
+// (resume-safe, matching MountPlayoutState) and each recurring occurrence
+// (distinct StartsAt) reshuffles differently.
+func deterministicPlaylistSeed(entry models.ScheduleEntry, playlistID string) int64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(entry.ID))
+	_, _ = h.Write([]byte(playlistID))
+	_, _ = h.Write([]byte(entry.StartsAt.UTC().Format(time.RFC3339Nano)))
+	_, _ = h.Write([]byte(entry.EndsAt.UTC().Format(time.RFC3339Nano)))
+	_, _ = h.Write([]byte(entry.StationID))
+	_, _ = h.Write([]byte(entry.MountID))
+	return int64(h.Sum64() & 0x7fffffffffffffff)
+}
+
+// maybeShufflePlaylistItems returns items in a deterministic shuffled order when
+// the playlist (or its overriding schedule entry) calls for it, and unchanged
+// otherwise. It shuffles a copy so the caller's slice is left intact.
+func maybeShufflePlaylistItems(entry models.ScheduleEntry, playlist models.Playlist, items []string) []string {
+	if !playlistShuffleEnabled(playlist, entry) || len(items) < 2 {
+		return items
+	}
+	shuffled := make([]string, len(items))
+	copy(shuffled, items)
+	r := rand.New(rand.NewSource(deterministicPlaylistSeed(entry, playlist.ID)))
+	r.Shuffle(len(shuffled), func(i, j int) { shuffled[i], shuffled[j] = shuffled[j], shuffled[i] })
+	return shuffled
+}
+
 func (d *Director) applyTrackOverrides(ctx context.Context, entry models.ScheduleEntry, items []string) []string {
 	if len(items) == 0 || entry.Metadata == nil {
 		return items
@@ -2632,6 +2673,7 @@ func (d *Director) startPlaylistByID(ctx context.Context, entry models.ScheduleE
 	for i, item := range playlist.Items {
 		items[i] = item.MediaID
 	}
+	items = maybeShufflePlaylistItems(entry, playlist, items)
 	items = d.applyTrackOverrides(ctx, entry, items)
 	if len(items) == 0 {
 		d.logger.Warn().

--- a/internal/playout/director_playlist_shuffle_test.go
+++ b/internal/playout/director_playlist_shuffle_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package playout
+
+import (
+	"testing"
+	"time"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+func ptrBool(b bool) *bool { return &b }
+
+func strSlicesEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func strSameSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	counts := map[string]int{}
+	for _, v := range a {
+		counts[v]++
+	}
+	for _, v := range b {
+		counts[v]--
+	}
+	for _, c := range counts {
+		if c != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func TestPlaylistShuffleEnabled(t *testing.T) {
+	// nil override inherits the playlist's flag.
+	if !playlistShuffleEnabled(models.Playlist{Shuffle: true}, models.ScheduleEntry{}) {
+		t.Error("nil override should inherit playlist Shuffle=true")
+	}
+	if playlistShuffleEnabled(models.Playlist{Shuffle: false}, models.ScheduleEntry{}) {
+		t.Error("nil override should inherit playlist Shuffle=false")
+	}
+	// A per-slot override wins either way.
+	if playlistShuffleEnabled(models.Playlist{Shuffle: true}, models.ScheduleEntry{Shuffle: ptrBool(false)}) {
+		t.Error("override false should force shuffle off despite playlist Shuffle=true")
+	}
+	if !playlistShuffleEnabled(models.Playlist{Shuffle: false}, models.ScheduleEntry{Shuffle: ptrBool(true)}) {
+		t.Error("override true should force shuffle on despite playlist Shuffle=false")
+	}
+}
+
+func TestMaybeShufflePlaylistItems(t *testing.T) {
+	orig := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"}
+	items := append([]string(nil), orig...)
+	entry := models.ScheduleEntry{
+		ID: "e1", StationID: "s1", MountID: "m1",
+		StartsAt: time.Unix(1000, 0).UTC(), EndsAt: time.Unix(2000, 0).UTC(),
+	}
+
+	// Shuffle off -> unchanged.
+	if got := maybeShufflePlaylistItems(entry, models.Playlist{ID: "p1"}, items); !strSlicesEqual(got, orig) {
+		t.Errorf("shuffle off should return items in position order, got %v", got)
+	}
+
+	pl := models.Playlist{ID: "p1", Shuffle: true}
+	got := maybeShufflePlaylistItems(entry, pl, items)
+
+	if !strSameSet(got, orig) {
+		t.Errorf("shuffle must preserve the item set, got %v", got)
+	}
+	// 10! permutations make an accidental identity astronomically unlikely.
+	if strSlicesEqual(got, orig) {
+		t.Error("shuffle should reorder 10 items")
+	}
+	// The caller's slice must not be mutated.
+	if !strSlicesEqual(items, orig) {
+		t.Error("shuffle must not mutate the input slice")
+	}
+	// Deterministic: same entry+playlist -> same order (resume-safe).
+	if got2 := maybeShufflePlaylistItems(entry, pl, items); !strSlicesEqual(got, got2) {
+		t.Error("shuffle must be deterministic for the same entry+playlist")
+	}
+	// A different occurrence (different StartsAt) reshuffles differently.
+	entry2 := entry
+	entry2.StartsAt = time.Unix(50000, 0).UTC()
+	if got3 := maybeShufflePlaylistItems(entry2, pl, items); strSlicesEqual(got, got3) {
+		t.Error("a different occurrence should reshuffle to a different order")
+	}
+	// An entry override forces shuffle even when the playlist flag is off.
+	forced := maybeShufflePlaylistItems(models.ScheduleEntry{
+		ID: "e1", StationID: "s1", MountID: "m1",
+		StartsAt: entry.StartsAt, EndsAt: entry.EndsAt, Shuffle: ptrBool(true),
+	}, models.Playlist{ID: "p1", Shuffle: false}, items)
+	if strSlicesEqual(forced, orig) {
+		t.Error("entry override Shuffle=true should reorder even with playlist Shuffle=false")
+	}
+
+	// Fewer than 2 items is a no-op even with shuffle on.
+	one := []string{"only"}
+	if got := maybeShufflePlaylistItems(entry, pl, one); !strSlicesEqual(got, one) {
+		t.Error("single-item playlist should be unchanged")
+	}
+}

--- a/internal/web/pages_playlists.go
+++ b/internal/web/pages_playlists.go
@@ -156,6 +156,7 @@ func (h *Handler) PlaylistCreate(w http.ResponseWriter, r *http.Request) {
 		StationID:   station.ID,
 		Name:        r.FormValue("name"),
 		Description: r.FormValue("description"),
+		Shuffle:     playlistShuffleFromForm(r.FormValue("shuffle")),
 	}
 
 	if playlist.Name == "" {
@@ -314,6 +315,7 @@ func (h *Handler) PlaylistUpdate(w http.ResponseWriter, r *http.Request) {
 
 	playlist.Name = r.FormValue("name")
 	playlist.Description = r.FormValue("description")
+	playlist.Shuffle = playlistShuffleFromForm(r.FormValue("shuffle"))
 
 	if err := h.db.Save(&playlist).Error; err != nil {
 		http.Error(w, "Failed to update playlist", http.StatusInternalServerError)
@@ -326,6 +328,17 @@ func (h *Handler) PlaylistUpdate(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, "/dashboard/playlists/"+id, http.StatusSeeOther)
+}
+
+// playlistShuffleFromForm interprets a checkbox form value as a bool. An
+// unchecked checkbox submits nothing, so an empty/unknown value is false.
+func playlistShuffleFromForm(v string) bool {
+	switch v {
+	case "on", "true", "1", "yes":
+		return true
+	default:
+		return false
+	}
 }
 
 // PlaylistDelete handles playlist deletion

--- a/internal/web/templates/pages/dashboard/playlists/form.html
+++ b/internal/web/templates/pages/dashboard/playlists/form.html
@@ -56,6 +56,11 @@
                         <textarea class="form-control" name="description" rows="3"
                                   placeholder="Optional description for this playlist">{{$playlist.Description}}</textarea>
                     </div>
+                    <div class="mb-3 form-check">
+                        <input type="checkbox" class="form-check-input" id="playlistShuffle" name="shuffle" value="on" {{if $playlist.Shuffle}}checked{{end}}>
+                        <label class="form-check-label" for="playlistShuffle">Shuffle</label>
+                        <div class="form-text">Play this playlist's tracks in a randomized order instead of by position.</div>
+                    </div>
                 </div>
                 <div class="card-footer d-flex gap-2">
                     <button type="submit" class="btn btn-primary">


### PR DESCRIPTION
## What

Playlists can now play their tracks in a randomized order instead of strict position order, requested two ways:

1. **Playlist-level** (`Playlist.Shuffle`): the playlist's own default, toggled with a new checkbox in the playlist editor.
2. **Per schedule slot** (`ScheduleEntry.Shuffle *bool`): an override on a playlist schedule entry — `nil` inherits the playlist's setting, `true`/`false` forces it for that slot. Settable via the schedule update API (`"shuffle"` field).

Effective order = the entry override if set, otherwise the playlist flag.

## How

When shuffle is on, the media-id list is reordered with a seed derived from the entry + playlist (`deterministicPlaylistSeed`: entry id, playlist id, starts/ends, station, mount). That makes it:
- **resume-safe** — a process restart reproduces the same order (consistent with `MountPlayoutState`, which already persists the ordered items),
- **fresh per occurrence** — each recurring instance (distinct `StartsAt`) reshuffles differently.

Wired into both playlist playout paths (`startPlaylistEntry` for direct entries, `startPlaylistByID` for clock playlist slots), shuffled before track overrides. GORM auto-migrate adds the two columns.

## Tests

`director_playlist_shuffle_test.go` covers override precedence, set preservation, determinism for the same occurrence, different order across occurrences, no mutation of the caller's slice, and the <2-item no-op. Existing tick/playout tests still pass.

## Follow-up

The per-slot override is wired through the model, playout, and the schedule update API; the schedule calendar's inline edit form doesn't yet expose a toggle for it (the playlist-level toggle is fully in the UI). Easy to add next.