### PR TITLE
fix(mounts): alias a custom mount to its station's live stream instead of 404 (#53)

### DIFF
--- a/internal/server/mount_alias_test.go
+++ b/internal/server/mount_alias_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package server
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+func TestAliasSiblingMountNames(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Mount{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+
+	stationA := uuid.NewString()
+	stationB := uuid.NewString()
+	seed := []models.Mount{
+		{ID: uuid.NewString(), StationID: stationA, Name: "main-a", Format: "mp3"},
+		{ID: uuid.NewString(), StationID: stationA, Name: "fic-stream", Format: "mp3"}, // custom alias
+		{ID: uuid.NewString(), StationID: stationB, Name: "main-b", Format: "mp3"},
+	}
+	for _, m := range seed {
+		if err := db.Create(&m).Error; err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	// The custom alias resolves to its station's other mount, and only that.
+	got := aliasSiblingMountNames(db, "fic-stream")
+	if len(got) != 1 || got[0] != "main-a" {
+		t.Errorf("fic-stream siblings = %v, want [main-a]", got)
+	}
+	// Never crosses into another station's mounts.
+	for _, n := range got {
+		if n == "main-b" {
+			t.Error("alias must not resolve across stations")
+		}
+	}
+	// The main mount's siblings exclude itself and include the alias.
+	if g := aliasSiblingMountNames(db, "main-a"); len(g) != 1 || g[0] != "fic-stream" {
+		t.Errorf("main-a siblings = %v, want [fic-stream]", g)
+	}
+	// An unknown name resolves to nothing (falls through to 404).
+	if g := aliasSiblingMountNames(db, "does-not-exist"); g != nil {
+		t.Errorf("unknown mount siblings = %v, want nil", g)
+	}
+	// Guard rails.
+	if aliasSiblingMountNames(db, "") != nil || aliasSiblingMountNames(nil, "x") != nil {
+		t.Error("empty name / nil db should return nil")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -837,6 +837,19 @@ func (s *Server) configureRoutes() {
 		mountName := chi.URLParam(r, "mount")
 		mount := s.director.Broadcast().GetMount(mountName)
 		if mount == nil {
+			// The name isn't a live broadcast mount. It may be a custom mount the
+			// operator added in Stream Mounts, which is a pure alias to that
+			// station's own live stream (a station only aliases its own). Resolve
+			// it to whichever of the station's mounts is currently broadcasting so
+			// /live/<alias> streams the station's live output instead of 404ing.
+			for _, sibling := range aliasSiblingMountNames(s.db, mountName) {
+				if bm := s.director.Broadcast().GetMount(sibling); bm != nil {
+					mount = bm
+					break
+				}
+			}
+		}
+		if mount == nil {
 			http.Error(w, "Stream not found", http.StatusNotFound)
 			return
 		}
@@ -852,4 +865,30 @@ func (s *Server) configureRoutes() {
 
 	// Web UI routes
 	s.webHandler.Routes(s.router)
+}
+
+// aliasSiblingMountNames returns the names of the OTHER mounts belonging to the
+// station that owns the mount named requestedName. It backs custom-mount
+// aliasing: a mount added in Stream Mounts that isn't itself a live broadcast
+// mount resolves to one of its station's live mounts. Scoped to the owning
+// station, so a mount can only ever alias its own station's stream. Returns nil
+// when no mount by that name exists.
+func aliasSiblingMountNames(db *gorm.DB, requestedName string) []string {
+	if db == nil || requestedName == "" {
+		return nil
+	}
+	var owner models.Mount
+	if err := db.Where("name = ?", requestedName).First(&owner).Error; err != nil {
+		return nil
+	}
+	var siblings []models.Mount
+	if err := db.Where("station_id = ? AND name <> ?", owner.StationID, requestedName).
+		Find(&siblings).Error; err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(siblings))
+	for _, m := range siblings {
+		names = append(names, m.Name)
+	}
+	return names
 }


### PR DESCRIPTION
## Problem (GitLab #53)

Adding a mount in Stream Mounts stores a DB row and shows a `/live/<name>` URL, but it **404s**. Broadcast mounts only register in the live registry under the name of a mount an active schedule entry is playing, so a custom mount nobody scheduled is never registered (repro: `fic-stream` → `/live/fic-stream` → 404).

## Fix

On a registry miss, `/live/{mount}` looks the name up in the `mounts` table; if it's a real mount, it streams whichever of that station's **other** mounts is currently broadcasting. So any custom mount name becomes a pure alias to the station's own live stream:

- Multiple aliases per station all resolve to the same live output.
- The lookup is scoped to the owning station (`station_id`), so a mount can only alias **its own** station's stream, never another's.
- No new encoder — the alias resolves to the existing live mount.
- A name matching no mount, or a station that isn't live, still 404s.

The DB resolution is factored into `aliasSiblingMountNames` (pure, station-scoped); the handler just walks those names against the broadcast registry.

## Test

`TestAliasSiblingMountNames` covers same-station resolution, cross-station isolation, self-exclusion, unknown names, and nil/empty guards.