### PR TITLE
test(coverage): mediaengine parsers + output builders (#255)

### DIFF
--- a/internal/mediaengine/analyzer_parse_test.go
+++ b/internal/mediaengine/analyzer_parse_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package mediaengine
+
+import (
+	"bytes"
+	"math"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	pb "github.com/friendsincode/grimnir_radio/proto/mediaengine/v1"
+)
+
+func approxEq(a, b, tol float32) bool {
+	return float32(math.Abs(float64(a-b))) <= tol
+}
+
+func TestDBToLinear(t *testing.T) {
+	if got := dbToLinear(0); !approxEq(got, 1, 1e-6) {
+		t.Fatalf("0 dB -> %f, want 1", got)
+	}
+	if got := dbToLinear(-60); got != 0 {
+		t.Fatalf("-60 dB floor -> %f, want 0", got)
+	}
+	if got := dbToLinear(-100); got != 0 {
+		t.Fatalf("below floor -> %f, want 0", got)
+	}
+	// -20 dB is 0.1 linear.
+	if got := dbToLinear(-20); !approxEq(got, 0.1, 1e-4) {
+		t.Fatalf("-20 dB -> %f, want ~0.1", got)
+	}
+	// Positive dB clamps to 1.
+	if got := dbToLinear(6); got != 1 {
+		t.Fatalf("+6 dB should clamp to 1, got %f", got)
+	}
+}
+
+func TestParseLoudnessOutput(t *testing.T) {
+	a := NewAnalyzer(zerolog.Nop())
+	resp := &pb.AnalyzeMediaResponse{}
+	out := "integrated loudness: -14.5 LUFS\nloudness range: 7.2 LU\ntrue peak: -1.3 dBTP"
+	a.parseLoudnessOutput(out, resp)
+
+	if !approxEq(resp.LoudnessLufs, -14.5, 1e-3) {
+		t.Fatalf("LoudnessLufs = %f, want -14.5", resp.LoudnessLufs)
+	}
+	// ReplayGain targets -18 LUFS.
+	if !approxEq(resp.ReplayGain, -3.5, 1e-3) {
+		t.Fatalf("ReplayGain = %f, want -3.5", resp.ReplayGain)
+	}
+	if !approxEq(resp.LoudnessRange, 7.2, 1e-3) {
+		t.Fatalf("LoudnessRange = %f, want 7.2", resp.LoudnessRange)
+	}
+	if !approxEq(resp.TruePeak, -1.3, 1e-3) {
+		t.Fatalf("TruePeak = %f, want -1.3", resp.TruePeak)
+	}
+}
+
+func TestParseLoudnessOutput_NoMatches(t *testing.T) {
+	a := NewAnalyzer(zerolog.Nop())
+	resp := &pb.AnalyzeMediaResponse{}
+	a.parseLoudnessOutput("nothing useful here", resp)
+	if resp.LoudnessLufs != 0 || resp.TruePeak != 0 {
+		t.Fatalf("unmatched output should leave fields zero: %+v", resp)
+	}
+}
+
+func TestParseWaveformOutputFromBuffer(t *testing.T) {
+	a := NewAnalyzer(zerolog.Nop())
+	// Two frames of peak+rms; values are in dB and get converted to 0-1 linear.
+	buf := bytes.NewBufferString(
+		"peak=(double){ 0.0, -6.0 } rms=(double){ -20.0, -20.0 }\n" +
+			"peak=(double){ -6.0, 0.0 } rms=(double){ -60.0, -20.0 }\n",
+	)
+	resp := &pb.GenerateWaveformResponse{}
+	a.parseWaveformOutputFromBuffer(buf, resp, pb.WaveformType_WAVEFORM_TYPE_BOTH)
+
+	if len(resp.PeakLeft) != 2 || len(resp.RmsLeft) != 2 {
+		t.Fatalf("expected 2 frames each, got peak=%d rms=%d", len(resp.PeakLeft), len(resp.RmsLeft))
+	}
+	// 0 dB -> 1.0 linear.
+	if !approxEq(resp.PeakLeft[0], 1, 1e-4) {
+		t.Fatalf("PeakLeft[0] = %f, want 1", resp.PeakLeft[0])
+	}
+	// -60 dB floor -> 0.
+	if resp.RmsLeft[1] != 0 {
+		t.Fatalf("RmsLeft[1] = %f, want 0 (floor)", resp.RmsLeft[1])
+	}
+}
+
+func TestParseWaveformOutputFromBuffer_PeakOnly(t *testing.T) {
+	a := NewAnalyzer(zerolog.Nop())
+	buf := bytes.NewBufferString("peak=(double){ 0.0, 0.0 } rms=(double){ -20.0, -20.0 }\n")
+	resp := &pb.GenerateWaveformResponse{}
+	a.parseWaveformOutputFromBuffer(buf, resp, pb.WaveformType_WAVEFORM_TYPE_PEAK)
+
+	if len(resp.PeakLeft) != 1 {
+		t.Fatalf("expected 1 peak frame, got %d", len(resp.PeakLeft))
+	}
+	if len(resp.RmsLeft) != 0 {
+		t.Fatalf("peak-only should skip rms, got %d rms frames", len(resp.RmsLeft))
+	}
+}

--- a/internal/mediaengine/encoder_output_test.go
+++ b/internal/mediaengine/encoder_output_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package mediaengine
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildHTTPOutput(t *testing.T) {
+	eb := NewEncoderBuilder(EncoderConfig{OutputType: OutputTypeHTTP, OutputURL: "http://edge.example/stream"})
+	got, err := eb.buildOutput()
+	if err != nil {
+		t.Fatalf("buildOutput: %v", err)
+	}
+	if got != `souphttpclientsink location="http://edge.example/stream"` {
+		t.Fatalf("http output = %q", got)
+	}
+}
+
+func TestBuildRTPOutput_Defaults(t *testing.T) {
+	// Zero RTP fields fall back to 127.0.0.1:5004 and Opus payload type 111.
+	eb := NewEncoderBuilder(EncoderConfig{OutputType: OutputTypeRTP})
+	got, err := eb.buildOutput()
+	if err != nil {
+		t.Fatalf("buildOutput: %v", err)
+	}
+	want := "rtpopuspay pt=111 ! udpsink host=127.0.0.1 port=5004"
+	if got != want {
+		t.Fatalf("rtp default output = %q, want %q", got, want)
+	}
+}
+
+func TestBuildRTPOutput_Explicit(t *testing.T) {
+	eb := NewEncoderBuilder(EncoderConfig{
+		OutputType:     OutputTypeRTP,
+		RTPHost:        "10.0.0.9",
+		RTPPort:        6000,
+		RTPPayloadType: 96,
+	})
+	got, err := eb.buildOutput()
+	if err != nil {
+		t.Fatalf("buildOutput: %v", err)
+	}
+	for _, want := range []string{"pt=96", "host=10.0.0.9", "port=6000"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("rtp output %q missing %q", got, want)
+		}
+	}
+}
+
+func TestBuildOutput_UnsupportedType(t *testing.T) {
+	eb := NewEncoderBuilder(EncoderConfig{OutputType: OutputType("carrier-pigeon")})
+	if _, err := eb.buildOutput(); err == nil {
+		t.Fatal("expected error for unsupported output type")
+	}
+}


### PR DESCRIPTION
Part of #255. Batch 3: the gstreamer-free helpers in the media engine that had no direct tests.

`internal/mediaengine`: **70.3% → 73.2%**. Total statement coverage **57.3% → 57.4%**.

## analyzer.go
- `dbToLinear` — 0 dB → 1, the -60 dB floor → 0, -20 dB → ~0.1, positive dB clamps to 1.
- `parseLoudnessOutput` — integrated LUFS, replay-gain derivation against the -18 LUFS target, loudness range, true peak, plus the no-match path.
- `parseWaveformOutputFromBuffer` — peak+rms frame parsing, dB→linear conversion, and the per-`WaveformType` field gating (peak-only skips rms).

## encoder.go
- `buildOutput` dispatch for HTTP and RTP, the RTP default fallbacks (`127.0.0.1:5004`, Opus payload type 111), and the unsupported-output-type error.

Test-only. The remaining mediaengine gaps (`BatchAnalyze`, `RouteLive`, `StreamTelemetry`, live input teardown) need a real gstreamer/gRPC stream and belong in the integration tier, not unit tests.