### PR TITLE
style(playout): gofmt director_playlist_requeue_test.go

### DIFF
--- a/internal/playout/director_playlist_requeue_test.go
+++ b/internal/playout/director_playlist_requeue_test.go
@@ -45,7 +45,7 @@ func TestMountsPlayingPlaylist(t *testing.T) {
 		"m1": {StationID: "sA", MountName: "main-a", EntryID: "e1", SourceType: "playlist", SourceID: "pl-1"},
 		"m2": {StationID: "sA", MountName: "main-a-lq", EntryID: "e1", SourceType: "clock_playlist", SourceID: "pl-1"},
 		"m3": {StationID: "sC", MountName: "sb", EntryID: "e3", SourceType: "smart_block", SourceID: "pl-1"}, // wrong type
-		"m4": {StationID: "sD", MountName: "other", EntryID: "e4", SourceType: "playlist", SourceID: "pl-2"},  // other playlist
+		"m4": {StationID: "sD", MountName: "other", EntryID: "e4", SourceType: "playlist", SourceID: "pl-2"}, // other playlist
 	}}
 
 	got := d.mountsPlayingPlaylist("pl-1")


### PR DESCRIPTION
The #290 merge landed `internal/playout/director_playlist_requeue_test.go` with a misaligned trailing comment, so main's `gofmt (must be clean)` gate went red on the push run. `gofmt -w` realigns the single comment; no logic change.

The v1.40.30 Docker image built fine; only the CI lint gate broke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)