### PR TITLE
fix(dashboard): auto-select single station for the user; clamp picker bios (#70)

### DIFF
--- a/internal/web/pages_dashboard.go
+++ b/internal/web/pages_dashboard.go
@@ -30,8 +30,10 @@ func (h *Handler) DashboardHome(w http.ResponseWriter, r *http.Request) {
 
 	// If no station selected, redirect to selection
 	if station == nil {
-		var stations []models.Station
-		h.db.Where("active = ?", true).Find(&stations)
+		// Scope to the stations this user can actually reach. Querying every
+		// active station instead bounced single-station users through the picker
+		// on multi-station installs (the select page then auto-selected anyway).
+		stations := h.LoadStations(r)
 
 		if len(stations) == 1 {
 			// Auto-select single station

--- a/internal/web/templates/pages/dashboard/station-select.html
+++ b/internal/web/templates/pages/dashboard/station-select.html
@@ -20,11 +20,10 @@
                     <label class="list-group-item list-group-item-action d-flex align-items-center gap-3">
                         <input type="radio" name="station_id" value="{{.ID}}"
                                class="form-check-input" required>
-                        <div class="flex-grow-1">
+                        <div class="flex-grow-1" style="min-width:0">
                             <strong>{{.Name}}</strong>
                             {{if .Description}}
-                            <br>
-                            <small class="text-body-secondary">{{.Description}}</small>
+                            <small class="text-body-secondary d-block text-truncate">{{.Description}}</small>
                             {{end}}
                         </div>
                         {{if .Active}}


### PR DESCRIPTION
## Problem (GitLab #70)

Two station-picker annoyances from the 2026-07 UI review:
1. Accounts with exactly one station still passed through `/dashboard/stations/select` on every login.
2. The picker rendered full multi-paragraph station bios per row, so choosing a station meant scrolling walls of text.

## Fix

1. **Auto-select for the actual user.** The dashboard home redirect decided whether to auto-select by querying *every active station* (`h.db.Where("active = ?", true)`), so a user with access to one station on a multi-station install got bounced through the picker (which then auto-selected anyway via the user-scoped `LoadStations`). Use `LoadStations(r)` here too, so the single reachable station is selected directly.
2. **Clamp the bio.** The description now renders as a single truncated line (`text-truncate`) with `min-width:0` on the flex item so it ellipsizes; a row is name + one-line blurb + Active badge.

## Note

The one-line auto-select flow already existed on the select page itself; this makes the home redirect consistent so single-station users don't take the extra hop. `TestMigrationsImport_LibreTime_NotSupported` fails locally on a filesystem quirk unrelated to this change (fails on clean main too); it passes in CI.