### PR TITLE
test(coverage): cover four zero-test leaf packages (55% -> 57%)

### DIFF
--- a/internal/logbuffer/buffer_test.go
+++ b/internal/logbuffer/buffer_test.go
@@ -1,0 +1,294 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package logbuffer
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+)
+
+const testUUID = "11111111-2222-3333-4444-555555555555"
+
+func entry(level, component, msg string, fields map[string]interface{}) LogEntry {
+	return LogEntry{Timestamp: time.Now(), Level: level, Component: component, Message: msg, Fields: fields}
+}
+
+func TestNew_DefaultCapacityOnNonPositive(t *testing.T) {
+	if b := New(0); b.capacity != 10000 {
+		t.Fatalf("capacity for New(0) = %d, want 10000", b.capacity)
+	}
+	if b := New(-5); b.capacity != 10000 {
+		t.Fatalf("capacity for New(-5) = %d, want 10000", b.capacity)
+	}
+	if b := New(7); b.capacity != 7 {
+		t.Fatalf("capacity for New(7) = %d, want 7", b.capacity)
+	}
+}
+
+func TestAdd_RingWraparoundKeepsNewest(t *testing.T) {
+	b := New(3)
+	for i := 0; i < 5; i++ {
+		b.Add(entry("info", "c", fmt.Sprintf("m%d", i), nil))
+	}
+	all := b.GetAll()
+	if len(all) != 3 {
+		t.Fatalf("GetAll len = %d, want 3", len(all))
+	}
+	// Oldest two (m0, m1) evicted; remaining in chronological order.
+	want := []string{"m2", "m3", "m4"}
+	for i, w := range want {
+		if all[i].Message != w {
+			t.Fatalf("entry[%d] = %q, want %q", i, all[i].Message, w)
+		}
+	}
+}
+
+func TestGetAll_EmptyBuffer(t *testing.T) {
+	if got := New(4).GetAll(); len(got) != 0 {
+		t.Fatalf("empty GetAll len = %d, want 0", len(got))
+	}
+}
+
+func TestGetAll_PartialFillOrder(t *testing.T) {
+	b := New(10)
+	b.Add(entry("info", "c", "first", nil))
+	b.Add(entry("info", "c", "second", nil))
+	all := b.GetAll()
+	if len(all) != 2 || all[0].Message != "first" || all[1].Message != "second" {
+		t.Fatalf("unexpected partial-fill order: %+v", all)
+	}
+}
+
+func TestQuery_Filters(t *testing.T) {
+	b := New(50)
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	b.Add(LogEntry{Timestamp: base, Level: "info", Component: "playout", Message: "started playback"})
+	b.Add(LogEntry{Timestamp: base.Add(time.Minute), Level: "error", Component: "harbor", Message: "connection refused"})
+	b.Add(LogEntry{Timestamp: base.Add(2 * time.Minute), Level: "warn", Component: "playout", Message: "buffer low"})
+
+	if got := b.Query(QueryParams{Level: "error"}); len(got) != 1 || got[0].Component != "harbor" {
+		t.Fatalf("level filter: %+v", got)
+	}
+	if got := b.Query(QueryParams{Component: "playout"}); len(got) != 2 {
+		t.Fatalf("component filter len = %d, want 2", len(got))
+	}
+	if got := b.Query(QueryParams{Search: "REFUSED"}); len(got) != 1 {
+		t.Fatalf("case-insensitive search len = %d, want 1", len(got))
+	}
+	if got := b.Query(QueryParams{Since: base.Add(90 * time.Second)}); len(got) != 1 || got[0].Message != "buffer low" {
+		t.Fatalf("since filter: %+v", got)
+	}
+	if got := b.Query(QueryParams{Limit: 2}); len(got) != 2 {
+		t.Fatalf("limit len = %d, want 2", len(got))
+	}
+	desc := b.Query(QueryParams{Descending: true})
+	if len(desc) != 3 || desc[0].Message != "buffer low" {
+		t.Fatalf("descending order wrong: %+v", desc)
+	}
+}
+
+func TestQuery_SearchInFields(t *testing.T) {
+	b := New(10)
+	b.Add(entry("info", "playout", "generic", map[string]interface{}{"track": "Highway Star"}))
+	if got := b.Query(QueryParams{Search: "highway"}); len(got) != 1 {
+		t.Fatalf("search-in-fields len = %d, want 1", len(got))
+	}
+}
+
+func TestStationIDFromFields(t *testing.T) {
+	cases := []struct {
+		name   string
+		fields map[string]interface{}
+		want   string
+	}{
+		{"nil", nil, ""},
+		{"preferred station_id", map[string]interface{}{"station_id": testUUID}, testUUID},
+		{"alternate stationID", map[string]interface{}{"stationID": testUUID}, testUUID},
+		{"alternate station_uuid", map[string]interface{}{"station_uuid": testUUID}, testUUID},
+		{"ambiguous station as uuid", map[string]interface{}{"station": testUUID}, testUUID},
+		{"ambiguous station as name ignored", map[string]interface{}{"station": "Rock FM"}, ""},
+		{"non-uuid station_id ignored", map[string]interface{}{"station_id": "not-a-uuid"}, ""},
+		{"bytes value", map[string]interface{}{"station_id": []byte(testUUID)}, testUUID},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := StationIDFromFields(tc.fields); got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCoerceString(t *testing.T) {
+	if coerceString(map[string]interface{}{"a": 1}) != "" {
+		t.Fatal("map should coerce to empty")
+	}
+	if coerceString([]interface{}{1, 2}) != "" {
+		t.Fatal("slice should coerce to empty")
+	}
+	if coerceString(42) != "42" {
+		t.Fatalf("int coerce = %q, want 42", coerceString(42))
+	}
+	if coerceString([]byte("hi")) != "hi" {
+		t.Fatal("bytes coerce failed")
+	}
+}
+
+func TestLooksLikeUUID(t *testing.T) {
+	if !looksLikeUUID(testUUID) {
+		t.Fatal("canonical UUID rejected")
+	}
+	if looksLikeUUID("tooshort") {
+		t.Fatal("short string accepted")
+	}
+	if looksLikeUUID("111111112222333344445555555555556666") { // 36 chars, no hyphens
+		t.Fatal("hyphen-less 36-char string accepted")
+	}
+}
+
+func TestStatsAndComponents(t *testing.T) {
+	b := New(10)
+	b.Add(entry("info", "playout", "a", nil))
+	b.Add(entry("error", "harbor", "b", nil))
+	b.Add(entry("info", "playout", "c", nil))
+
+	s := b.Stats()
+	if s.Count != 3 || s.Capacity != 10 {
+		t.Fatalf("stats = %+v", s)
+	}
+	if s.LevelCount["info"] != 2 || s.LevelCount["error"] != 1 {
+		t.Fatalf("level counts = %+v", s.LevelCount)
+	}
+	comps := b.GetComponents()
+	if len(comps) != 2 {
+		t.Fatalf("components = %v, want 2 unique", comps)
+	}
+}
+
+func TestClear(t *testing.T) {
+	b := New(5)
+	b.Add(entry("info", "c", "x", nil))
+	b.Clear()
+	if b.Stats().Count != 0 {
+		t.Fatal("Clear did not reset count")
+	}
+	if len(b.GetAll()) != 0 {
+		t.Fatal("GetAll not empty after Clear")
+	}
+}
+
+func TestStationBuffers_MirrorAndScopedQuery(t *testing.T) {
+	b := New(100)
+	b.EnableStationBuffers(10, 5)
+	b.Add(entry("info", "playout", "station log", map[string]interface{}{"station_id": testUUID}))
+	b.Add(entry("info", "system", "global log", nil))
+
+	// Scoped query pulls from the per-station buffer.
+	got := b.Query(QueryParams{StationID: testUUID})
+	if len(got) != 1 || got[0].Message != "station log" {
+		t.Fatalf("scoped query: %+v", got)
+	}
+	if b.StatsForStation(testUUID).Count != 1 {
+		t.Fatalf("station stats count = %d, want 1", b.StatsForStation(testUUID).Count)
+	}
+	if comps := b.GetComponentsForStation(testUUID); len(comps) != 1 || comps[0] != "playout" {
+		t.Fatalf("station components = %v", comps)
+	}
+}
+
+func TestEnableStationBuffers_Guards(t *testing.T) {
+	b := New(10)
+	b.EnableStationBuffers(0, 5) // non-positive capacity is a no-op
+	if b.stationBuffers != nil {
+		t.Fatal("station buffers should stay disabled for capacity 0")
+	}
+	b.EnableStationBuffers(10, 0) // zero maxStations defaults to 200
+	if b.maxStationBuffers != 200 {
+		t.Fatalf("maxStationBuffers = %d, want default 200", b.maxStationBuffers)
+	}
+}
+
+func TestWriter_ParsesJSONAndNormalizesStation(t *testing.T) {
+	b := New(10)
+	var fallback bytes.Buffer
+	w := NewWriter(b, &fallback)
+
+	rec := map[string]interface{}{
+		"level":     "warn",
+		"message":   "disk low",
+		"component": "storage",
+		"time":      "2026-01-01T00:00:00Z",
+		"stationID": testUUID,
+	}
+	raw, _ := json.Marshal(rec)
+	n, err := w.Write(raw)
+	if err != nil {
+		t.Fatalf("write err: %v", err)
+	}
+	if n != len(raw) {
+		t.Fatalf("write n = %d, want %d", n, len(raw))
+	}
+	if fallback.Len() == 0 {
+		t.Fatal("fallback did not receive the raw bytes")
+	}
+
+	all := b.GetAll()
+	if len(all) != 1 {
+		t.Fatalf("buffer entries = %d, want 1", len(all))
+	}
+	e := all[0]
+	if e.Level != "warn" || e.Message != "disk low" || e.Component != "storage" {
+		t.Fatalf("parsed entry wrong: %+v", e)
+	}
+	if e.Fields["station_id"] != testUUID {
+		t.Fatalf("station_id not normalized: %+v", e.Fields)
+	}
+	if !e.Timestamp.Equal(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)) {
+		t.Fatalf("timestamp not parsed: %v", e.Timestamp)
+	}
+}
+
+func TestWriter_UnixTimeAndInvalidJSON(t *testing.T) {
+	b := New(10)
+	w := NewWriter(b, nil)
+
+	// Unix-timestamp form.
+	raw, _ := json.Marshal(map[string]interface{}{"level": "info", "message": "m", "time": float64(1735689600)})
+	if _, err := w.Write(raw); err != nil {
+		t.Fatalf("write err: %v", err)
+	}
+	if got := b.GetAll()[0].Timestamp.Unix(); got != 1735689600 {
+		t.Fatalf("unix ts = %d", got)
+	}
+
+	// Invalid JSON is ignored (no panic, nothing added), and Write with nil fallback returns len.
+	n, err := w.Write([]byte("not json"))
+	if err != nil {
+		t.Fatalf("invalid json err: %v", err)
+	}
+	if n != len("not json") {
+		t.Fatalf("n = %d, want %d", n, len("not json"))
+	}
+	if len(b.GetAll()) != 1 {
+		t.Fatal("invalid JSON should not add an entry")
+	}
+}
+
+func TestContainsIgnoreCase(t *testing.T) {
+	if !containsIgnoreCase("Hello World", "world") {
+		t.Fatal("should match case-insensitively")
+	}
+	if containsIgnoreCase("abc", "abcd") {
+		t.Fatal("substr longer than string should not match")
+	}
+	if !containsIgnoreCase("abc", "") {
+		t.Fatal("empty substr should match")
+	}
+}

--- a/internal/schedule/export_test.go
+++ b/internal/schedule/export_test.go
@@ -1,0 +1,263 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package schedule
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+func TestEscapeUnescapeICalText_RoundTrip(t *testing.T) {
+	cases := []string{
+		"plain text",
+		"comma, semicolon; and backslash \\",
+		"line one\nline two",
+		"Rock & Roll; Vol, 2\\",
+	}
+	for _, in := range cases {
+		if got := unescapeICalText(escapeICalText(in)); got != in {
+			t.Fatalf("round-trip failed for %q: got %q", in, got)
+		}
+	}
+}
+
+func TestEscapeICalText_KnownEscapes(t *testing.T) {
+	got := escapeICalText("a;b,c\nd\\e")
+	want := `a\;b\,c\nd\\e`
+	if got != want {
+		t.Fatalf("escape = %q, want %q", got, want)
+	}
+}
+
+func TestSlugify(t *testing.T) {
+	cases := map[string]string{
+		"Rock FM":         "rock-fm",
+		"KJAZZ 88.1!":     "kjazz-881",
+		"  Spaces  ":      "--spaces--",
+		"Ünïcode Removed": "ncode-removed",
+		"already-slug-9":  "already-slug-9",
+	}
+	for in, want := range cases {
+		if got := slugify(in); got != want {
+			t.Fatalf("slugify(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestSortStrings(t *testing.T) {
+	s := []string{"2026-01-03", "2026-01-01", "2026-01-02"}
+	sortStrings(s)
+	want := []string{"2026-01-01", "2026-01-02", "2026-01-03"}
+	for i := range want {
+		if s[i] != want[i] {
+			t.Fatalf("sorted[%d] = %s, want %s", i, s[i], want[i])
+		}
+	}
+}
+
+func TestFormatICalTime_IsUTCZulu(t *testing.T) {
+	loc := time.FixedZone("EST", -5*3600)
+	tm := time.Date(2026, 1, 2, 8, 30, 0, 0, loc) // 13:30 UTC
+	if got := formatICalTime(tm); got != "20260102T133000Z" {
+		t.Fatalf("formatICalTime = %q, want 20260102T133000Z", got)
+	}
+}
+
+func TestParseICalTime(t *testing.T) {
+	cases := map[string]time.Time{
+		"20260102T133000Z":                 time.Date(2026, 1, 2, 13, 30, 0, 0, time.UTC),
+		"20260102T133000":                  time.Date(2026, 1, 2, 13, 30, 0, 0, time.UTC),
+		"20260102":                         time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+		"TZID=America/NY:20260102T133000Z": time.Date(2026, 1, 2, 13, 30, 0, 0, time.UTC), // TZID stripped
+	}
+	for in, want := range cases {
+		if got := parseICalTime(in); !got.Equal(want) {
+			t.Fatalf("parseICalTime(%q) = %v, want %v", in, got, want)
+		}
+	}
+	if got := parseICalTime("garbage"); !got.IsZero() {
+		t.Fatalf("parseICalTime(garbage) = %v, want zero", got)
+	}
+}
+
+func TestParseICalEvents(t *testing.T) {
+	content := "BEGIN:VCALENDAR\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"UID:abc@grimnir\r\n" +
+		"SUMMARY:Morning Show\\, Live\r\n" +
+		"DESCRIPTION:News\\; weather\r\n" +
+		"DTSTART:20260102T090000Z\r\n" +
+		"DTEND:20260102T100000Z\r\n" +
+		"END:VEVENT\r\n" +
+		"BEGIN:VEVENT\r\n" +
+		"SUMMARY:Night Show\r\n" +
+		"DTSTART:20260102T220000Z\r\n" +
+		"DTEND:20260102T230000Z\r\n" +
+		"END:VEVENT\r\n" +
+		"END:VCALENDAR\r\n"
+
+	events := parseICalEvents(content)
+	if len(events) != 2 {
+		t.Fatalf("parsed %d events, want 2", len(events))
+	}
+	if events[0].UID != "abc@grimnir" {
+		t.Fatalf("UID = %q", events[0].UID)
+	}
+	if events[0].Summary != "Morning Show, Live" {
+		t.Fatalf("SUMMARY unescape failed: %q", events[0].Summary)
+	}
+	if events[0].Description != "News; weather" {
+		t.Fatalf("DESCRIPTION unescape failed: %q", events[0].Description)
+	}
+	if !events[0].Start.Equal(time.Date(2026, 1, 2, 9, 0, 0, 0, time.UTC)) {
+		t.Fatalf("start = %v", events[0].Start)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DB-backed export / import
+// ---------------------------------------------------------------------------
+
+func newScheduleTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Station{}, &models.User{}, &models.Show{}, &models.ShowInstance{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func seedShowInstance(t *testing.T, db *gorm.DB, stationID string, start time.Time) {
+	t.Helper()
+	show := models.Show{ID: "show1", StationID: stationID, Name: "Morning Show", Description: "News", Color: "#FF0000", DefaultDurationMinutes: 60, DTStart: start, Active: true}
+	if err := db.Create(&show).Error; err != nil {
+		t.Fatalf("seed show: %v", err)
+	}
+	inst := models.ShowInstance{ID: "inst1", ShowID: show.ID, StationID: stationID, StartsAt: start, EndsAt: start.Add(time.Hour), Status: models.ShowInstanceScheduled}
+	if err := db.Create(&inst).Error; err != nil {
+		t.Fatalf("seed instance: %v", err)
+	}
+}
+
+func TestExportToICal(t *testing.T) {
+	db := newScheduleTestDB(t)
+	svc := NewExportService(db, zerolog.Nop())
+	db.Create(&models.Station{ID: "st1", Name: "Rock FM", Active: true})
+	start := time.Date(2026, 1, 2, 9, 0, 0, 0, time.UTC)
+	seedShowInstance(t, db, "st1", start)
+
+	res, err := svc.ExportToICal(context.Background(), "st1", start.Add(-time.Hour), start.Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("export: %v", err)
+	}
+	body := string(res.Data)
+	for _, want := range []string{"BEGIN:VCALENDAR", "BEGIN:VEVENT", "SUMMARY:Morning Show", "UID:inst1@grimnir", "X-APPLE-CALENDAR-COLOR:#FF0000", "END:VCALENDAR"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("export missing %q in:\n%s", want, body)
+		}
+	}
+	if res.ContentType != "text/calendar; charset=utf-8" {
+		t.Fatalf("content type = %q", res.ContentType)
+	}
+	if !strings.HasPrefix(res.Filename, "rock-fm-schedule-2026-01-02") {
+		t.Fatalf("filename = %q", res.Filename)
+	}
+}
+
+func TestExportToICal_StationNotFound(t *testing.T) {
+	svc := NewExportService(newScheduleTestDB(t), zerolog.Nop())
+	if _, err := svc.ExportToICal(context.Background(), "missing", time.Now(), time.Now().Add(time.Hour)); err == nil {
+		t.Fatal("expected error for missing station")
+	}
+}
+
+func TestImportFromICal(t *testing.T) {
+	db := newScheduleTestDB(t)
+	svc := NewExportService(db, zerolog.Nop())
+	db.Create(&models.Station{ID: "st1", Name: "Rock FM", Active: true})
+
+	ical := "BEGIN:VEVENT\r\n" +
+		"SUMMARY:Imported Show\r\n" +
+		"DTSTART:20260201T090000Z\r\n" +
+		"DTEND:20260201T100000Z\r\n" +
+		"END:VEVENT\r\n" +
+		// This one is missing DTEND and must be skipped.
+		"BEGIN:VEVENT\r\n" +
+		"SUMMARY:Incomplete\r\n" +
+		"DTSTART:20260201T110000Z\r\n" +
+		"END:VEVENT\r\n"
+
+	res, err := svc.ImportFromICal(context.Background(), "st1", strings.NewReader(ical))
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if res.Imported != 1 {
+		t.Fatalf("imported = %d, want 1", res.Imported)
+	}
+	if res.Skipped != 1 {
+		t.Fatalf("skipped = %d, want 1", res.Skipped)
+	}
+
+	var shows int64
+	db.Model(&models.Show{}).Where("station_id = ? AND name = ?", "st1", "Imported Show").Count(&shows)
+	if shows != 1 {
+		t.Fatalf("expected the imported show to be created, got %d", shows)
+	}
+}
+
+func TestImportFromICal_ConflictSkipped(t *testing.T) {
+	db := newScheduleTestDB(t)
+	svc := NewExportService(db, zerolog.Nop())
+	db.Create(&models.Station{ID: "st1", Name: "Rock FM", Active: true})
+	start := time.Date(2026, 2, 1, 9, 0, 0, 0, time.UTC)
+	seedShowInstance(t, db, "st1", start) // occupies 09:00-10:00
+
+	// Overlapping event must be reported as a conflict, not imported.
+	ical := "BEGIN:VEVENT\r\nSUMMARY:Morning Show\r\nDTSTART:20260201T093000Z\r\nDTEND:20260201T103000Z\r\nEND:VEVENT\r\n"
+	res, err := svc.ImportFromICal(context.Background(), "st1", strings.NewReader(ical))
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if res.Imported != 0 || res.Skipped != 1 {
+		t.Fatalf("imported=%d skipped=%d, want 0/1", res.Imported, res.Skipped)
+	}
+	if len(res.Errors) == 0 {
+		t.Fatal("expected a conflict error to be recorded")
+	}
+}
+
+func TestExportToPDF(t *testing.T) {
+	db := newScheduleTestDB(t)
+	svc := NewExportService(db, zerolog.Nop())
+	db.Create(&models.Station{ID: "st1", Name: "Rock FM", Active: true})
+	start := time.Date(2026, 1, 2, 9, 0, 0, 0, time.UTC)
+	seedShowInstance(t, db, "st1", start)
+
+	out, err := svc.ExportToPDF(context.Background(), "st1", start.Add(-time.Hour), start.Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("pdf: %v", err)
+	}
+	html := string(out)
+	if !strings.Contains(html, "Rock FM Schedule") || !strings.Contains(html, "Morning Show") {
+		t.Fatalf("PDF HTML missing expected content:\n%s", html)
+	}
+}

--- a/internal/scheduling/validator_test.go
+++ b/internal/scheduling/validator_test.go
@@ -1,0 +1,310 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package scheduling
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+func testValidator(t *testing.T) (*Validator, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.Station{}, &models.User{}, &models.Show{}, &models.ShowInstance{},
+		&models.ScheduleEntry{}, &models.ScheduleRule{}, &models.Playlist{},
+		&models.SmartBlock{}, &models.ClockHour{}, &models.Webstream{}, &models.MediaItem{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewValidator(db, zerolog.Nop()), db
+}
+
+func at(h, m int) time.Time {
+	return time.Date(2026, 3, 1, h, m, 0, 0, time.UTC)
+}
+
+func item(id string, startH, endH int) ScheduleItem {
+	return ScheduleItem{ID: id, Type: "show_instance", StationID: "st1", StartsAt: at(startH, 0), EndsAt: at(endH, 0)}
+}
+
+func hostItem(id, host string, startH, endH int) ScheduleItem {
+	i := item(id, startH, endH)
+	i.HostUserID = &host
+	return i
+}
+
+// ---------------------------------------------------------------------------
+// pure helpers
+// ---------------------------------------------------------------------------
+
+func TestMaxMinTime(t *testing.T) {
+	a, b := at(9, 0), at(10, 0)
+	if !maxTime(a, b).Equal(b) {
+		t.Fatal("maxTime wrong")
+	}
+	if !minTime(a, b).Equal(a) {
+		t.Fatal("minTime wrong")
+	}
+	if !maxTime(b, a).Equal(b) || !minTime(b, a).Equal(a) {
+		t.Fatal("max/minTime not symmetric")
+	}
+}
+
+func TestItemLabel(t *testing.T) {
+	if got := itemLabel(ScheduleItem{Display: "Show: Morning"}); got != "Show: Morning" {
+		t.Fatalf("display label = %q", got)
+	}
+	if got := itemLabel(ScheduleItem{SourceType: "playlist"}); got != "playlist" {
+		t.Fatalf("sourcetype label = %q", got)
+	}
+	if got := itemLabel(ScheduleItem{Type: "schedule_entry"}); got != "schedule_entry" {
+		t.Fatalf("type label = %q", got)
+	}
+}
+
+func TestItemsOverlap(t *testing.T) {
+	v := &Validator{}
+	if !v.itemsOverlap(item("a", 9, 11), item("b", 10, 12)) {
+		t.Fatal("overlapping items reported as non-overlapping")
+	}
+	if v.itemsOverlap(item("a", 9, 10), item("b", 10, 11)) {
+		t.Fatal("adjacent items must not overlap")
+	}
+	if !v.itemsOverlap(item("a", 9, 12), item("b", 10, 11)) {
+		t.Fatal("contained item must overlap")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// overlap / gap / duration / consecutive checks
+// ---------------------------------------------------------------------------
+
+func TestCheckOverlaps(t *testing.T) {
+	v := &Validator{}
+	none := v.checkOverlaps([]ScheduleItem{item("a", 9, 10), item("b", 10, 11)})
+	if len(none) != 0 {
+		t.Fatalf("expected no overlap, got %d", len(none))
+	}
+	got := v.checkOverlaps([]ScheduleItem{item("a", 9, 11), item("b", 10, 12)})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 overlap, got %d", len(got))
+	}
+	if got[0].Severity != models.RuleSeverityError || got[0].RuleType != models.RuleTypeOverlap {
+		t.Fatalf("wrong violation shape: %+v", got[0])
+	}
+	if got[0].Details["overlap_minutes"] != 60 {
+		t.Fatalf("overlap_minutes = %v, want 60", got[0].Details["overlap_minutes"])
+	}
+}
+
+func TestCheckGaps(t *testing.T) {
+	v := &Validator{}
+	rule := models.ScheduleRule{RuleType: models.RuleTypeGap, Severity: models.RuleSeverityWarning, Config: map[string]any{"max_gap_minutes": float64(30)}}
+	// 9-10 then 11-12 => 60-minute gap > 30.
+	items := []ScheduleItem{item("a", 9, 10), item("b", 11, 12)}
+	if got := v.checkGaps(rule, items, at(9, 0), at(12, 0)); len(got) != 1 {
+		t.Fatalf("expected 1 gap violation, got %d", len(got))
+	}
+	// Adjacent items: no gap.
+	if got := v.checkGaps(rule, []ScheduleItem{item("a", 9, 10), item("b", 10, 11)}, at(9, 0), at(11, 0)); len(got) != 0 {
+		t.Fatalf("expected no gap, got %d", len(got))
+	}
+	// ignore_hours skips the gap at hour 10.
+	ignore := models.ScheduleRule{RuleType: models.RuleTypeGap, Config: map[string]any{"max_gap_minutes": float64(30), "ignore_hours": []any{float64(10)}}}
+	if got := v.checkGaps(ignore, items, at(9, 0), at(12, 0)); len(got) != 0 {
+		t.Fatalf("ignore_hours should suppress the gap, got %d", len(got))
+	}
+}
+
+func TestCheckMinDuration(t *testing.T) {
+	v := &Validator{}
+	rule := models.ScheduleRule{RuleType: models.RuleTypeMinDuration, Config: map[string]any{"minutes": float64(30)}}
+	short := ScheduleItem{ID: "s", StartsAt: at(9, 0), EndsAt: at(9, 10)} // 10 min
+	if got := v.checkMinDuration(rule, []ScheduleItem{short}); len(got) != 1 {
+		t.Fatalf("expected min-duration violation, got %d", len(got))
+	}
+	if got := v.checkMinDurationForItem(rule, short); len(got) != 1 {
+		t.Fatalf("ForItem expected violation, got %d", len(got))
+	}
+	ok := ScheduleItem{ID: "o", StartsAt: at(9, 0), EndsAt: at(10, 0)}
+	if got := v.checkMinDurationForItem(rule, ok); len(got) != 0 {
+		t.Fatalf("ForItem should pass a 60-min item, got %d", len(got))
+	}
+}
+
+func TestCheckMaxDuration(t *testing.T) {
+	v := &Validator{}
+	rule := models.ScheduleRule{RuleType: models.RuleTypeMaxDuration, Config: map[string]any{"minutes": float64(60)}}
+	long := ScheduleItem{ID: "l", StartsAt: at(9, 0), EndsAt: at(12, 0)} // 180 min
+	if got := v.checkMaxDuration(rule, []ScheduleItem{long}); len(got) != 1 {
+		t.Fatalf("expected max-duration violation, got %d", len(got))
+	}
+	if got := v.checkMaxDurationForItem(rule, long); len(got) != 1 {
+		t.Fatalf("ForItem expected violation, got %d", len(got))
+	}
+	ok := ScheduleItem{ID: "o", StartsAt: at(9, 0), EndsAt: at(9, 30)}
+	if got := v.checkMaxDurationForItem(rule, ok); len(got) != 0 {
+		t.Fatalf("ForItem should pass a 30-min item, got %d", len(got))
+	}
+}
+
+func TestCheckMaxConsecutive(t *testing.T) {
+	v := &Validator{}
+	rule := models.ScheduleRule{RuleType: models.RuleTypeMaxConsecutive, Config: map[string]any{"max_hours": float64(4)}}
+	// Same host back-to-back 9-11, 11-13, 13-15 => 6h consecutive > 4h.
+	items := []ScheduleItem{hostItem("a", "dj1", 9, 11), hostItem("b", "dj1", 11, 13), hostItem("c", "dj1", 13, 15)}
+	got := v.checkMaxConsecutive(rule, items)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 consecutive violation, got %d", len(got))
+	}
+	if got[0].Details["consecutive_hours"].(float64) != 6 {
+		t.Fatalf("consecutive_hours = %v, want 6", got[0].Details["consecutive_hours"])
+	}
+	// A >15min gap splits the block so neither half exceeds 4h.
+	split := []ScheduleItem{hostItem("a", "dj1", 9, 11), hostItem("b", "dj1", 13, 15)}
+	if got := v.checkMaxConsecutive(rule, split); len(got) != 0 {
+		t.Fatalf("split blocks should not violate, got %d", len(got))
+	}
+}
+
+func TestRunRule_Dispatch(t *testing.T) {
+	v := &Validator{}
+	items := []ScheduleItem{item("a", 9, 11), item("b", 10, 12)}
+	// Unknown rule type returns nil.
+	if got := v.runRule(models.ScheduleRule{RuleType: "nonexistent"}, items, at(9, 0), at(12, 0)); got != nil {
+		t.Fatalf("unknown rule should return nil, got %v", got)
+	}
+	// Min-duration dispatches to the per-item aggregate check.
+	if got := v.runRuleForItem(models.ScheduleRule{RuleType: models.RuleTypeMinDuration, Config: map[string]any{"minutes": float64(120)}}, item("a", 9, 10), items); len(got) != 1 {
+		t.Fatalf("runRuleForItem min_duration expected 1, got %d", len(got))
+	}
+	if got := v.runRuleForItem(models.ScheduleRule{RuleType: "nope"}, item("a", 9, 10), items); got != nil {
+		t.Fatalf("runRuleForItem unknown expected nil, got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DB-backed
+// ---------------------------------------------------------------------------
+
+func seedInstance(t *testing.T, db *gorm.DB, id, stationID, host string, start, end time.Time) {
+	t.Helper()
+	inst := models.ShowInstance{ID: id, ShowID: "show-" + id, StationID: stationID, StartsAt: start, EndsAt: end, Status: models.ShowInstanceScheduled}
+	if host != "" {
+		inst.HostUserID = &host
+	}
+	if err := db.Create(&inst).Error; err != nil {
+		t.Fatalf("seed instance: %v", err)
+	}
+	db.Create(&models.Show{ID: "show-" + id, StationID: stationID, Name: "Show " + id, DefaultDurationMinutes: 60})
+}
+
+func TestFetchScheduleItems(t *testing.T) {
+	v, db := testValidator(t)
+	seedInstance(t, db, "i1", "st1", "", at(9, 0), at(10, 0))
+	db.Create(&models.Playlist{ID: "pl1", StationID: "st1", Name: "Drive Time"})
+	db.Create(&models.ScheduleEntry{ID: "e1", StationID: "st1", StartsAt: at(11, 0), EndsAt: at(12, 0), SourceType: "playlist", SourceID: "pl1"})
+
+	items, err := v.fetchScheduleItems("st1", at(0, 0), at(23, 0))
+	if err != nil {
+		t.Fatalf("fetch: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("fetched %d items, want 2", len(items))
+	}
+	// Sorted by start; first is the 9am instance, labelled from its show name.
+	if items[0].Type != "show_instance" || items[0].Display != "Show: Show i1" {
+		t.Fatalf("instance item wrong: %+v", items[0])
+	}
+	if items[1].Display != "Playlist: Drive Time" {
+		t.Fatalf("entry item wrong: %+v", items[1])
+	}
+}
+
+func TestValidate_DetectsOverlap(t *testing.T) {
+	v, db := testValidator(t)
+	seedInstance(t, db, "i1", "st1", "", at(9, 0), at(11, 0))
+	seedInstance(t, db, "i2", "st1", "", at(10, 0), at(12, 0))
+
+	res, err := v.Validate("st1", at(0, 0), at(23, 0))
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if res.Valid {
+		t.Fatal("expected schedule to be invalid due to overlap")
+	}
+	if len(res.Errors) != 1 || res.Errors[0].RuleType != models.RuleTypeOverlap {
+		t.Fatalf("expected 1 overlap error, got %+v", res.Errors)
+	}
+}
+
+func TestValidate_CustomRuleSeverities(t *testing.T) {
+	v, db := testValidator(t)
+	seedInstance(t, db, "i1", "st1", "", at(9, 0), at(9, 5)) // 5-minute show
+	db.Create(&models.ScheduleRule{ID: "r1", StationID: "st1", Name: "Min 15", RuleType: models.RuleTypeMinDuration, Severity: models.RuleSeverityWarning, Config: map[string]any{"minutes": float64(15)}, Active: true})
+
+	res, err := v.Validate("st1", at(0, 0), at(23, 0))
+	if err != nil {
+		t.Fatalf("validate: %v", err)
+	}
+	if len(res.Warnings) != 1 {
+		t.Fatalf("expected 1 warning from the min-duration rule, got %d", len(res.Warnings))
+	}
+	if !res.Valid {
+		t.Fatal("warnings alone should keep the schedule valid")
+	}
+}
+
+func TestValidateItem_OverlapWithExisting(t *testing.T) {
+	v, db := testValidator(t)
+	seedInstance(t, db, "existing", "st1", "", at(9, 0), at(11, 0))
+
+	candidate := ScheduleItem{ID: "new", Type: "show_instance", StationID: "st1", StartsAt: at(10, 0), EndsAt: at(12, 0)}
+	violations, err := v.ValidateItem(candidate)
+	if err != nil {
+		t.Fatalf("validate item: %v", err)
+	}
+	if len(violations) != 1 || violations[0].RuleType != models.RuleTypeOverlap {
+		t.Fatalf("expected 1 overlap, got %+v", violations)
+	}
+}
+
+func TestCheckDJDoubleBooking(t *testing.T) {
+	v, db := testValidator(t)
+	// dj1 booked on st2 from 9-11 (the "other station").
+	seedInstance(t, db, "other", "st2", "dj1", at(9, 0), at(11, 0))
+	rule := models.ScheduleRule{ID: "r", RuleType: models.RuleTypeDJDoubleBooking, Severity: models.RuleSeverityError, Name: "No double booking"}
+
+	// Same dj1 on st1 overlapping 10-12.
+	items := []ScheduleItem{hostItem("here", "dj1", 10, 12)}
+	got := v.checkDJDoubleBooking(rule, items)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 double-booking violation, got %d", len(got))
+	}
+	if got[0].Details["other_station_id"] != "st2" {
+		t.Fatalf("other_station_id = %v", got[0].Details["other_station_id"])
+	}
+
+	// Per-item variant.
+	if fi := v.checkDJDoubleBookingForItem(rule, hostItem("here", "dj1", 10, 12), items); len(fi) != 1 {
+		t.Fatalf("ForItem expected 1, got %d", len(fi))
+	}
+	// No host id => no check.
+	if fi := v.checkDJDoubleBookingForItem(rule, item("nohost", 10, 12), items); fi != nil {
+		t.Fatalf("hostless item should yield nil, got %v", fi)
+	}
+}

--- a/internal/webhooks/service_test.go
+++ b/internal/webhooks/service_test.go
@@ -1,0 +1,219 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package webhooks
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/events"
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+func testService(t *testing.T) (*Service, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Station{}, &models.User{}, &models.Show{}, &models.ShowInstance{}, &models.WebhookTarget{}, &models.WebhookLog{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewService(db, events.NewBus(), zerolog.Nop()), db
+}
+
+func TestSignPayload_MatchesHMAC(t *testing.T) {
+	s := &Service{}
+	body := []byte(`{"event":"test"}`)
+	got := s.signPayload(body, "supersecret")
+
+	mac := hmac.New(sha256.New, []byte("supersecret"))
+	mac.Write(body)
+	want := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if got != want {
+		t.Fatalf("signature = %q, want %q", got, want)
+	}
+}
+
+func TestWebhookHandlesEvent(t *testing.T) {
+	s := &Service{}
+	cases := []struct {
+		events string
+		event  string
+		want   bool
+	}{
+		{"", EventShowStart, true}, // empty = all events
+		{"show_start,show_end", "show_start", true},
+		{"show_start, show_end", "show_end", true}, // whitespace tolerated
+		{"show_start", "show_end", false},
+	}
+	for _, tc := range cases {
+		got := s.webhookHandlesEvent(models.WebhookTarget{Events: tc.events}, tc.event)
+		if got != tc.want {
+			t.Fatalf("handles(%q,%q) = %v, want %v", tc.events, tc.event, got, tc.want)
+		}
+	}
+}
+
+func TestInstanceToPayload(t *testing.T) {
+	s := &Service{}
+	if s.instanceToPayload(nil) != nil {
+		t.Fatal("nil instance should give nil payload")
+	}
+	if s.instanceToPayload(&models.ShowInstance{}) != nil {
+		t.Fatal("instance without show should give nil payload")
+	}
+
+	start := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	inst := &models.ShowInstance{
+		ID:       "inst1",
+		StartsAt: start,
+		EndsAt:   start.Add(time.Hour),
+		Show:     &models.Show{Name: "Morning", Description: "News", Color: "#FFF"},
+	}
+	// Instance host takes precedence.
+	inst.Host = &models.User{Email: "host@station.fm"}
+	inst.Show.Host = &models.User{Email: "showhost@station.fm"}
+	p := s.instanceToPayload(inst)
+	if p.ID != "inst1" || p.Name != "Morning" || p.HostName != "host@station.fm" {
+		t.Fatalf("payload = %+v", p)
+	}
+
+	// Falls back to the show's host when the instance has none.
+	inst.Host = nil
+	if p := s.instanceToPayload(inst); p.HostName != "showhost@station.fm" {
+		t.Fatalf("expected show-host fallback, got %q", p.HostName)
+	}
+}
+
+func TestSendWebhook_DeliversSignedAndLogs(t *testing.T) {
+	svc, db := testService(t)
+
+	var gotSig, gotEvent string
+	var gotBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotSig = r.Header.Get("X-Grimnir-Signature")
+		gotEvent = r.Header.Get("X-Grimnir-Event")
+		gotBody, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	wh := models.WebhookTarget{ID: "wh1", StationID: "st1", URL: srv.URL, Secret: "sk", Active: true}
+	start := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	current := &models.ShowInstance{ID: "i1", StartsAt: start, EndsAt: start.Add(time.Hour), Show: &models.Show{Name: "Morning"}}
+
+	svc.sendWebhook(t.Context(), wh, EventShowStart, current, nil)
+
+	if gotEvent != EventShowStart {
+		t.Fatalf("event header = %q", gotEvent)
+	}
+	// Signature header must be the HMAC of the exact delivered body.
+	mac := hmac.New(sha256.New, []byte("sk"))
+	mac.Write(gotBody)
+	want := "sha256=" + hex.EncodeToString(mac.Sum(nil))
+	if gotSig != want {
+		t.Fatalf("signature = %q, want %q", gotSig, want)
+	}
+
+	// A delivery row is recorded with the 200 status.
+	var log models.WebhookLog
+	if err := db.First(&log, "target_id = ?", "wh1").Error; err != nil {
+		t.Fatalf("expected a delivery log: %v", err)
+	}
+	if log.StatusCode != http.StatusOK || log.Event != EventShowStart {
+		t.Fatalf("delivery log = %+v", log)
+	}
+}
+
+func TestTestWebhook(t *testing.T) {
+	svc, _ := testService(t)
+
+	ok := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Grimnir-Event") != "test" {
+			t.Errorf("expected test event header")
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer ok.Close()
+	if err := svc.TestWebhook(&models.WebhookTarget{URL: ok.URL, Secret: "s"}); err != nil {
+		t.Fatalf("TestWebhook on 204 should succeed: %v", err)
+	}
+
+	bad := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer bad.Close()
+	if err := svc.TestWebhook(&models.WebhookTarget{URL: bad.URL}); err == nil {
+		t.Fatal("TestWebhook on 500 should error")
+	}
+
+	if err := svc.TestWebhook(&models.WebhookTarget{URL: "http://127.0.0.1:0"}); err == nil {
+		t.Fatal("TestWebhook to an unreachable URL should error")
+	}
+}
+
+func TestGetNextShow(t *testing.T) {
+	svc, db := testService(t)
+	base := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	db.Create(&models.Show{ID: "sh1", StationID: "st1", Name: "Later"})
+	db.Create(&models.ShowInstance{ID: "n1", ShowID: "sh1", StationID: "st1", StartsAt: base.Add(2 * time.Hour), EndsAt: base.Add(3 * time.Hour), Status: models.ShowInstanceScheduled})
+
+	if next := svc.getNextShow("st1", base); next == nil || next.ID != "n1" {
+		t.Fatalf("expected next show n1, got %+v", next)
+	}
+	if next := svc.getNextShow("st1", base.Add(10*time.Hour)); next != nil {
+		t.Fatalf("expected no next show after everything, got %+v", next)
+	}
+}
+
+func TestHandleShowEvent(t *testing.T) {
+	svc, db := testService(t)
+	base := time.Date(2026, 1, 1, 9, 0, 0, 0, time.UTC)
+	db.Create(&models.Show{ID: "sh1", StationID: "st1", Name: "Morning"})
+	db.Create(&models.ShowInstance{ID: "i1", ShowID: "sh1", StationID: "st1", StartsAt: base, EndsAt: base.Add(time.Hour), Status: models.ShowInstanceScheduled})
+
+	// No station_id in the payload => early return, no panic.
+	svc.handleShowEvent(t.Context(), events.Payload{}, EventShowStart)
+
+	// With a valid instance and no webhook targets, it resolves the instance and
+	// next show then fires zero webhooks (deterministic, no goroutines spawned).
+	svc.handleShowEvent(t.Context(), events.Payload{"station_id": "st1", "instance_id": "i1"}, EventShowStart)
+
+	// Missing instance still resolves via the now-based next-show lookup.
+	svc.handleShowEvent(t.Context(), events.Payload{"station_id": "st1"}, EventShowEnd)
+}
+
+func TestCheckTransitions_TracksActiveShow(t *testing.T) {
+	svc, db := testService(t)
+	now := time.Now()
+	db.Create(&models.Station{ID: "st1", Name: "Rock", Public: true})
+	db.Create(&models.Show{ID: "sh1", StationID: "st1", Name: "On Air"})
+	db.Create(&models.ShowInstance{ID: "cur", ShowID: "sh1", StationID: "st1", StartsAt: now.Add(-time.Hour), EndsAt: now.Add(time.Hour), Status: models.ShowInstanceScheduled})
+
+	active := map[string]string{}
+	svc.checkTransitions(t.Context(), active)
+	if active["st1"] != "cur" {
+		t.Fatalf("active show for st1 = %q, want cur", active["st1"])
+	}
+
+	// No change on a second pass.
+	svc.checkTransitions(t.Context(), active)
+	if active["st1"] != "cur" {
+		t.Fatalf("active show changed unexpectedly to %q", active["st1"])
+	}
+}


### PR DESCRIPTION
Part of #255. First batch: knock out four packages that shipped with **zero** test files, using genuine behavioral tests rather than line-padding.

| package | before | after |
|---|---|---|
| `internal/logbuffer` | 0% | 89.2% |
| `internal/schedule` | 0% | 91.0% |
| `internal/scheduling` | 0% | 79.2% |
| `internal/webhooks` | 0% | 67.8% |

Total statement coverage: **55.15% → 57.00%**.

## What's tested

- **logbuffer** — ring-buffer wraparound/eviction, `Query` across every filter (level, component, station, search, since, limit, descending), the station-UUID heuristic across key variants, per-station buffer mirroring, and the zerolog JSON `Writer` including `station_id` normalization.
- **schedule** — iCal escape/unescape round-trips, time parse/format (TZID stripping, all three formats), multi-event parsing, plus DB-backed `ExportToICal` / `ImportFromICal` (conflict + skip paths) and `ExportToPDF` on in-memory sqlite.
- **scheduling** — overlap / gap / min-duration / max-duration / max-consecutive rule checks, the cross-station DJ double-booking query, rule dispatch, and `Validate` / `ValidateItem` end to end.
- **webhooks** — HMAC-SHA256 signature verified against the exact delivered body, event-subscription matching, instance→payload host precedence, and delivery + `TestWebhook` over httptest (2xx / 5xx / unreachable).

Test-only; no runtime code changed, so no version bump. The service-layer targets #255 names (mediaengine supervisor/crossfade, storage eviction, harbor lifecycle, live ingress, client bufconn) follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)