### PR TITLE
fix(analytics): normalize artist grouping so case/whitespace variants merge (#69)

### DIFF
--- a/internal/web/analytics_artist_normalize_test.go
+++ b/internal/web/analytics_artist_normalize_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package web
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+// TestTopArtistsNormalization checks the aggregation used by the analytics pages:
+// case- and surrounding-whitespace-variant spellings collapse into one artist,
+// while an internal-spacing difference stays distinct (trim/case-fold only).
+func TestTopArtistsNormalization(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.PlayHistory{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	station := uuid.NewString()
+	now := time.Now()
+	seed := []string{
+		"Sound Minds", "Sound Minds", // exact
+		"sound minds",   // case
+		" Sound Minds ", // surrounding whitespace
+		"soundminds",    // internal spacing differs -> stays separate
+		"", "", "",      // unknown
+		"Other Artist",
+	}
+	for _, a := range seed {
+		if err := db.Create(&models.PlayHistory{
+			ID: uuid.NewString(), StationID: station, MountID: uuid.NewString(),
+			Artist: a, Title: "T", StartedAt: now,
+		}).Error; err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	type artistCount struct {
+		Artist string
+		Count  int64
+	}
+	var got []artistCount
+	if err := db.Model(&models.PlayHistory{}).
+		Select("MIN(TRIM(artist)) as artist, COUNT(*) as count").
+		Where("station_id = ? AND started_at >= ?", station, now.AddDate(0, 0, -7)).
+		Group("LOWER(TRIM(artist))").
+		Order("count DESC").
+		Scan(&got).Error; err != nil {
+		t.Fatalf("query: %v", err)
+	}
+
+	counts := map[string]int64{}
+	for _, g := range got {
+		counts[g.Artist] = g.Count
+	}
+	// The four "Sound Minds" case/whitespace variants merge into one group of 4.
+	if counts["Sound Minds"] != 4 {
+		t.Errorf("Sound Minds variants: got %d, want 4 (groups=%v)", counts["Sound Minds"], counts)
+	}
+	// Trim/case-fold does not remove internal spacing, so "soundminds" stays its own.
+	if counts["soundminds"] != 1 {
+		t.Errorf("soundminds: got %d, want 1 (separate group)", counts["soundminds"])
+	}
+	// Blank artists collapse to a single group (labeled Unknown in the template).
+	if counts[""] != 3 {
+		t.Errorf("blank/unknown: got %d, want 3", counts[""])
+	}
+	if counts["Other Artist"] != 1 {
+		t.Errorf("Other Artist: got %d, want 1", counts["Other Artist"])
+	}
+}

--- a/internal/web/pages_analytics.go
+++ b/internal/web/pages_analytics.go
@@ -68,10 +68,13 @@ func (h *Handler) AnalyticsDashboard(w http.ResponseWriter, r *http.Request) {
 		Count  int64
 	}
 	var topArtists []artistCount
+	// Group case- and surrounding-whitespace-insensitively so "Sound Minds" and
+	// "sound minds " are one artist, not two ranks; MIN(artist) shows a
+	// representative original spelling. Blank/Unknown is labeled in the template.
 	h.db.Model(&models.PlayHistory{}).
-		Select("artist, COUNT(*) as count").
+		Select("MIN(TRIM(artist)) as artist, COUNT(*) as count").
 		Where("station_id = ? AND started_at >= ?", station.ID, time.Now().AddDate(0, 0, -7)).
-		Group("artist").
+		Group("LOWER(TRIM(artist))").
 		Order("count DESC").
 		Limit(10).
 		Scan(&topArtists)
@@ -352,10 +355,11 @@ func (h *Handler) AnalyticsSpins(w http.ResponseWriter, r *http.Request) {
 		Count  int64
 	}
 	var topTracks []trackSpin
+	// Merge case-/whitespace-variant spellings of the same track.
 	h.db.Model(&models.PlayHistory{}).
-		Select("artist, title, COUNT(*) as count").
+		Select("MIN(TRIM(artist)) as artist, MIN(TRIM(title)) as title, COUNT(*) as count").
 		Where("station_id = ? AND started_at >= ? AND started_at <= ?", station.ID, fromDate, toDate).
-		Group("artist, title").
+		Group("LOWER(TRIM(artist)), LOWER(TRIM(title))").
 		Order("count DESC").
 		Limit(50).
 		Scan(&topTracks)
@@ -366,10 +370,11 @@ func (h *Handler) AnalyticsSpins(w http.ResponseWriter, r *http.Request) {
 		Count  int64
 	}
 	var topArtists []artistSpin
+	// Case- and whitespace-insensitive grouping (see AnalyticsDashboard).
 	h.db.Model(&models.PlayHistory{}).
-		Select("artist, COUNT(*) as count").
+		Select("MIN(TRIM(artist)) as artist, COUNT(*) as count").
 		Where("station_id = ? AND started_at >= ? AND started_at <= ?", station.ID, fromDate, toDate).
-		Group("artist").
+		Group("LOWER(TRIM(artist))").
 		Order("count DESC").
 		Limit(20).
 		Scan(&topArtists)


### PR DESCRIPTION
## Problem (GitLab #69)

Analytics "Top Artists (7 days)" ranked **"Sound Minds" and "soundminds" as different artists** because the aggregation grouped on the raw artist string. Same for the spins report's top artists/tracks.

## Fix

Group on `LOWER(TRIM(artist))` so case- and surrounding-whitespace variants count as one artist, and select `MIN(TRIM(artist))` as a clean representative spelling. `MIN(artist)` alone would surface a leading-space copy (`" Sound Minds "`), which the test caught. Applied to all three aggregations: dashboard top-artists, spins top-artists, and spins top-tracks (artist + title).

Blank artists still collapse to one group, labeled "Unknown" by the template. Trim/case-fold intentionally does **not** merge internal-spacing differences (`"soundminds"` stays its own artist), so genuinely different names aren't over-merged.

## Test

`TestTopArtistsNormalization` seeds exact/case/whitespace/blank/internal-spacing variants and asserts the merge counts (4 "Sound Minds" variants → one group, "soundminds" stays separate, blanks → one group).

## Not included

The issue also mentions the detailed play-history view showing mount raw codes instead of names; that's a separate view and left for a follow-up.