### PR TITLE
test(coverage): webstream failover + syndication materialization (61.7%)

### DIFF
--- a/internal/syndication/service_test.go
+++ b/internal/syndication/service_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package syndication
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+func newSvc(t *testing.T) (*Service, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.Station{}, &models.Show{}, &models.ShowInstance{},
+		&models.Network{}, &models.NetworkShow{}, &models.NetworkSubscription{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return NewService(db, zerolog.Nop()), db
+}
+
+func ctx() context.Context { return context.Background() }
+
+func sp(v string) *string { return &v }
+
+// ---------------------------------------------------------------------------
+// pure helpers
+// ---------------------------------------------------------------------------
+
+func TestParseDays(t *testing.T) {
+	got := parseDays("MO, we ,FR,bogus")
+	want := []int{1, 3, 5} // MO=1, WE=3, FR=5; bogus dropped
+	if len(got) != len(want) {
+		t.Fatalf("parseDays = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("parseDays[%d] = %d, want %d", i, got[i], want[i])
+		}
+	}
+	if len(parseDays("")) != 0 {
+		t.Fatal("empty days should parse to nothing")
+	}
+}
+
+func TestParseTime(t *testing.T) {
+	if h, m := parseTime("09:30:00"); h != 9 || m != 30 {
+		t.Fatalf("HH:MM:SS = %d:%d", h, m)
+	}
+	if h, m := parseTime("21:05"); h != 21 || m != 5 {
+		t.Fatalf("HH:MM = %d:%d", h, m)
+	}
+	if h, m := parseTime("garbage"); h != 0 || m != 0 {
+		t.Fatalf("malformed should be 0:0, got %d:%d", h, m)
+	}
+}
+
+func TestContainsDay(t *testing.T) {
+	days := []int{1, 3, 5}
+	if !containsDay(days, 3) || containsDay(days, 2) {
+		t.Fatal("containsDay wrong")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// network + show CRUD
+// ---------------------------------------------------------------------------
+
+func TestNetworkCRUD(t *testing.T) {
+	svc, _ := newSvc(t)
+	n, err := svc.CreateNetwork(ctx(), "Public Radio Exchange", "desc", "owner1")
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	got, err := svc.GetNetwork(ctx(), n.ID)
+	if err != nil || got.Name != "Public Radio Exchange" {
+		t.Fatalf("get: %v / %+v", err, got)
+	}
+	svc.CreateNetwork(ctx(), "Other Net", "", "owner2")
+
+	byOwner, _ := svc.ListNetworks(ctx(), "owner1")
+	if len(byOwner) != 1 {
+		t.Fatalf("owner filter = %d, want 1", len(byOwner))
+	}
+	all, _ := svc.ListNetworks(ctx(), "")
+	if len(all) != 2 {
+		t.Fatalf("all networks = %d, want 2", len(all))
+	}
+	if _, err := svc.GetNetwork(ctx(), "missing"); err == nil {
+		t.Fatal("expected error for missing network")
+	}
+}
+
+func TestNetworkShowCRUD(t *testing.T) {
+	svc, db := newSvc(t)
+	show := &models.NetworkShow{NetworkID: sp("net1"), Name: "Morning Edition", Duration: 120, Active: true}
+	if err := svc.CreateNetworkShow(ctx(), show); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if show.ID == "" {
+		t.Fatal("CreateNetworkShow should assign an ID")
+	}
+	got, err := svc.GetNetworkShow(ctx(), show.ID)
+	if err != nil || got.Duration != 120 {
+		t.Fatalf("get: %v / %+v", err, got)
+	}
+
+	shows, _ := svc.ListNetworkShows(ctx(), "net1")
+	if len(shows) != 1 {
+		t.Fatalf("list = %d, want 1", len(shows))
+	}
+
+	if err := svc.UpdateNetworkShow(ctx(), show.ID, map[string]any{"duration": 90}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	updated, _ := svc.GetNetworkShow(ctx(), show.ID)
+	if updated.Duration != 90 {
+		t.Fatalf("duration after update = %d", updated.Duration)
+	}
+
+	// Subscribe then delete: subscriptions are cascaded.
+	svc.Subscribe(ctx(), "st1", show.ID, "09:00:00", "MO")
+	if err := svc.DeleteNetworkShow(ctx(), show.ID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	var subs int64
+	db.Model(&models.NetworkSubscription{}).Count(&subs)
+	if subs != 0 {
+		t.Fatalf("delete should cascade subscriptions, %d remain", subs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// subscriptions
+// ---------------------------------------------------------------------------
+
+func TestSubscribeUnsubscribe(t *testing.T) {
+	svc, _ := newSvc(t)
+	show := &models.NetworkShow{ID: "sh1", NetworkID: sp("net1"), Name: "Show", Duration: 60, Active: true}
+	svc.CreateNetworkShow(ctx(), show)
+
+	sub, err := svc.Subscribe(ctx(), "st1", "sh1", "09:00:00", "MO,WE")
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+	// Duplicate subscription is rejected.
+	if _, err := svc.Subscribe(ctx(), "st1", "sh1", "10:00:00", "TU"); err == nil {
+		t.Fatal("duplicate subscription should be rejected")
+	}
+
+	got, _ := svc.GetStationSubscriptions(ctx(), "st1")
+	if len(got) != 1 || got[0].LocalDays != "MO,WE" {
+		t.Fatalf("station subscriptions = %+v", got)
+	}
+
+	if err := svc.Unsubscribe(ctx(), sub.ID); err != nil {
+		t.Fatalf("unsubscribe: %v", err)
+	}
+	after, _ := svc.GetStationSubscriptions(ctx(), "st1")
+	if len(after) != 0 {
+		t.Fatalf("after unsubscribe = %d, want 0", len(after))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// materialization
+// ---------------------------------------------------------------------------
+
+func TestMaterializeSubscriptions(t *testing.T) {
+	svc, db := newSvc(t)
+	show := &models.NetworkShow{ID: "sh1", NetworkID: sp("net1"), Name: "Daily Show", Duration: 60, Active: true}
+	svc.CreateNetworkShow(ctx(), show)
+	// Air every day at 09:00 local.
+	svc.Subscribe(ctx(), "st1", "sh1", "09:00:00", "MO,TU,WE,TH,FR,SA,SU")
+
+	start := time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 7)
+
+	instances, err := svc.MaterializeSubscriptions(ctx(), "st1", start, end)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if len(instances) != 7 {
+		t.Fatalf("expected 7 daily instances, got %d", len(instances))
+	}
+	if instances[0].EndsAt.Sub(instances[0].StartsAt) != time.Hour {
+		t.Fatalf("instance duration = %v, want 1h", instances[0].EndsAt.Sub(instances[0].StartsAt))
+	}
+	// They are persisted.
+	var stored int64
+	db.Model(&models.ShowInstance{}).Count(&stored)
+	if stored != 7 {
+		t.Fatalf("persisted instances = %d, want 7", stored)
+	}
+}
+
+func TestMaterializeSubscriptions_SkipsConflicts(t *testing.T) {
+	svc, db := newSvc(t)
+	show := &models.NetworkShow{ID: "sh1", NetworkID: sp("net1"), Name: "Daily", Duration: 60, Active: true}
+	svc.CreateNetworkShow(ctx(), show)
+	svc.Subscribe(ctx(), "st1", "sh1", "09:00:00", "MO,TU,WE,TH,FR,SA,SU")
+
+	start := time.Date(2026, 3, 2, 0, 0, 0, 0, time.UTC)
+	end := start.AddDate(0, 0, 7)
+
+	// Pre-seed a conflicting instance overlapping the first day's 09:00-10:00 slot.
+	db.Create(&models.ShowInstance{
+		ID: "existing", StationID: "st1",
+		StartsAt: start.Add(9 * time.Hour), EndsAt: start.Add(10 * time.Hour),
+		Status: models.ShowInstanceScheduled,
+	})
+
+	instances, err := svc.MaterializeSubscriptions(ctx(), "st1", start, end)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	// One day collides and is skipped => 6 new instances.
+	if len(instances) != 6 {
+		t.Fatalf("expected 6 instances after conflict skip, got %d", len(instances))
+	}
+}

--- a/internal/webstream/failover_test.go
+++ b/internal/webstream/failover_test.go
@@ -1,0 +1,235 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package webstream
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/events"
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+// ---------------------------------------------------------------------------
+// pure helpers
+// ---------------------------------------------------------------------------
+
+func TestParseStreamTitle(t *testing.T) {
+	title, artist := parseStreamTitle("StreamTitle='Depeche Mode - Enjoy the Silence';StreamUrl='x';")
+	if artist != "Depeche Mode" || title != "Enjoy the Silence" {
+		t.Fatalf("artist=%q title=%q", artist, title)
+	}
+	// Title-only (no " - " separator).
+	if ti, ar := parseStreamTitle("StreamTitle='Station ID';"); ti != "Station ID" || ar != "" {
+		t.Fatalf("title-only: ti=%q ar=%q", ti, ar)
+	}
+	// Empty StreamTitle.
+	if ti, ar := parseStreamTitle("StreamTitle='';"); ti != "" || ar != "" {
+		t.Fatalf("empty: ti=%q ar=%q", ti, ar)
+	}
+	// No StreamTitle prefix at all.
+	if ti, ar := parseStreamTitle("SomethingElse='x';"); ti != "" || ar != "" {
+		t.Fatalf("no prefix: ti=%q ar=%q", ti, ar)
+	}
+	// Unterminated quote falls back to the remainder as title.
+	if ti, _ := parseStreamTitle("StreamTitle='Unterminated"); ti != "Unterminated" {
+		t.Fatalf("unterminated: ti=%q", ti)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// failover state machine (deterministic, no live network)
+// ---------------------------------------------------------------------------
+
+func newChecker(t *testing.T, ws *models.Webstream) (*HealthChecker, *gorm.DB, *events.Bus) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Webstream{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	if err := db.Create(ws).Error; err != nil {
+		t.Fatalf("seed webstream: %v", err)
+	}
+	bus := events.NewBus()
+	return NewHealthChecker(ws.ID, db, bus, zerolog.Nop()), db, bus
+}
+
+func TestHandleFailedCheck_EscalatesThenHoldsInGrace(t *testing.T) {
+	// Large grace period so the third failure records unhealthy but does NOT
+	// actually fail over (the exact bug class we want pinned down).
+	ws := &models.Webstream{
+		ID: "ws1", StationID: "st1", Name: "Relay",
+		URLs:            []string{"http://a/", "http://b/"},
+		FailoverEnabled: true, FailoverGraceMs: 600000,
+	}
+	hc, db, _ := newChecker(t, ws)
+
+	hc.handleFailedCheck(ws, fmt.Errorf("boom"))
+	if ws.HealthStatus != "degraded" {
+		t.Fatalf("after 1 fail: status=%q, want degraded", ws.HealthStatus)
+	}
+	hc.handleFailedCheck(ws, fmt.Errorf("boom"))
+	if ws.HealthStatus != "unhealthy" {
+		t.Fatalf("after 2 fails: status=%q, want unhealthy", ws.HealthStatus)
+	}
+	hc.handleFailedCheck(ws, fmt.Errorf("boom")) // hits threshold, but grace holds it
+	if ws.HealthStatus != "unhealthy" {
+		t.Fatalf("after 3 fails in grace: status=%q, want unhealthy", ws.HealthStatus)
+	}
+	// No failover occurred: still on the primary URL.
+	if ws.CurrentIndex != 0 {
+		t.Fatalf("grace period should defer failover, but index moved to %d", ws.CurrentIndex)
+	}
+	if hc.failoverEligibleAt.IsZero() {
+		t.Fatal("failoverEligibleAt should be armed once the threshold is reached")
+	}
+
+	// Persisted state matches.
+	var reloaded models.Webstream
+	db.First(&reloaded, "id = ?", "ws1")
+	if reloaded.HealthStatus != "unhealthy" || reloaded.CurrentIndex != 0 {
+		t.Fatalf("persisted state wrong: %+v", reloaded)
+	}
+}
+
+func TestHandleSuccessfulCheck_ResetsState(t *testing.T) {
+	ws := &models.Webstream{ID: "ws1", StationID: "st1", URLs: []string{"http://a/"}, HealthStatus: "degraded"}
+	hc, _, bus := newChecker(t, ws)
+	hc.consecutiveFails = 2
+	hc.failoverEligibleAt = time.Now().Add(time.Hour)
+
+	sub := bus.Subscribe(events.EventWebstreamHealth)
+	hc.handleSuccessfulCheck(ws)
+
+	if ws.HealthStatus != "healthy" {
+		t.Fatalf("status = %q, want healthy", ws.HealthStatus)
+	}
+	if hc.consecutiveFails != 0 || !hc.failoverEligibleAt.IsZero() {
+		t.Fatalf("counters not reset: fails=%d eligible=%v", hc.consecutiveFails, hc.failoverEligibleAt)
+	}
+	select {
+	case p := <-sub:
+		if p["status"] != "healthy" {
+			t.Fatalf("health event status = %v", p["status"])
+		}
+	default:
+		t.Fatal("expected a health event on recovery")
+	}
+}
+
+func TestTriggerFailover_DisabledMarksUnhealthy(t *testing.T) {
+	ws := &models.Webstream{ID: "ws1", StationID: "st1", URLs: []string{"http://a/", "http://b/"}, FailoverEnabled: false}
+	hc, _, _ := newChecker(t, ws)
+
+	hc.triggerFailover(ws)
+	if ws.HealthStatus != "unhealthy" {
+		t.Fatalf("disabled failover status = %q, want unhealthy", ws.HealthStatus)
+	}
+	if ws.CurrentIndex != 0 {
+		t.Fatal("disabled failover must not advance the URL index")
+	}
+}
+
+func TestTriggerFailover_NoNextURLMarksUnhealthy(t *testing.T) {
+	// Failover enabled but only one URL => no next URL to move to.
+	ws := &models.Webstream{ID: "ws1", StationID: "st1", URLs: []string{"http://only/"}, FailoverEnabled: true}
+	hc, _, _ := newChecker(t, ws)
+
+	hc.triggerFailover(ws)
+	if ws.HealthStatus != "unhealthy" {
+		t.Fatalf("no-next-url status = %q, want unhealthy", ws.HealthStatus)
+	}
+}
+
+func TestHandleFailedThenSuccess_Recovers(t *testing.T) {
+	ws := &models.Webstream{ID: "ws1", StationID: "st1", URLs: []string{"http://a/"}, FailoverEnabled: true, FailoverGraceMs: 600000}
+	hc, _, _ := newChecker(t, ws)
+	hc.handleFailedCheck(ws, fmt.Errorf("x"))
+	hc.handleFailedCheck(ws, fmt.Errorf("x"))
+	if hc.consecutiveFails != 2 {
+		t.Fatalf("consecutiveFails = %d, want 2", hc.consecutiveFails)
+	}
+	hc.handleSuccessfulCheck(ws)
+	if hc.consecutiveFails != 0 || ws.HealthStatus != "healthy" {
+		t.Fatalf("recovery failed: fails=%d status=%q", hc.consecutiveFails, ws.HealthStatus)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ICY metadata parsing over httptest
+// ---------------------------------------------------------------------------
+
+func TestParseICYMetadata_HeaderFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// No icy-metaint => the parser falls back to the icy-name header.
+		w.Header().Set("icy-name", "Jazz FM")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	p := &ICYPoller{}
+	title, artist, err := p.parseICYMetadata(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if title != "Jazz FM" || artist != "" {
+		t.Fatalf("header fallback: title=%q artist=%q", title, artist)
+	}
+}
+
+func TestParseICYMetadata_HTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	p := &ICYPoller{}
+	if _, _, err := p.parseICYMetadata(context.Background(), srv.URL); err == nil {
+		t.Fatal("expected an error for HTTP 404")
+	}
+}
+
+func TestParseICYMetadata_InlineStreamTitle(t *testing.T) {
+	const metaInt = 16
+	meta := "StreamTitle='Depeche Mode - Enjoy the Silence';"
+	blocks := (len(meta) + 15) / 16
+	padded := make([]byte, blocks*16)
+	copy(padded, meta)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("icy-metaint", fmt.Sprintf("%d", metaInt))
+		w.WriteHeader(http.StatusOK)
+		flusher, _ := w.(http.Flusher)
+		w.Write(make([]byte, metaInt)) // one audio block
+		w.Write([]byte{byte(blocks)})  // metadata length in 16-byte units
+		w.Write(padded)                // the metadata block
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}))
+	defer srv.Close()
+
+	p := &ICYPoller{}
+	title, artist, err := p.parseICYMetadata(context.Background(), srv.URL)
+	if err != nil {
+		t.Fatalf("parse inline: %v", err)
+	}
+	if artist != "Depeche Mode" || title != "Enjoy the Silence" {
+		t.Fatalf("inline parse: artist=%q title=%q", artist, title)
+	}
+}


### PR DESCRIPTION
Part of #255, aimed at the code that has actually broken in production rather than raw %.

| package | before | after |
|---|---|---|
| `internal/webstream` | 41.9% | 58.9% |
| `internal/syndication` | 0% | 84.3% |

Total statement coverage: **61.1% → 61.7%**.

## webstream — the failover state machine
Driven deterministically against sqlite with **no live network**, so these can't flake:
- The escalation ladder: healthy → `degraded` on the first miss → `unhealthy`, then the grace-period hold at the failover threshold that must **not** fail over early (the exact bug class worth pinning).
- `handleSuccessfulCheck` resetting the fail counter + `failoverEligibleAt` and emitting the health event.
- `triggerFailover` refusals — failover disabled, or no next URL — marking `unhealthy` without advancing the URL index.
- `parseStreamTitle` and ICY metadata reading over `httptest` (header fallback, HTTP error, inline `StreamTitle`).

The live `checkURL`/`livenessCheck` happy path is timing-sensitive and stays in the integration tier.

## syndication — subscription materialization
Network/show CRUD, subscribe/unsubscribe with duplicate rejection and cascade-on-delete, the `parseDays`/`parseTime`/`containsDay` helpers, and `MaterializeSubscriptions` including the overlap check that skips a slot when an instance already occupies it.

Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)