### PR TITLE
test(coverage): exclude generated proto + landingpage/models/analytics (61.1%)

### DIFF
--- a/internal/analytics/schedule_analytics_test.go
+++ b/internal/analytics/schedule_analytics_test.go
@@ -1,0 +1,112 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package analytics
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+func newScheduleAnalytics(t *testing.T) (*ScheduleAnalyticsService, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.Station{}, &models.Show{}, &models.ShowInstance{},
+		&models.ScheduleAnalytics{}, &models.ScheduleAnalyticsDaily{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewScheduleAnalyticsService(db, zerolog.Nop()), db
+}
+
+func TestDayName(t *testing.T) {
+	want := []string{"Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"}
+	for i, w := range want {
+		if got := dayName(i); got != w {
+			t.Fatalf("dayName(%d) = %q, want %q", i, got, w)
+		}
+	}
+	if dayName(7) != "Unknown" || dayName(-1) != "Unknown" {
+		t.Fatal("out-of-range day should be Unknown")
+	}
+}
+
+func TestMin(t *testing.T) {
+	if min(3, 5) != 3 || min(5, 3) != 3 || min(4, 4) != 4 {
+		t.Fatal("min wrong")
+	}
+}
+
+func TestRecordHourlyStats(t *testing.T) {
+	svc, db := newScheduleAnalytics(t)
+	date := time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)
+	// A show instance covering hour 9 links the analytics row to the show.
+	db.Create(&models.Show{ID: "sh1", StationID: "st1", Name: "Morning"})
+	db.Create(&models.ShowInstance{
+		ID: "i1", ShowID: "sh1", StationID: "st1",
+		StartsAt: date.Add(9 * time.Hour), EndsAt: date.Add(11 * time.Hour), Status: models.ShowInstanceScheduled,
+	})
+
+	err := svc.RecordHourlyStats(context.Background(), "st1", date, 9, HourlyStats{
+		AvgListeners: 42, PeakListeners: 80, TuneIns: 10, TuneOuts: 5, TotalMinutes: 2520,
+	})
+	if err != nil {
+		t.Fatalf("record: %v", err)
+	}
+
+	var row models.ScheduleAnalytics
+	if err := db.First(&row, "station_id = ? AND hour = ?", "st1", 9).Error; err != nil {
+		t.Fatalf("row not created: %v", err)
+	}
+	if row.ShowID == nil || *row.ShowID != "sh1" {
+		t.Fatalf("row should link to the covering show: %+v", row.ShowID)
+	}
+	if row.AvgListeners != 42 || row.PeakListeners != 80 {
+		t.Fatalf("stats not stored: %+v", row)
+	}
+}
+
+func seedHourly(t *testing.T, db *gorm.DB, id, showID string, date time.Time, hour, avg, peak int) {
+	t.Helper()
+	sid := showID
+	row := &models.ScheduleAnalytics{
+		ID: id, StationID: "st1", ShowID: &sid, Date: date, Hour: hour,
+		AvgListeners: avg, PeakListeners: peak, TuneIns: 3, TotalMinutes: avg * 60,
+	}
+	if err := db.Create(row).Error; err != nil {
+		t.Fatalf("seed hourly: %v", err)
+	}
+}
+
+func TestGetShowPerformance(t *testing.T) {
+	svc, db := newScheduleAnalytics(t)
+	date := time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)
+	db.Create(&models.Show{ID: "sh1", StationID: "st1", Name: "Morning Drive"})
+	seedHourly(t, db, "a1", "sh1", date, 9, 40, 70)
+	seedHourly(t, db, "a2", "sh1", date, 10, 60, 90)
+
+	perf, err := svc.GetShowPerformance(context.Background(), "st1", date, date.AddDate(0, 0, 1))
+	if err != nil {
+		t.Fatalf("show performance: %v", err)
+	}
+	if len(perf) != 1 {
+		t.Fatalf("expected 1 show, got %d", len(perf))
+	}
+	if perf[0].ShowName != "Morning Drive" || perf[0].PeakListeners != 90 {
+		t.Fatalf("performance row wrong: %+v", perf[0])
+	}
+}

--- a/internal/landingpage/pure_test.go
+++ b/internal/landingpage/pure_test.go
@@ -1,0 +1,189 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package landingpage
+
+import (
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// themes.go
+// ---------------------------------------------------------------------------
+
+func TestGetTheme(t *testing.T) {
+	first := BuiltInThemes[0]
+	if got := GetTheme(first.ID); got == nil || got.ID != first.ID {
+		t.Fatalf("GetTheme(%q) = %v", first.ID, got)
+	}
+	if GetTheme("no-such-theme") != nil {
+		t.Fatal("unknown theme should return nil")
+	}
+}
+
+func TestGetThemeDefaults_FallsBackToFirst(t *testing.T) {
+	if d := GetThemeDefaults(BuiltInThemes[0].ID); d == nil {
+		t.Fatal("known theme defaults should be non-nil")
+	}
+	// Unknown id falls back to the first built-in theme's defaults, never nil.
+	if d := GetThemeDefaults("bogus"); d == nil {
+		t.Fatal("unknown theme should fall back, not return nil")
+	}
+}
+
+func TestGetPlatformThemeDefaults(t *testing.T) {
+	d := GetPlatformThemeDefaults()
+	if d["theme"] != "daw-dark" {
+		t.Fatalf("platform theme = %v", d["theme"])
+	}
+	if _, ok := d["hero"].(map[string]any); !ok {
+		t.Fatal("platform defaults should carry a hero section")
+	}
+}
+
+func TestMergeConfigAndDeepMerge(t *testing.T) {
+	// nil user config returns the theme defaults unchanged.
+	base := GetThemeDefaults(BuiltInThemes[0].ID)
+	if got := MergeConfig(BuiltInThemes[0].ID, nil); len(got) != len(base) {
+		t.Fatalf("nil user config should return defaults (len %d vs %d)", len(got), len(base))
+	}
+
+	// Deep merge: nested override replaces only the specified leaf.
+	merged := deepMerge(
+		map[string]any{"header": map[string]any{"showLogo": true, "tagline": "old"}, "top": 1},
+		map[string]any{"header": map[string]any{"tagline": "new"}, "extra": 2},
+	)
+	hdr := merged["header"].(map[string]any)
+	if hdr["tagline"] != "new" {
+		t.Fatalf("override leaf not applied: %v", hdr["tagline"])
+	}
+	if hdr["showLogo"] != true {
+		t.Fatal("unspecified base leaf should be preserved")
+	}
+	if merged["top"] != 1 || merged["extra"] != 2 {
+		t.Fatalf("top-level merge wrong: %+v", merged)
+	}
+
+	// A non-map override replaces a map base wholesale.
+	replaced := deepMerge(map[string]any{"k": map[string]any{"a": 1}}, map[string]any{"k": "scalar"})
+	if replaced["k"] != "scalar" {
+		t.Fatalf("scalar override should replace map, got %v", replaced["k"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// widgets.go
+// ---------------------------------------------------------------------------
+
+func TestWidgetDefinitionAndDefaults(t *testing.T) {
+	if def := GetWidgetDefinition(WidgetSchedule); def == nil || def.Type != WidgetSchedule {
+		t.Fatalf("schedule widget definition missing: %v", def)
+	}
+	if GetWidgetDefinition(WidgetType("nope")) != nil {
+		t.Fatal("unknown widget type should be nil")
+	}
+	if d := GetWidgetDefaults(WidgetSchedule); d == nil {
+		t.Fatal("known widget defaults should be non-nil")
+	}
+	// Unknown type returns an empty (non-nil) map.
+	if d := GetWidgetDefaults(WidgetType("nope")); d == nil || len(d) != 0 {
+		t.Fatalf("unknown widget defaults = %v, want empty map", d)
+	}
+}
+
+func TestGetWidgetsByCategory(t *testing.T) {
+	byCat := GetWidgetsByCategory()
+	if len(byCat) == 0 {
+		t.Fatal("expected widgets grouped into at least one category")
+	}
+	total := 0
+	for _, defs := range byCat {
+		total += len(defs)
+	}
+	if total != len(WidgetRegistry) {
+		t.Fatalf("grouped total %d != registry %d", total, len(WidgetRegistry))
+	}
+}
+
+func TestValidateWidgetConfig(t *testing.T) {
+	if err := ValidateWidgetConfig(WidgetConfig{Type: WidgetText}); err != nil {
+		t.Fatalf("valid widget should pass: %v", err)
+	}
+	if err := ValidateWidgetConfig(WidgetConfig{Type: WidgetType("bogus")}); err != ErrInvalidWidgetType {
+		t.Fatalf("invalid widget err = %v, want ErrInvalidWidgetType", err)
+	}
+	if ErrInvalidWidgetType.Error() == "" {
+		t.Fatal("error string should be non-empty")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// renderer.go config helpers
+// ---------------------------------------------------------------------------
+
+func TestConfigHelpers(t *testing.T) {
+	cfg := map[string]any{
+		"b":     true,
+		"iInt":  7,
+		"iF":    float64(9),
+		"i64":   int64(11),
+		"s":     "hi",
+		"other": 1,
+	}
+	if configVal(cfg, "missing", "def") != "def" {
+		t.Fatal("configVal default")
+	}
+	if configVal(cfg, "s", "def") != "hi" {
+		t.Fatal("configVal hit")
+	}
+	if !configBool(cfg, "b", false) || configBool(cfg, "missing", false) {
+		t.Fatal("configBool")
+	}
+	if configBool(cfg, "s", true) != true {
+		t.Fatal("configBool wrong-type falls back to default")
+	}
+	if configInt(cfg, "iInt", 0) != 7 || configInt(cfg, "iF", 0) != 9 || configInt(cfg, "i64", 0) != 11 {
+		t.Fatal("configInt numeric coercion")
+	}
+	if configInt(cfg, "missing", 3) != 3 || configInt(cfg, "s", 3) != 3 {
+		t.Fatal("configInt default")
+	}
+	if configString(cfg, "s", "def") != "hi" || configString(cfg, "b", "def") != "def" {
+		t.Fatal("configString")
+	}
+}
+
+func TestFormatAndTruncateHelpers(t *testing.T) {
+	if got := formatTime(time.Date(2026, 1, 1, 15, 4, 0, 0, time.UTC)); got != "3:04 PM" {
+		t.Fatalf("formatTime = %q", got)
+	}
+	if got := formatDuration(90 * time.Minute); got != "1h 30m" {
+		t.Fatalf("formatDuration hours = %q", got)
+	}
+	if got := formatDuration(45 * time.Minute); got != "45m" {
+		t.Fatalf("formatDuration minutes = %q", got)
+	}
+	if got := truncate("short", 20); got != "short" {
+		t.Fatalf("truncate short = %q", got)
+	}
+	if got := truncate("abcdefghij", 8); got != "abcde..." {
+		t.Fatalf("truncate long = %q", got)
+	}
+}
+
+func TestJSONMarshalHelper(t *testing.T) {
+	if got := jsonMarshal(nil); string(got) != "null" {
+		t.Fatalf("nil -> %q, want null", got)
+	}
+	if got := jsonMarshal(map[string]int{"a": 1}); string(got) != `{"a":1}` {
+		t.Fatalf("map -> %q", got)
+	}
+	// Unmarshalable value (a channel) falls back to "null" rather than erroring.
+	if got := jsonMarshal(make(chan int)); string(got) != "null" {
+		t.Fatalf("unmarshalable -> %q, want null", got)
+	}
+}

--- a/internal/landingpage/service_test.go
+++ b/internal/landingpage/service_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package landingpage
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+func newLPService(t *testing.T) (*Service, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.LandingPage{}, &models.LandingPageVersion{}, &models.LandingPageAsset{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewService(db, nil, t.TempDir(), zerolog.Nop()), db
+}
+
+func bg() context.Context { return context.Background() }
+
+func TestGetOrCreate_Idempotent(t *testing.T) {
+	svc, db := newLPService(t)
+	p1, err := svc.GetOrCreate(bg(), "st1")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if p1.Theme != "default" || p1.PublishedConfig == nil {
+		t.Fatalf("new page not seeded with defaults: %+v", p1)
+	}
+	p2, _ := svc.GetOrCreate(bg(), "st1")
+	if p2.ID != p1.ID {
+		t.Fatal("GetOrCreate should return the existing page, not a new one")
+	}
+	var n int64
+	db.Model(&models.LandingPage{}).Count(&n)
+	if n != 1 {
+		t.Fatalf("expected exactly 1 row, got %d", n)
+	}
+}
+
+func TestGetOrCreatePlatform_AndGetPlatform(t *testing.T) {
+	svc, _ := newLPService(t)
+
+	// GetPlatform before creation returns ErrNotFound.
+	if _, err := svc.GetPlatform(bg()); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("GetPlatform before create = %v, want ErrNotFound", err)
+	}
+
+	p, err := svc.GetOrCreatePlatform(bg())
+	if err != nil {
+		t.Fatalf("create platform: %v", err)
+	}
+	if p.StationID != nil {
+		t.Fatal("platform page should have nil StationID")
+	}
+	// Idempotent.
+	again, _ := svc.GetOrCreatePlatform(bg())
+	if again.ID != p.ID {
+		t.Fatal("platform GetOrCreate not idempotent")
+	}
+	if _, err := svc.GetPlatform(bg()); err != nil {
+		t.Fatalf("GetPlatform after create: %v", err)
+	}
+}
+
+func TestConfigGetters(t *testing.T) {
+	svc, _ := newLPService(t)
+
+	// Station getters seed via GetOrCreate; with no draft, draft falls back to published.
+	pub, err := svc.GetPublished(bg(), "st1")
+	if err != nil || pub == nil {
+		t.Fatalf("GetPublished: %v", err)
+	}
+	draft, err := svc.GetDraft(bg(), "st1")
+	if err != nil {
+		t.Fatalf("GetDraft: %v", err)
+	}
+	if len(draft) != len(pub) {
+		t.Fatal("draft should fall back to published when no draft is set")
+	}
+
+	// Platform variants.
+	if _, err := svc.GetPlatformPublished(bg()); err != nil {
+		t.Fatalf("GetPlatformPublished: %v", err)
+	}
+	if _, err := svc.GetPlatformDraft(bg()); err != nil {
+		t.Fatalf("GetPlatformDraft: %v", err)
+	}
+}
+
+func TestGet_NotFoundThenFound(t *testing.T) {
+	svc, _ := newLPService(t)
+	if _, err := svc.Get(bg(), "missing"); !errors.Is(err, ErrNotFound) {
+		t.Fatalf("Get missing = %v, want ErrNotFound", err)
+	}
+	svc.GetOrCreate(bg(), "st1")
+	if _, err := svc.Get(bg(), "st1"); err != nil {
+		t.Fatalf("Get existing: %v", err)
+	}
+}
+
+func TestUpdateThemeCSSHead(t *testing.T) {
+	svc, db := newLPService(t)
+	svc.GetOrCreate(bg(), "st1")
+
+	// Unknown theme is rejected.
+	if err := svc.UpdateTheme(bg(), "st1", "no-such-theme"); err == nil {
+		t.Fatal("expected error for unknown theme")
+	}
+	valid := BuiltInThemes[0].ID
+	if err := svc.UpdateTheme(bg(), "st1", valid); err != nil {
+		t.Fatalf("update theme: %v", err)
+	}
+	if err := svc.UpdateCustomCSS(bg(), "st1", "body{color:red}"); err != nil {
+		t.Fatalf("update css: %v", err)
+	}
+	if err := svc.UpdateCustomHead(bg(), "st1", "<meta>"); err != nil {
+		t.Fatalf("update head: %v", err)
+	}
+
+	var page models.LandingPage
+	db.Where("station_id = ?", "st1").First(&page)
+	if page.Theme != valid || page.CustomCSS != "body{color:red}" || page.CustomHead != "<meta>" {
+		t.Fatalf("updates not persisted: %+v", page)
+	}
+}
+
+func TestListAndGetTheme(t *testing.T) {
+	svc, _ := newLPService(t)
+	if len(svc.ListThemes()) == 0 {
+		t.Fatal("expected built-in themes")
+	}
+	if svc.GetTheme(BuiltInThemes[0].ID) == nil {
+		t.Fatal("GetTheme should find a built-in theme")
+	}
+	if svc.GetTheme("nope") != nil {
+		t.Fatal("GetTheme unknown should be nil")
+	}
+}
+
+func TestListVersions_Empty(t *testing.T) {
+	svc, _ := newLPService(t)
+	svc.GetOrCreate(bg(), "st1")
+	versions, total, err := svc.ListVersions(bg(), "st1", 10, 0)
+	if err != nil {
+		t.Fatalf("list versions: %v", err)
+	}
+	if total != 0 || len(versions) != 0 {
+		t.Fatalf("expected no versions yet, got total=%d len=%d", total, len(versions))
+	}
+}

--- a/internal/models/helpers_test.go
+++ b/internal/models/helpers_test.go
@@ -1,0 +1,234 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package models
+
+import (
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Webstream failover chain
+// ---------------------------------------------------------------------------
+
+func TestWebstream_HealthAndDurations(t *testing.T) {
+	ws := &Webstream{HealthStatus: "healthy", HealthCheckSampleMS: 2000, HealthCheckMaxStallMS: 5000}
+	if !ws.IsHealthy() {
+		t.Fatal("healthy status should report healthy")
+	}
+	ws.HealthStatus = "degraded"
+	if ws.IsHealthy() {
+		t.Fatal("non-healthy status should not report healthy")
+	}
+	if ws.HealthCheckSampleWindow() != 2*time.Second {
+		t.Fatalf("sample window = %v", ws.HealthCheckSampleWindow())
+	}
+	if ws.HealthCheckMaxStall() != 5*time.Second {
+		t.Fatalf("max stall = %v", ws.HealthCheckMaxStall())
+	}
+}
+
+func TestWebstream_URLSelection(t *testing.T) {
+	empty := &Webstream{}
+	if empty.GetPrimaryURL() != "" || empty.GetCurrentURL() != "" {
+		t.Fatal("empty URL list should yield empty strings")
+	}
+
+	ws := &Webstream{URLs: []string{"a", "b", "c"}}
+	if ws.GetPrimaryURL() != "a" {
+		t.Fatalf("primary = %q", ws.GetPrimaryURL())
+	}
+	// Stale index is normalized back to 0.
+	ws.CurrentIndex = 9
+	if ws.GetCurrentURL() != "a" || ws.CurrentIndex != 0 {
+		t.Fatalf("stale index not reset: url=%q idx=%d", ws.GetCurrentURL(), ws.CurrentIndex)
+	}
+}
+
+func TestWebstream_NextFailoverURL(t *testing.T) {
+	// Failover disabled -> no next.
+	if got := (&Webstream{URLs: []string{"a", "b"}, FailoverEnabled: false}).GetNextFailoverURL(); got != "" {
+		t.Fatalf("disabled failover = %q, want empty", got)
+	}
+	// Single URL -> no next.
+	if got := (&Webstream{URLs: []string{"a"}, FailoverEnabled: true}).GetNextFailoverURL(); got != "" {
+		t.Fatalf("single url = %q, want empty", got)
+	}
+	// Middle of chain -> next URL.
+	ws := &Webstream{URLs: []string{"a", "b", "c"}, FailoverEnabled: true, CurrentIndex: 0}
+	if got := ws.GetNextFailoverURL(); got != "b" {
+		t.Fatalf("next = %q, want b", got)
+	}
+	// End of chain, auto-recover -> wraps to primary.
+	ws2 := &Webstream{URLs: []string{"a", "b"}, FailoverEnabled: true, CurrentIndex: 1, AutoRecoverEnabled: true}
+	if got := ws2.GetNextFailoverURL(); got != "a" {
+		t.Fatalf("wrap = %q, want a", got)
+	}
+	// End of chain, no auto-recover -> exhausted.
+	ws3 := &Webstream{URLs: []string{"a", "b"}, FailoverEnabled: true, CurrentIndex: 1}
+	if got := ws3.GetNextFailoverURL(); got != "" {
+		t.Fatalf("exhausted = %q, want empty", got)
+	}
+}
+
+func TestWebstream_FailoverToNextAndReset(t *testing.T) {
+	ws := &Webstream{URLs: []string{"a", "b", "c"}, FailoverEnabled: true}
+	if !ws.FailoverToNext() || ws.CurrentIndex != 1 || ws.CurrentURL != "b" {
+		t.Fatalf("first failover: idx=%d url=%q", ws.CurrentIndex, ws.CurrentURL)
+	}
+	ws.FailoverToNext() // -> c (idx 2)
+	// At the end without auto-recover, advancing fails and leaves state put.
+	if ws.FailoverToNext() {
+		t.Fatal("should not advance past the end without auto-recover")
+	}
+	if ws.CurrentIndex != 2 {
+		t.Fatalf("index moved unexpectedly to %d", ws.CurrentIndex)
+	}
+
+	// Auto-recover wraps back to primary.
+	wrap := &Webstream{URLs: []string{"a", "b"}, FailoverEnabled: true, AutoRecoverEnabled: true, CurrentIndex: 1}
+	if !wrap.FailoverToNext() || wrap.CurrentIndex != 0 {
+		t.Fatalf("auto-recover wrap failed: idx=%d", wrap.CurrentIndex)
+	}
+
+	// Disabled failover never advances.
+	if (&Webstream{URLs: []string{"a", "b"}}).FailoverToNext() {
+		t.Fatal("disabled failover should not advance")
+	}
+
+	ws.ResetToPrimary()
+	if ws.CurrentIndex != 0 || ws.CurrentURL != "a" {
+		t.Fatalf("reset: idx=%d url=%q", ws.CurrentIndex, ws.CurrentURL)
+	}
+}
+
+func TestWebstream_HealthMarkers(t *testing.T) {
+	ws := &Webstream{}
+	ws.MarkHealthy()
+	if ws.HealthStatus != "healthy" || ws.LastHealthCheck == nil {
+		t.Fatalf("mark healthy: %+v", ws)
+	}
+	ws.MarkUnhealthy()
+	if ws.HealthStatus != "unhealthy" {
+		t.Fatal("mark unhealthy")
+	}
+	ws.MarkDegraded()
+	if ws.HealthStatus != "degraded" {
+		t.Fatal("mark degraded")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Other predicate/helper methods
+// ---------------------------------------------------------------------------
+
+func TestAPIKeyValidity(t *testing.T) {
+	future := time.Now().Add(time.Hour)
+	past := time.Now().Add(-time.Hour)
+
+	valid := &APIKey{ExpiresAt: future}
+	if valid.IsExpired() || valid.IsRevoked() || !valid.IsValid() {
+		t.Fatal("fresh key should be valid")
+	}
+	expired := &APIKey{ExpiresAt: past}
+	if !expired.IsExpired() || expired.IsValid() {
+		t.Fatal("past-expiry key should be expired and invalid")
+	}
+	revoked := &APIKey{ExpiresAt: future, RevokedAt: &past}
+	if !revoked.IsRevoked() || revoked.IsValid() {
+		t.Fatal("revoked key should be invalid")
+	}
+}
+
+func TestRecordingHelpers(t *testing.T) {
+	active := &Recording{Status: RecordingStatusActive, DurationMs: 90000}
+	if !active.IsActive() || active.IsComplete() {
+		t.Fatal("active recording state")
+	}
+	if active.Duration() != 90*time.Second {
+		t.Fatalf("duration = %v", active.Duration())
+	}
+	done := &Recording{Status: RecordingStatusComplete}
+	if !done.IsComplete() || done.IsActive() {
+		t.Fatal("complete recording state")
+	}
+}
+
+func TestLiveSessionHelpers(t *testing.T) {
+	ls := &LiveSession{Active: true, ConnectedAt: time.Now().Add(-time.Minute)}
+	if !ls.IsActive() {
+		t.Fatal("active session")
+	}
+	if ls.Duration() < time.Minute {
+		t.Fatalf("live duration too small: %v", ls.Duration())
+	}
+	ls.Disconnect()
+	if ls.IsActive() || ls.DisconnectedAt == nil {
+		t.Fatal("disconnect should clear active and stamp DisconnectedAt")
+	}
+	// After disconnect, duration is fixed between connect and disconnect.
+	if ls.Duration() <= 0 {
+		t.Fatalf("post-disconnect duration = %v", ls.Duration())
+	}
+}
+
+func TestPrioritySourceHelpers(t *testing.T) {
+	ps := &PrioritySource{Active: true, Priority: PriorityEmergency}
+	if !ps.IsActive() || !ps.IsEmergency() {
+		t.Fatal("active emergency source")
+	}
+	ps.Deactivate()
+	if ps.IsActive() || ps.DeactivatedAt == nil {
+		t.Fatal("deactivate should clear active and stamp DeactivatedAt")
+	}
+	live := &PrioritySource{SourceType: SourceTypeLive}
+	if !live.IsLive() {
+		t.Fatal("live source-type should report live")
+	}
+}
+
+func TestLandingPageHelpers(t *testing.T) {
+	platform := &LandingPage{StationID: nil}
+	if !platform.IsPlatformPage() {
+		t.Fatal("nil station is platform page")
+	}
+	if platform.LogoURL() != "/landing-assets/by-type/logo?platform=true" {
+		t.Fatalf("platform logo url = %q", platform.LogoURL())
+	}
+
+	st := "st1"
+	station := &LandingPage{StationID: &st, DraftConfig: map[string]any{"x": 1}}
+	if station.IsPlatformPage() {
+		t.Fatal("station page should not be platform")
+	}
+	if !station.HasDraft() {
+		t.Fatal("non-empty draft should report HasDraft")
+	}
+	if station.LogoURL() != "/landing-assets/by-type/logo?station_id=st1" {
+		t.Fatalf("station logo url = %q", station.LogoURL())
+	}
+
+	empty := "" // empty station id also counts as platform
+	if !(&LandingPage{StationID: &empty}).IsPlatformPage() {
+		t.Fatal("empty station id should count as platform page")
+	}
+}
+
+func TestShowInstanceHelpers(t *testing.T) {
+	cancelled := &ShowInstance{Status: ShowInstanceCancelled}
+	if !cancelled.IsCancelled() {
+		t.Fatal("cancelled status")
+	}
+	exc := &ShowInstance{ExceptionType: ShowExceptionCancelled}
+	if !exc.IsCancelled() || !exc.IsException() {
+		t.Fatal("exception-cancelled instance")
+	}
+	regular := &ShowInstance{Status: ShowInstanceScheduled}
+	if regular.IsCancelled() || regular.IsException() {
+		t.Fatal("scheduled instance is neither cancelled nor an exception")
+	}
+}

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -7,12 +7,14 @@ cd "$ROOT_DIR"
 COVERAGE_MIN="${COVERAGE_MIN:-80}"
 COVERAGE_ENFORCE="${COVERAGE_ENFORCE:-0}"
 COVERAGE_PROFILE="${COVERAGE_PROFILE:-coverage.out}"
-COVERAGE_EXCLUDE_REGEX="${COVERAGE_EXCLUDE_REGEX:-/test/e2e}"
+# Generated protobuf/gRPC stubs under proto/ carry no hand-written logic worth
+# covering, so they only distort the denominator; exclude them alongside e2e.
+COVERAGE_EXCLUDE_REGEX="${COVERAGE_EXCLUDE_REGEX:-(/test/e2e|/proto/)}"
 
 export GOCACHE="${GOCACHE:-$ROOT_DIR/.gocache}"
 export GOMODCACHE="${GOMODCACHE:-$ROOT_DIR/.gomodcache}"
 
-mapfile -t packages < <(go list ./... | grep -v "$COVERAGE_EXCLUDE_REGEX" || true)
+mapfile -t packages < <(go list ./... | grep -Ev "$COVERAGE_EXCLUDE_REGEX" || true)
 if [ "${#packages[@]}" -eq 0 ]; then
   echo "No packages selected for coverage."
   exit 1


### PR DESCRIPTION
Part of #255. The "biggest win" batch: one metric fix plus three more packages.

## 1. Stop counting generated code
`proto/mediaengine/v1` is `protoc` output (`DO NOT EDIT`) — 1,198 statements at 0% that only distort the denominator. Added it to `COVERAGE_EXCLUDE_REGEX` in `scripts/coverage.sh` (and switched the filter to `grep -Ev` so the alternation is treated as an extended regex). No test code, and it lifts the reported total **58.4% → 60.4%**.

## 2. Three more packages covered

| package | before | after |
|---|---|---|
| `internal/landingpage` | 0% | 32.9% |
| `internal/models` | 2.8% | 21.0% |
| `internal/analytics` | 0% | 26.8% |

- **landingpage** — theme lookup + deep-merge, the widget registry and validation, the renderer config/format/truncate/json helpers, and the sqlite-testable service methods (`GetOrCreate` idempotency, platform vs station pages, config getters, theme/CSS/head updates, `ErrNotFound` paths).
- **models** — the pure helper methods, chiefly the **webstream failover chain** (primary/current/next URL selection, `FailoverToNext` with wrap + auto-recover, stale-index guards, health markers) plus the `APIKey` / `Recording` / `LiveSession` / `PrioritySource` / `LandingPage` / `ShowInstance` predicates.
- **analytics** — `dayName` / `min`, `RecordHourlyStats` show-linkage, and `GetShowPerformance`.

The draft/publish writers (landingpage) and the daily-rollup / time-slot queries (analytics) use postgres `jsonb` / `EXTRACT` and stay in the integration tier; noted in the commit body.

**Total statement coverage: 58.4% → 61.1%.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)