### PR TITLE
test(coverage): live-ingress lifecycle + storage monitor (#255)

### DIFF
--- a/internal/live/service_lifecycle_test.go
+++ b/internal/live/service_lifecycle_test.go
@@ -1,0 +1,275 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package live
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/friendsincode/grimnir_radio/internal/events"
+	"github.com/friendsincode/grimnir_radio/internal/models"
+	"github.com/friendsincode/grimnir_radio/internal/priority"
+	"github.com/google/uuid"
+	"github.com/rs/zerolog"
+	"gorm.io/gorm"
+)
+
+func newLiveService(t *testing.T) (*Service, *gorm.DB, *events.Bus) {
+	t.Helper()
+	db := setupTestDB(t)
+	bus := events.NewBus()
+	svc := NewService(db, priority.NewService(db, bus, zerolog.Nop()), bus, zerolog.Nop())
+	return svc, db, bus
+}
+
+// ---------------------------------------------------------------------------
+// GenerateToken
+// ---------------------------------------------------------------------------
+
+func TestGenerateToken(t *testing.T) {
+	svc, db, _ := newLiveService(t)
+	station := createTestStation(t, db)
+
+	token, err := svc.GenerateToken(context.Background(), GenerateTokenRequest{
+		StationID: station.ID,
+		MountID:   uuid.NewString(),
+		UserID:    uuid.NewString(),
+		Username:  "dj-nova",
+		Priority:  models.PriorityLiveOverride,
+		ExpiresIn: time.Hour,
+	})
+	if err != nil {
+		t.Fatalf("GenerateToken: %v", err)
+	}
+	if len(token) != 64 { // 32 random bytes hex-encoded
+		t.Fatalf("token length = %d, want 64", len(token))
+	}
+
+	var session models.LiveSession
+	if err := db.First(&session, "token = ?", token).Error; err != nil {
+		t.Fatalf("session not persisted: %v", err)
+	}
+	if session.TokenUsed || session.Active {
+		t.Fatalf("fresh session should be unused and inactive: %+v", session)
+	}
+	if session.Username != "dj-nova" {
+		t.Fatalf("username = %q", session.Username)
+	}
+}
+
+func TestGenerateToken_InvalidPriority(t *testing.T) {
+	svc, db, _ := newLiveService(t)
+	station := createTestStation(t, db)
+	_, err := svc.GenerateToken(context.Background(), GenerateTokenRequest{
+		StationID: station.ID,
+		Priority:  models.PriorityAutomation, // not a live priority
+	})
+	if err == nil {
+		t.Fatal("expected error for non-live priority")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AuthorizeSource
+// ---------------------------------------------------------------------------
+
+func TestAuthorizeSource(t *testing.T) {
+	svc, db, _ := newLiveService(t)
+	station := createTestStation(t, db)
+	mountID := uuid.NewString()
+	token, err := svc.GenerateToken(context.Background(), GenerateTokenRequest{
+		StationID: station.ID, MountID: mountID, UserID: uuid.NewString(), Username: "dj", Priority: models.PriorityLiveScheduled,
+	})
+	if err != nil {
+		t.Fatalf("gen: %v", err)
+	}
+
+	ok, err := svc.AuthorizeSource(context.Background(), station.ID, mountID, token)
+	if err != nil || !ok {
+		t.Fatalf("authorize valid token: ok=%v err=%v", ok, err)
+	}
+
+	ok, err = svc.AuthorizeSource(context.Background(), station.ID, mountID, "wrong-token")
+	if ok || err != ErrInvalidToken {
+		t.Fatalf("authorize bad token: ok=%v err=%v, want false/ErrInvalidToken", ok, err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HandleConnect / HandleDisconnect
+// ---------------------------------------------------------------------------
+
+func seedConnectableSession(t *testing.T, db *gorm.DB, stationID, mountID, token string, prio models.PriorityLevel) *models.LiveSession {
+	t.Helper()
+	session := &models.LiveSession{
+		ID:          uuid.NewString(),
+		StationID:   stationID,
+		MountID:     mountID,
+		UserID:      uuid.NewString(),
+		Username:    "dj-live",
+		Priority:    prio,
+		Token:       token,
+		ConnectedAt: time.Now(),
+		Metadata:    make(map[string]any),
+	}
+	if err := db.Create(session).Error; err != nil {
+		t.Fatalf("seed session: %v", err)
+	}
+	return session
+}
+
+func TestHandleConnect_Override(t *testing.T) {
+	svc, db, _ := newLiveService(t)
+	station := createTestStation(t, db)
+	mountID := uuid.NewString()
+	sess := seedConnectableSession(t, db, station.ID, mountID, "tok-override", models.PriorityLiveOverride)
+
+	got, err := svc.HandleConnect(context.Background(), ConnectRequest{
+		StationID: station.ID, MountID: mountID, Token: "tok-override",
+		SourceIP: "203.0.113.5", SourcePort: 8000, UserAgent: "butt/1.0",
+	})
+	if err != nil {
+		t.Fatalf("HandleConnect: %v", err)
+	}
+	if !got.Active || got.SourceIP != "203.0.113.5" || got.SourcePort != 8000 {
+		t.Fatalf("session not updated on connect: %+v", got)
+	}
+	if got.ID != sess.ID {
+		t.Fatalf("returned wrong session %s", got.ID)
+	}
+}
+
+func TestHandleConnect_ScheduledAndAutoRecord(t *testing.T) {
+	svc, db, bus := newLiveService(t)
+	// Station with auto-record on.
+	station := &models.Station{ID: uuid.NewString(), Name: "Auto", RecordingAutoRecord: true}
+	if err := db.Create(station).Error; err != nil {
+		t.Fatalf("create station: %v", err)
+	}
+	mountID := uuid.NewString()
+	seedConnectableSession(t, db, station.ID, mountID, "tok-sched", models.PriorityLiveScheduled)
+
+	autoRec := bus.Subscribe(events.EventRecordingAutoStart)
+
+	if _, err := svc.HandleConnect(context.Background(), ConnectRequest{
+		StationID: station.ID, MountID: mountID, Token: "tok-sched",
+	}); err != nil {
+		t.Fatalf("HandleConnect scheduled: %v", err)
+	}
+
+	select {
+	case payload := <-autoRec:
+		if payload["station_id"] != station.ID {
+			t.Fatalf("auto-record event station = %v", payload["station_id"])
+		}
+	case <-time.After(200 * time.Millisecond):
+		t.Fatal("expected an auto-record event for the auto-record station")
+	}
+}
+
+func TestHandleConnect_SessionNotFound(t *testing.T) {
+	svc, db, _ := newLiveService(t)
+	station := createTestStation(t, db)
+	_, err := svc.HandleConnect(context.Background(), ConnectRequest{
+		StationID: station.ID, MountID: uuid.NewString(), Token: "nope",
+	})
+	if err != ErrSessionNotFound {
+		t.Fatalf("err = %v, want ErrSessionNotFound", err)
+	}
+}
+
+func TestHandleDisconnect(t *testing.T) {
+	svc, db, _ := newLiveService(t)
+	station := createTestStation(t, db)
+	mountID := uuid.NewString()
+	sess := seedConnectableSession(t, db, station.ID, mountID, "tok-dc", models.PriorityLiveOverride)
+	// Connect first so there's priority state to release.
+	if _, err := svc.HandleConnect(context.Background(), ConnectRequest{StationID: station.ID, MountID: mountID, Token: "tok-dc"}); err != nil {
+		t.Fatalf("connect: %v", err)
+	}
+
+	if err := svc.HandleDisconnect(context.Background(), sess.ID); err != nil {
+		t.Fatalf("HandleDisconnect: %v", err)
+	}
+
+	var reloaded models.LiveSession
+	db.First(&reloaded, "id = ?", sess.ID)
+	if reloaded.Active {
+		t.Fatal("session should be inactive after disconnect")
+	}
+	if reloaded.DisconnectedAt == nil {
+		t.Fatal("DisconnectedAt should be set")
+	}
+}
+
+func TestHandleDisconnect_NotFound(t *testing.T) {
+	svc, _, _ := newLiveService(t)
+	if err := svc.HandleDisconnect(context.Background(), "missing"); err != ErrSessionNotFound {
+		t.Fatalf("err = %v, want ErrSessionNotFound", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GetActiveSessions / GetSession
+// ---------------------------------------------------------------------------
+
+func TestGetActiveSessions(t *testing.T) {
+	svc, db, _ := newLiveService(t)
+	stA := &models.Station{ID: uuid.NewString(), Name: "Station A"}
+	stB := &models.Station{ID: uuid.NewString(), Name: "Station B"}
+	if err := db.Create(stA).Error; err != nil {
+		t.Fatalf("create stA: %v", err)
+	}
+	if err := db.Create(stB).Error; err != nil {
+		t.Fatalf("create stB: %v", err)
+	}
+	// Two active (one per station) + one inactive.
+	mkSession := func(stationID, token string, active bool) {
+		s := &models.LiveSession{
+			ID: uuid.NewString(), StationID: stationID, MountID: uuid.NewString(),
+			UserID: uuid.NewString(), Username: "dj", Priority: models.PriorityLiveOverride,
+			Token: token, Active: active, ConnectedAt: time.Now(), Metadata: map[string]any{},
+		}
+		if err := db.Create(s).Error; err != nil {
+			t.Fatalf("create session %s: %v", token, err)
+		}
+	}
+	mkSession(stA.ID, "tok-a", true)
+	mkSession(stB.ID, "tok-b", true)
+	mkSession(stA.ID, "tok-inactive", false)
+
+	all, err := svc.GetActiveSessions(context.Background(), "")
+	if err != nil {
+		t.Fatalf("all: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("active across all stations = %d, want 2", len(all))
+	}
+
+	scoped, err := svc.GetActiveSessions(context.Background(), stA.ID)
+	if err != nil {
+		t.Fatalf("scoped: %v", err)
+	}
+	if len(scoped) != 1 || scoped[0].StationID != stA.ID {
+		t.Fatalf("scoped active = %+v", scoped)
+	}
+}
+
+func TestGetSession(t *testing.T) {
+	svc, db, _ := newLiveService(t)
+	station := createTestStation(t, db)
+	sess := createTestSession(t, db, station.ID, models.PriorityLiveOverride)
+
+	got, err := svc.GetSession(context.Background(), sess.ID)
+	if err != nil || got.ID != sess.ID {
+		t.Fatalf("GetSession: got=%v err=%v", got, err)
+	}
+	if _, err := svc.GetSession(context.Background(), "missing"); err != ErrSessionNotFound {
+		t.Fatalf("err = %v, want ErrSessionNotFound", err)
+	}
+}

--- a/internal/storage/monitor.go
+++ b/internal/storage/monitor.go
@@ -57,6 +57,10 @@ type Monitor struct {
 
 	mu                sync.Mutex
 	lastNotifiedLevel string // severity of the last notification sent
+
+	// usageFn reads filesystem usage; defaults to diskUsage and is overridable
+	// in tests to exercise the threshold-escalation state machine deterministically.
+	usageFn func(path string) (total, free uint64, usedPct float64, err error)
 }
 
 // NewMonitor creates a new storage monitor.
@@ -65,9 +69,10 @@ func NewMonitor(db *gorm.DB, cfg MonitorConfig, logger zerolog.Logger) *Monitor 
 		cfg.CheckInterval = 30 * time.Minute
 	}
 	return &Monitor{
-		db:     db,
-		cfg:    cfg,
-		logger: logger.With().Str("component", "storage-monitor").Logger(),
+		db:      db,
+		cfg:     cfg,
+		logger:  logger.With().Str("component", "storage-monitor").Logger(),
+		usageFn: diskUsage,
 	}
 }
 
@@ -112,7 +117,7 @@ func diskUsage(path string) (total, free uint64, usedPct float64, err error) {
 }
 
 func (m *Monitor) check(ctx context.Context) {
-	total, free, usedPct, err := diskUsage(m.cfg.MediaRoot)
+	total, free, usedPct, err := m.usageFn(m.cfg.MediaRoot)
 	if err != nil {
 		m.logger.Error().Err(err).Msg("failed to check disk usage")
 		return

--- a/internal/storage/monitor_check_test.go
+++ b/internal/storage/monitor_check_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package storage
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+func monitorTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.User{}, &models.Notification{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func seedAdmin(t *testing.T, db *gorm.DB, id string) {
+	t.Helper()
+	if err := db.Create(&models.User{ID: id, Email: id + "@grimnir.fm", Password: "x", PlatformRole: models.PlatformRoleAdmin}).Error; err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+}
+
+// fakeUsage returns a usageFn reporting a fixed used-percent.
+func fakeUsage(pct float64) func(string) (uint64, uint64, float64, error) {
+	return func(string) (uint64, uint64, float64, error) {
+		const total = uint64(1000)
+		used := uint64(pct * 10)
+		return total, total - used, pct, nil
+	}
+}
+
+func countNotifications(t *testing.T, db *gorm.DB) int64 {
+	t.Helper()
+	var n int64
+	db.Model(&models.Notification{}).Count(&n)
+	return n
+}
+
+func TestNewMonitor_DefaultInterval(t *testing.T) {
+	m := NewMonitor(monitorTestDB(t), MonitorConfig{}, zerolog.Nop())
+	if m.cfg.CheckInterval != 30*time.Minute {
+		t.Fatalf("default interval = %v, want 30m", m.cfg.CheckInterval)
+	}
+	if m.usageFn == nil {
+		t.Fatal("usageFn should default to diskUsage")
+	}
+}
+
+func TestCheck_NotifiesOncePerSeverity(t *testing.T) {
+	db := monitorTestDB(t)
+	seedAdmin(t, db, "a1")
+	seedAdmin(t, db, "a2")
+	m := NewMonitor(db, MonitorConfig{MediaRoot: "/media"}, zerolog.Nop())
+	ctx := context.Background()
+
+	// Cross the warning threshold (>=80): one notification per admin.
+	m.usageFn = fakeUsage(85)
+	m.check(ctx)
+	if got := countNotifications(t, db); got != 2 {
+		t.Fatalf("after warning: %d notifications, want 2", got)
+	}
+	if m.lastNotifiedLevel != severityWarning {
+		t.Fatalf("level = %q, want warning", m.lastNotifiedLevel)
+	}
+
+	// Still in the warning band: no additional notifications (notify-once).
+	m.usageFn = fakeUsage(83)
+	m.check(ctx)
+	if got := countNotifications(t, db); got != 2 {
+		t.Fatalf("re-check same band: %d notifications, want still 2", got)
+	}
+}
+
+func TestCheck_EscalatesAndResets(t *testing.T) {
+	db := monitorTestDB(t)
+	seedAdmin(t, db, "a1")
+	m := NewMonitor(db, MonitorConfig{MediaRoot: "/media"}, zerolog.Nop())
+	ctx := context.Background()
+
+	m.usageFn = fakeUsage(85) // warning
+	m.check(ctx)
+	m.usageFn = fakeUsage(92) // critical -> escalates
+	m.check(ctx)
+	m.usageFn = fakeUsage(96) // emergency -> escalates
+	m.check(ctx)
+	if got := countNotifications(t, db); got != 3 {
+		t.Fatalf("escalation should notify 3 times, got %d", got)
+	}
+	if m.lastNotifiedLevel != severityEmergency {
+		t.Fatalf("level = %q, want emergency", m.lastNotifiedLevel)
+	}
+
+	// Drop below all thresholds: state resets so a later rise re-notifies.
+	m.usageFn = fakeUsage(50)
+	m.check(ctx)
+	if m.lastNotifiedLevel != "" {
+		t.Fatalf("level after reset = %q, want empty", m.lastNotifiedLevel)
+	}
+	m.usageFn = fakeUsage(85)
+	m.check(ctx)
+	if got := countNotifications(t, db); got != 4 {
+		t.Fatalf("re-notify after reset: got %d, want 4", got)
+	}
+}
+
+func TestCheck_UsageError_NoNotify(t *testing.T) {
+	db := monitorTestDB(t)
+	seedAdmin(t, db, "a1")
+	m := NewMonitor(db, MonitorConfig{MediaRoot: "/media"}, zerolog.Nop())
+	m.usageFn = func(string) (uint64, uint64, float64, error) {
+		return 0, 0, 0, context.DeadlineExceeded
+	}
+	m.check(context.Background())
+	if got := countNotifications(t, db); got != 0 {
+		t.Fatalf("usage error should not notify, got %d", got)
+	}
+}
+
+func TestNotifyAdmins_NoAdmins(t *testing.T) {
+	db := monitorTestDB(t)
+	m := NewMonitor(db, MonitorConfig{}, zerolog.Nop())
+	// No admins seeded -> returns nil, creates nothing.
+	if err := m.notifyAdmins(context.Background(), &defaultThresholds[0], 96, 1000, 40); err != nil {
+		t.Fatalf("notifyAdmins: %v", err)
+	}
+	if got := countNotifications(t, db); got != 0 {
+		t.Fatalf("no admins should create no notifications, got %d", got)
+	}
+}
+
+func TestDiskUsage_RealTempDir(t *testing.T) {
+	total, free, pct, err := diskUsage(t.TempDir())
+	if err != nil {
+		t.Fatalf("diskUsage: %v", err)
+	}
+	if total == 0 {
+		t.Fatal("total should be non-zero on a real filesystem")
+	}
+	if free > total {
+		t.Fatal("free should not exceed total")
+	}
+	if pct < 0 || pct > 100 {
+		t.Fatalf("used pct = %f out of range", pct)
+	}
+	if _, _, _, err := diskUsage("/nonexistent/path/xyz"); err == nil {
+		t.Fatal("expected error for nonexistent path")
+	}
+}


### PR DESCRIPTION
Part of #255. Batch 2: two of the named service-layer targets.

| package | before | after |
|---|---|---|
| `internal/live` | 37.1% | 82.1% |
| `internal/storage` | 17.1% | 81.4% |

Total statement coverage: **57.0% → 57.3%**.

## live — ingress lifecycle

`GenerateToken` (valid + invalid-priority), `AuthorizeSource` (hit + `ErrInvalidToken`), `HandleConnect` for both override and scheduled priority including the auto-record event fan-out, `HandleDisconnect` (marks inactive, sets `DisconnectedAt`, releases priority), plus `GetActiveSessions` station filtering and `GetSession`. Reuses the existing sqlite + `priority.Service` harness from `handover_test.go`.

## storage — disk-threshold monitor

Covers the `check()` threshold state machine end to end: warning → critical → emergency escalation, notify-once-per-severity, and the drop-below-threshold reset that re-arms notifications. Also `notifyAdmins` (no-admins path) and `diskUsage` against a real temp dir.

One behavior-preserving production seam: `monitor.go` gains an unexported `usageFn` field defaulting to `diskUsage`, so tests inject a fixed used-percent instead of depending on the real filesystem's fill level. No runtime behavior change.

Next batch: `mediaengine` supervisor restart/backoff + crossfade timing math.

🤖 Generated with [Claude Code](https://claude.com/claude-code)