### PR TITLE
fix(settings): wire the Analysis / WebSocket / Metrics toggles (#60)

### DIFF
--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -803,11 +803,21 @@ func (a *API) handleMediaUpload(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	jobID, err := a.analyzer.Enqueue(r.Context(), mediaID)
-	if err != nil {
-		a.db.WithContext(r.Context()).Model(&models.MediaItem{}).Where("id = ?", mediaID).Update("analysis_state", models.AnalysisFailed)
-		writeError(w, http.StatusInternalServerError, "analysis_queue_error")
-		return
+	var jobID string
+	if a.analysisEnabled() {
+		id, err := a.analyzer.Enqueue(r.Context(), mediaID)
+		if err != nil {
+			a.db.WithContext(r.Context()).Model(&models.MediaItem{}).Where("id = ?", mediaID).Update("analysis_state", models.AnalysisFailed)
+			writeError(w, http.StatusInternalServerError, "analysis_queue_error")
+			return
+		}
+		jobID = id
+	} else {
+		// Media Analysis is disabled in system settings: the file's duration is
+		// already set from the upload probe, so mark it playable and skip the
+		// analysis queue rather than leaving it stuck pending.
+		item.AnalysisState = models.AnalysisComplete
+		a.db.WithContext(r.Context()).Model(&models.MediaItem{}).Where("id = ?", mediaID).Update("analysis_state", models.AnalysisComplete)
 	}
 
 	success = true
@@ -1613,8 +1623,25 @@ func (a *API) handleWebhookTrackStart(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusAccepted, map[string]string{"status": "received"})
 }
 
+// analysisEnabled reports whether the Media Analysis system setting is on. It
+// defaults to enabled when the settings row can't be read, so a transient DB
+// error never silently stops analysis.
+func (a *API) analysisEnabled() bool {
+	s, err := models.GetSystemSettings(a.db)
+	if err != nil {
+		return true
+	}
+	return s.AnalysisEnabled
+}
+
 func (a *API) handleEvents(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
+	// The WebSocket-updates setting gates the live event stream. When it's off,
+	// refuse the connection rather than pushing updates the operator disabled.
+	if s, err := models.GetSystemSettings(a.db); err == nil && !s.WebsocketEnabled {
+		http.Error(w, "live updates are disabled in system settings", http.StatusServiceUnavailable)
+		return
+	}
 	conn, err := ws.Accept(w, r, &ws.AcceptOptions{InsecureSkipVerify: true})
 	if err != nil {
 		a.logger.Error().Err(err).Msg("websocket accept failed")
@@ -1977,6 +2004,14 @@ func (a *API) handleReanalyzeMissingArtwork(w http.ResponseWriter, r *http.Reque
 		writeJSON(w, http.StatusServiceUnavailable, map[string]any{
 			"success": false,
 			"error":   "Analyzer service not available",
+		})
+		return
+	}
+
+	if !a.analysisEnabled() {
+		writeJSON(w, http.StatusConflict, map[string]any{
+			"success": false,
+			"error":   "Media Analysis is disabled in system settings",
 		})
 		return
 	}

--- a/internal/api/settings_toggles_test.go
+++ b/internal/api/settings_toggles_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package api
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+func TestAnalysisEnabledSetting(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "settings.db")), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.SystemSettings{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	a := &API{db: db, logger: zerolog.Nop()}
+
+	// Fresh settings default to Media Analysis on.
+	if !a.analysisEnabled() {
+		t.Error("expected analysis enabled by default")
+	}
+
+	// Turning the toggle off is respected.
+	s, err := models.GetSystemSettings(db)
+	if err != nil {
+		t.Fatalf("get settings: %v", err)
+	}
+	s.AnalysisEnabled = false
+	if err := db.Save(s).Error; err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if a.analysisEnabled() {
+		t.Error("expected analysis disabled after AnalysisEnabled=false")
+	}
+
+	// And back on.
+	s.AnalysisEnabled = true
+	if err := db.Save(s).Error; err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	if !a.analysisEnabled() {
+		t.Error("expected analysis enabled after AnalysisEnabled=true")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -39,6 +39,7 @@ import (
 	"github.com/friendsincode/grimnir_radio/internal/logbuffer"
 	"github.com/friendsincode/grimnir_radio/internal/media"
 	meclient "github.com/friendsincode/grimnir_radio/internal/mediaengine/client"
+	"github.com/friendsincode/grimnir_radio/internal/models"
 	"github.com/friendsincode/grimnir_radio/internal/notifications"
 	"github.com/friendsincode/grimnir_radio/internal/playout"
 	"github.com/friendsincode/grimnir_radio/internal/priority"
@@ -822,7 +823,14 @@ func (s *Server) configureRoutes() {
 		_, _ = w.Write([]byte(response))
 	})
 
-	s.router.Handle("/metrics", telemetry.Handler())
+	// The Prometheus Metrics setting gates the /metrics endpoint (read once at
+	// startup; toggling it takes effect on restart). Default-on: a settings read
+	// error still registers it.
+	if settings, err := models.GetSystemSettings(s.db); err != nil || settings.MetricsEnabled {
+		s.router.Handle("/metrics", telemetry.Handler())
+	} else {
+		s.logger.Info().Msg("Prometheus /metrics endpoint disabled by system settings")
+	}
 
 	// Audio broadcast streams (served directly by Go, no Icecast needed)
 	s.router.HandleFunc("/live/{mount}", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Problem (GitLab #60)

System Settings shows three toggles — **Media Analysis**, **WebSocket updates**, **Prometheus Metrics** — that save successfully and do nothing. The values were stored and displayed but never consumed: analysis, websockets, and metrics all ran unconditionally. Misleading configurability.

## Fix

Wire each toggle to its subsystem (chose to make them functional rather than remove operator-set config):

- **Media Analysis** (`api.go` upload + bulk re-analyze): when off, uploads skip the analysis queue. The file's duration is already set from the upload probe, so the item is marked playable (`AnalysisComplete`) instead of stuck `pending`; the bulk re-analyze endpoint returns 409.
- **WebSocket updates** (`handleEvents`): when off, the live event-stream refuses the connection (503) instead of pushing updates the operator disabled.
- **Prometheus Metrics** (`server.go`): the `/metrics` endpoint is only registered when on. Read once at startup, so toggling it takes effect on restart.

All three default on and **fail open** on a settings read error, so a transient DB hiccup never silently disables a subsystem. The UI toggles already existed; they now do something.

## Test

`TestAnalysisEnabledSetting` covers the analysis gate: default-on for fresh settings, off after `AnalysisEnabled=false`, back on after re-enabling. Build + vet clean.

## Note

The metrics toggle is startup-read (restart to apply); analysis and websocket are checked at runtime. Worth a one-line help-text note in the settings UI, left for a follow-up.