### PR TITLE
test(coverage): underwriting + audit services (58.1%)

### DIFF
--- a/internal/audit/service_test.go
+++ b/internal/audit/service_test.go
@@ -1,0 +1,156 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package audit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/events"
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+func newAuditService(t *testing.T) (*Service, *gorm.DB, *events.Bus) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.AuditLog{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	bus := events.NewBus()
+	return NewService(db, bus, zerolog.Nop()), db, bus
+}
+
+func TestLog_FillsDefaults(t *testing.T) {
+	svc, db, _ := newAuditService(t)
+	entry := &models.AuditLog{Action: models.AuditActionStationCreate}
+	if err := svc.Log(context.Background(), entry); err != nil {
+		t.Fatalf("log: %v", err)
+	}
+	if entry.ID == "" || entry.Timestamp.IsZero() || entry.CreatedAt.IsZero() || entry.Details == nil {
+		t.Fatalf("Log did not fill defaults: %+v", entry)
+	}
+	var n int64
+	db.Model(&models.AuditLog{}).Count(&n)
+	if n != 1 {
+		t.Fatalf("expected 1 row, got %d", n)
+	}
+}
+
+func TestLogAuditEntry_ExtractsPayload(t *testing.T) {
+	svc, db, _ := newAuditService(t)
+	svc.logAuditEntry(context.Background(), models.AuditActionAPIKeyCreate, events.Payload{
+		"user_id":       "u1",
+		"user_email":    "dj@grimnir.fm",
+		"station_id":    "st1",
+		"resource_type": "apikey",
+		"resource_id":   "key1",
+		"ip_address":    "203.0.113.1",
+		"user_agent":    "curl/8",
+		"extra_field":   "kept-in-details",
+	})
+
+	var log models.AuditLog
+	if err := db.First(&log, "action = ?", models.AuditActionAPIKeyCreate).Error; err != nil {
+		t.Fatalf("no audit row: %v", err)
+	}
+	if log.UserID == nil || *log.UserID != "u1" {
+		t.Fatalf("user_id not extracted: %+v", log.UserID)
+	}
+	if log.StationID == nil || *log.StationID != "st1" {
+		t.Fatalf("station_id not extracted: %+v", log.StationID)
+	}
+	if log.UserEmail != "dj@grimnir.fm" || log.ResourceType != "apikey" || log.ResourceID != "key1" {
+		t.Fatalf("scalar fields wrong: %+v", log)
+	}
+	if log.IPAddress != "203.0.113.1" || log.UserAgent != "curl/8" {
+		t.Fatalf("request context wrong: %+v", log)
+	}
+	// Known keys are stripped from Details; unknown keys are kept.
+	if _, ok := log.Details["user_id"]; ok {
+		t.Fatal("user_id should not leak into Details")
+	}
+	if log.Details["extra_field"] != "kept-in-details" {
+		t.Fatalf("extra field missing from Details: %+v", log.Details)
+	}
+}
+
+func TestQuery_FiltersAndPagination(t *testing.T) {
+	svc, _, _ := newAuditService(t)
+	ctx := context.Background()
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	u1, st1 := "u1", "st1"
+
+	// 5 entries for u1/st1 with staggered timestamps, 1 for a different user.
+	for i := 0; i < 5; i++ {
+		svc.Log(ctx, &models.AuditLog{UserID: &u1, StationID: &st1, Action: models.AuditActionPlayoutSkip, Timestamp: base.Add(time.Duration(i) * time.Minute)})
+	}
+	other := "u2"
+	svc.Log(ctx, &models.AuditLog{UserID: &other, Action: models.AuditActionStationCreate, Timestamp: base})
+
+	// Filter by user.
+	logs, total, err := svc.Query(ctx, QueryFilters{UserID: &u1})
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if total != 5 || len(logs) != 5 {
+		t.Fatalf("user filter: total=%d len=%d, want 5/5", total, len(logs))
+	}
+	// Most-recent-first ordering.
+	if !logs[0].Timestamp.After(logs[1].Timestamp) {
+		t.Fatal("expected descending timestamp order")
+	}
+
+	// Filter by action.
+	action := models.AuditActionStationCreate
+	_, total, _ = svc.Query(ctx, QueryFilters{Action: &action})
+	if total != 1 {
+		t.Fatalf("action filter total = %d, want 1", total)
+	}
+
+	// Time window filter.
+	start := base.Add(2 * time.Minute)
+	_, total, _ = svc.Query(ctx, QueryFilters{UserID: &u1, StartTime: &start})
+	if total != 3 {
+		t.Fatalf("start-time filter total = %d, want 3", total)
+	}
+
+	// Pagination: limit + offset.
+	page, _, _ := svc.Query(ctx, QueryFilters{UserID: &u1, Limit: 2, Offset: 2})
+	if len(page) != 2 {
+		t.Fatalf("paged len = %d, want 2", len(page))
+	}
+}
+
+func TestStart_LogsSubscribedEvent(t *testing.T) {
+	svc, db, bus := newAuditService(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go svc.Start(ctx)
+
+	// Retry-publish until the subscription is live and a row lands (or timeout).
+	deadline := time.Now().Add(2 * time.Second)
+	var n int64
+	for time.Now().Before(deadline) {
+		bus.Publish(events.EventDJConnect, events.Payload{"user_id": "u1", "station_id": "st1"})
+		time.Sleep(25 * time.Millisecond)
+		db.Model(&models.AuditLog{}).Where("action = ?", models.AuditActionLiveConnect).Count(&n)
+		if n > 0 {
+			break
+		}
+	}
+	if n == 0 {
+		t.Fatal("audit Start did not record the DJ-connect event")
+	}
+}

--- a/internal/underwriting/service_test.go
+++ b/internal/underwriting/service_test.go
@@ -1,0 +1,276 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package underwriting
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+func newTestService(t *testing.T) (*Service, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.Station{}, &models.Show{}, &models.ShowInstance{}, &models.MediaItem{},
+		&models.Sponsor{}, &models.UnderwritingObligation{}, &models.UnderwritingSpot{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewService(db, zerolog.Nop()), db
+}
+
+func ctx() context.Context { return context.Background() }
+
+func TestGetDaypart(t *testing.T) {
+	cases := map[int]models.Daypart{
+		7:  models.DaypartMorning,
+		12: models.DaypartMidday,
+		16: models.DaypartAfternoon,
+		20: models.DaypartEvening,
+		3:  models.DaypartOvernight,
+		0:  models.DaypartOvernight,
+	}
+	for hour, want := range cases {
+		if got := getDaypart(hour); got != want {
+			t.Fatalf("getDaypart(%d) = %s, want %s", hour, got, want)
+		}
+	}
+}
+
+func TestSponsorCRUD(t *testing.T) {
+	svc, _ := newTestService(t)
+	sp := &models.Sponsor{StationID: "st1", Name: "Acme", Active: true}
+	if err := svc.CreateSponsor(ctx(), sp); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if sp.ID == "" {
+		t.Fatal("CreateSponsor should assign an ID")
+	}
+
+	got, err := svc.GetSponsor(ctx(), sp.ID)
+	if err != nil || got.Name != "Acme" {
+		t.Fatalf("get: %v / %+v", err, got)
+	}
+
+	// Second, inactive sponsor to exercise the activeOnly filter. The Active
+	// column defaults to true at insert, so force it off afterward.
+	inactive := &models.Sponsor{StationID: "st1", Name: "Zzz"}
+	svc.CreateSponsor(ctx(), inactive)
+	svc.db.Model(inactive).Update("active", false)
+
+	all, _ := svc.ListSponsors(ctx(), "st1", false)
+	if len(all) != 2 {
+		t.Fatalf("list all = %d, want 2", len(all))
+	}
+	active, _ := svc.ListSponsors(ctx(), "st1", true)
+	if len(active) != 1 || active[0].Name != "Acme" {
+		t.Fatalf("list active = %+v", active)
+	}
+
+	if err := svc.UpdateSponsor(ctx(), sp.ID, map[string]any{"name": "Acme Corp"}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	updated, _ := svc.GetSponsor(ctx(), sp.ID)
+	if updated.Name != "Acme Corp" {
+		t.Fatalf("name after update = %q", updated.Name)
+	}
+
+	if _, err := svc.GetSponsor(ctx(), "missing"); err == nil {
+		t.Fatal("expected error for missing sponsor")
+	}
+}
+
+func TestDeleteSponsor_Cascades(t *testing.T) {
+	svc, db := newTestService(t)
+	sp := &models.Sponsor{StationID: "st1", Name: "Acme", Active: true}
+	svc.CreateSponsor(ctx(), sp)
+	obl := &models.UnderwritingObligation{SponsorID: sp.ID, StationID: "st1", SpotsPerWeek: 3, StartDate: time.Now(), Active: true}
+	svc.CreateObligation(ctx(), obl)
+	svc.ScheduleSpot(ctx(), obl.ID, time.Now(), nil)
+
+	if err := svc.DeleteSponsor(ctx(), sp.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	var sponsors, obligations, spots int64
+	db.Model(&models.Sponsor{}).Count(&sponsors)
+	db.Model(&models.UnderwritingObligation{}).Count(&obligations)
+	db.Model(&models.UnderwritingSpot{}).Count(&spots)
+	if sponsors != 0 || obligations != 0 || spots != 0 {
+		t.Fatalf("cascade left rows: sponsors=%d obligations=%d spots=%d", sponsors, obligations, spots)
+	}
+}
+
+func TestObligationCRUD(t *testing.T) {
+	svc, _ := newTestService(t)
+	obl := &models.UnderwritingObligation{SponsorID: "sp1", StationID: "st1", SpotsPerWeek: 5, StartDate: time.Now(), Active: true}
+	if err := svc.CreateObligation(ctx(), obl); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := svc.GetObligation(ctx(), obl.ID)
+	if err != nil || got.SpotsPerWeek != 5 {
+		t.Fatalf("get: %v / %+v", err, got)
+	}
+
+	// Expired obligation excluded by activeOnly's end_date guard.
+	past := time.Now().AddDate(0, 0, -1)
+	svc.CreateObligation(ctx(), &models.UnderwritingObligation{SponsorID: "sp1", StationID: "st1", SpotsPerWeek: 1, StartDate: time.Now().AddDate(0, 0, -30), EndDate: &past, Active: true})
+
+	active, _ := svc.ListObligations(ctx(), "st1", "", true)
+	if len(active) != 1 {
+		t.Fatalf("active obligations = %d, want 1", len(active))
+	}
+	bySponsor, _ := svc.ListObligations(ctx(), "", "sp1", false)
+	if len(bySponsor) != 2 {
+		t.Fatalf("by sponsor = %d, want 2", len(bySponsor))
+	}
+
+	if err := svc.UpdateObligation(ctx(), obl.ID, map[string]any{"spots_per_week": 8}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if err := svc.DeleteObligation(ctx(), obl.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if _, err := svc.GetObligation(ctx(), obl.ID); err == nil {
+		t.Fatal("expected error after delete")
+	}
+}
+
+func TestSpotLifecycleAndMissed(t *testing.T) {
+	svc, db := newTestService(t)
+	obl := &models.UnderwritingObligation{SponsorID: "sp1", StationID: "st1", SpotsPerWeek: 2, StartDate: time.Now(), Active: true}
+	svc.CreateObligation(ctx(), obl)
+
+	spot, err := svc.ScheduleSpot(ctx(), obl.ID, time.Now(), nil)
+	if err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+	if err := svc.MarkSpotAired(ctx(), spot.ID); err != nil {
+		t.Fatalf("aired: %v", err)
+	}
+	var reloaded models.UnderwritingSpot
+	db.First(&reloaded, "id = ?", spot.ID)
+	if reloaded.Status != models.SpotStatusAired || reloaded.AiredAt == nil {
+		t.Fatalf("spot not marked aired: %+v", reloaded)
+	}
+
+	// A stale scheduled spot gets swept to missed.
+	stale := models.NewUnderwritingSpot(obl.ID, time.Now().Add(-2*time.Hour))
+	db.Create(stale)
+	n, err := svc.CheckMissedSpots(ctx())
+	if err != nil {
+		t.Fatalf("check missed: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("missed swept = %d, want 1", n)
+	}
+
+	// MarkSpotMissed on a fresh spot.
+	fresh, _ := svc.ScheduleSpot(ctx(), obl.ID, time.Now(), nil)
+	if err := svc.MarkSpotMissed(ctx(), fresh.ID); err != nil {
+		t.Fatalf("mark missed: %v", err)
+	}
+}
+
+func TestScheduleWeeklySpots(t *testing.T) {
+	svc, db := newTestService(t)
+	obl := &models.UnderwritingObligation{SponsorID: "sp1", StationID: "st1", SpotsPerWeek: 2, StartDate: time.Now(), Active: true}
+	svc.CreateObligation(ctx(), obl)
+
+	weekStart := time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC) // Monday
+	// Three scheduled instances during the week; only 2 spots needed.
+	for i, h := range []int{8, 12, 20} {
+		db.Create(&models.ShowInstance{
+			ID: string(rune('a'+i)) + "-inst", ShowID: "sh1", StationID: "st1",
+			StartsAt: weekStart.AddDate(0, 0, i).Add(time.Duration(h) * time.Hour),
+			EndsAt:   weekStart.AddDate(0, 0, i).Add(time.Duration(h+1) * time.Hour),
+			Status:   models.ShowInstanceScheduled,
+		})
+	}
+
+	spots, err := svc.ScheduleWeeklySpots(ctx(), "st1", weekStart)
+	if err != nil {
+		t.Fatalf("weekly: %v", err)
+	}
+	if len(spots) != 2 {
+		t.Fatalf("scheduled %d spots, want 2 (capped at SpotsPerWeek)", len(spots))
+	}
+
+	// Re-running the same week schedules nothing more (quota already met).
+	again, _ := svc.ScheduleWeeklySpots(ctx(), "st1", weekStart)
+	if len(again) != 0 {
+		t.Fatalf("re-run scheduled %d, want 0", len(again))
+	}
+}
+
+func TestGetAvailableInstances_DaypartFilter(t *testing.T) {
+	svc, db := newTestService(t)
+	start := time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 7)
+	// One morning (8am) and one evening (20:00) instance.
+	db.Create(&models.ShowInstance{ID: "m", ShowID: "sh1", StationID: "st1", StartsAt: start.Add(8 * time.Hour), EndsAt: start.Add(9 * time.Hour), Status: models.ShowInstanceScheduled})
+	db.Create(&models.ShowInstance{ID: "e", ShowID: "sh1", StationID: "st1", StartsAt: start.Add(20 * time.Hour), EndsAt: start.Add(21 * time.Hour), Status: models.ShowInstanceScheduled})
+
+	got, err := svc.getAvailableInstances(ctx(), "st1", start, end, "morning", "")
+	if err != nil {
+		t.Fatalf("get available: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "m" {
+		t.Fatalf("daypart filter = %+v, want just morning instance", got)
+	}
+}
+
+func TestFulfillmentReport_StatusTiers(t *testing.T) {
+	svc, db := newTestService(t)
+	sp := &models.Sponsor{StationID: "st1", Name: "Acme", Active: true}
+	svc.CreateSponsor(ctx(), sp)
+	obl := &models.UnderwritingObligation{SponsorID: sp.ID, StationID: "st1", Name: "Q1", SpotsPerWeek: 10, StartDate: time.Now(), Active: true}
+	svc.CreateObligation(ctx(), obl)
+
+	periodStart := time.Date(2026, 3, 1, 0, 0, 0, 0, time.UTC)
+	periodEnd := periodStart.AddDate(0, 0, 7) // 1 week => 10 required
+
+	mkSpot := func(status models.SpotStatus, when time.Time) {
+		s := models.NewUnderwritingSpot(obl.ID, when)
+		s.Status = status
+		db.Create(s)
+	}
+	// 9 aired of 10 required => 90% => on_track.
+	for i := 0; i < 9; i++ {
+		mkSpot(models.SpotStatusAired, periodStart.Add(time.Duration(i)*time.Hour))
+	}
+	mkSpot(models.SpotStatusMissed, periodStart)
+
+	report, err := svc.GetFulfillmentReport(ctx(), obl.ID, periodStart, periodEnd)
+	if err != nil {
+		t.Fatalf("report: %v", err)
+	}
+	if report.SpotsRequired != 10 || report.SpotsAired != 9 || report.SpotsMissed != 1 {
+		t.Fatalf("report counts wrong: %+v", report)
+	}
+	if report.Status != "on_track" {
+		t.Fatalf("status = %q, want on_track (90%%)", report.Status)
+	}
+	if report.SponsorName != "Acme" {
+		t.Fatalf("sponsor name = %q", report.SponsorName)
+	}
+
+	// All reports across the station.
+	reports, err := svc.GetAllFulfillmentReports(ctx(), "st1", periodStart, periodEnd)
+	if err != nil || len(reports) != 1 {
+		t.Fatalf("all reports: %v / %d", err, len(reports))
+	}
+}


### PR DESCRIPTION
Part of #255. Batch 4: two more zero-test leaf packages, both sqlite-backed.

| package | before | after |
|---|---|---|
| `internal/underwriting` | 0% | 83.1% |
| `internal/audit` | 0% | 78.3% |

Total statement coverage: **57.4% → 58.1%**.

## underwriting
`getDaypart` bands; full sponsor and obligation CRUD including the `DeleteSponsor` cascade to obligations and spots; the `activeOnly` + end-date filters; spot lifecycle (schedule, mark aired, mark missed, `CheckMissedSpots` grace-period sweep); `ScheduleWeeklySpots` (quota capping + idempotent re-run); the daypart-preference filter in `getAvailableInstances`; and `GetFulfillmentReport` status tiers.

## audit
`Log` default-filling; `logAuditEntry` payload extraction (scalar fields lifted out, unknown keys retained in `Details`); `Query` filters (user / station / action / time) with descending order and limit/offset pagination; and the `Start` event loop recording a published DJ-connect event.

Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)