### PR TITLE
test(coverage): recording quota/CRUD guards + smartblock interstitials (61.9%)

### DIFF
--- a/internal/recording/service_test.go
+++ b/internal/recording/service_test.go
@@ -1,0 +1,218 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package recording
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+func newSvc(t *testing.T) (*Service, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.Station{}, &models.StationUser{}, &models.Recording{}, &models.RecordingChapter{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	// meClient is nil: only DB paths and quota rejections are exercised here.
+	return NewService(db, nil, t.TempDir(), zerolog.Nop()), db
+}
+
+func bg() context.Context { return context.Background() }
+
+// ---------------------------------------------------------------------------
+// pure helpers (chapter_embed.go)
+// ---------------------------------------------------------------------------
+
+func TestFormatChapterTimestamp(t *testing.T) {
+	cases := map[int64]string{
+		0:       "00:00:00.000",
+		1500:    "00:00:01.500",
+		61000:   "00:01:01.000",
+		3661250: "01:01:01.250",
+	}
+	for ms, want := range cases {
+		if got := formatChapterTimestamp(ms); got != want {
+			t.Fatalf("formatChapterTimestamp(%d) = %q, want %q", ms, got, want)
+		}
+	}
+}
+
+func TestFormatChapterName(t *testing.T) {
+	if got := formatChapterName("Enjoy the Silence", "Depeche Mode"); got != "Depeche Mode - Enjoy the Silence" {
+		t.Fatalf("both = %q", got)
+	}
+	if got := formatChapterName("Just Title", ""); got != "Just Title" {
+		t.Fatalf("title-only = %q", got)
+	}
+	if got := formatChapterName("", "Just Artist"); got != "Just Artist" {
+		t.Fatalf("artist-only = %q", got)
+	}
+	if got := formatChapterName("", ""); got != "" {
+		t.Fatalf("empty = %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// StartRecording quota guards (reject before the media engine is touched)
+// ---------------------------------------------------------------------------
+
+func TestStartRecording_StationNotFound(t *testing.T) {
+	svc, _ := newSvc(t)
+	if _, err := svc.StartRecording(bg(), StartRequest{StationID: "missing", UserID: "u1"}); err == nil {
+		t.Fatal("expected error for missing station")
+	}
+}
+
+func TestStartRecording_StationQuotaExceeded(t *testing.T) {
+	svc, db := newSvc(t)
+	db.Create(&models.Station{ID: "st1", Name: "S", RecordingQuotaBytes: 1000, RecordingStorageUsed: 1000})
+	if _, err := svc.StartRecording(bg(), StartRequest{StationID: "st1", UserID: "u1"}); err == nil {
+		t.Fatal("expected station quota-exceeded error")
+	}
+}
+
+func TestStartRecording_DJQuotaExceeded(t *testing.T) {
+	svc, db := newSvc(t)
+	db.Create(&models.Station{ID: "st1", Name: "S", RecordingQuotaBytes: 0})
+	db.Create(&models.StationUser{UserID: "u1", StationID: "st1", RecordingQuotaBytes: 500, RecordingStorageUsed: 500})
+	if _, err := svc.StartRecording(bg(), StartRequest{StationID: "st1", UserID: "u1"}); err == nil {
+		t.Fatal("expected DJ quota-exceeded error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// chapters + recording CRUD
+// ---------------------------------------------------------------------------
+
+func seedRecording(t *testing.T, db *gorm.DB, id, station string, status string, size int64) {
+	t.Helper()
+	r := &models.Recording{
+		ID: id, StationID: station, UserID: "u1", Status: status,
+		StartedAt: time.Now().Add(-time.Minute), SizeBytes: size,
+	}
+	if err := db.Create(r).Error; err != nil {
+		t.Fatalf("seed recording: %v", err)
+	}
+}
+
+func TestAddChapter(t *testing.T) {
+	svc, db := newSvc(t)
+	seedRecording(t, db, "r1", "st1", models.RecordingStatusActive, 0)
+
+	if err := svc.AddChapter(bg(), "r1", "Song A", "Artist A", "Album"); err != nil {
+		t.Fatalf("add chapter 1: %v", err)
+	}
+	if err := svc.AddChapter(bg(), "r1", "Song B", "Artist B", "Album"); err != nil {
+		t.Fatalf("add chapter 2: %v", err)
+	}
+	var chapters []models.RecordingChapter
+	db.Where("recording_id = ?", "r1").Order("position ASC").Find(&chapters)
+	if len(chapters) != 2 || chapters[0].Position != 0 || chapters[1].Position != 1 {
+		t.Fatalf("chapter positions wrong: %+v", chapters)
+	}
+
+	// Chapters can't be added to an inactive/missing recording.
+	seedRecording(t, db, "r2", "st1", models.RecordingStatusComplete, 0)
+	if err := svc.AddChapter(bg(), "r2", "x", "y", "z"); err == nil {
+		t.Fatal("expected error adding chapter to a non-active recording")
+	}
+}
+
+func TestListAndGetRecording(t *testing.T) {
+	svc, db := newSvc(t)
+	for _, id := range []string{"r1", "r2", "r3"} {
+		seedRecording(t, db, id, "st1", models.RecordingStatusComplete, 100)
+	}
+	seedRecording(t, db, "other", "st2", models.RecordingStatusComplete, 100)
+
+	recs, total, err := svc.ListRecordings(bg(), "st1", 2, 0)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if total != 3 || len(recs) != 2 {
+		t.Fatalf("list st1: total=%d page=%d, want 3/2", total, len(recs))
+	}
+
+	// GetRecording preloads chapters.
+	db.Create(&models.RecordingChapter{ID: "c1", RecordingID: "r1", Position: 0, Title: "T"})
+	got, err := svc.GetRecording(bg(), "r1")
+	if err != nil || len(got.Chapters) != 1 {
+		t.Fatalf("get with chapters: %v / %+v", err, got)
+	}
+	if _, err := svc.GetRecording(bg(), "missing"); err == nil {
+		t.Fatal("expected error for missing recording")
+	}
+}
+
+func TestUpdateAndDeleteRecording(t *testing.T) {
+	svc, db := newSvc(t)
+	seedRecording(t, db, "r1", "st1", models.RecordingStatusComplete, 0)
+	db.Create(&models.RecordingChapter{ID: "c1", RecordingID: "r1", Position: 0})
+
+	if err := svc.UpdateRecording(bg(), "r1", map[string]any{"title": "Renamed"}); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	var reloaded models.Recording
+	db.First(&reloaded, "id = ?", "r1")
+	if reloaded.Title != "Renamed" {
+		t.Fatalf("title = %q", reloaded.Title)
+	}
+
+	// Active recordings can't be deleted.
+	seedRecording(t, db, "active", "st1", models.RecordingStatusActive, 0)
+	if err := svc.DeleteRecording(bg(), "active"); err == nil {
+		t.Fatal("expected error deleting an active recording")
+	}
+
+	// Zero-size complete recording deletes cleanly and cascades chapters.
+	if err := svc.DeleteRecording(bg(), "r1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	var recs, chaps int64
+	db.Model(&models.Recording{}).Where("id = ?", "r1").Count(&recs)
+	db.Model(&models.RecordingChapter{}).Where("recording_id = ?", "r1").Count(&chaps)
+	if recs != 0 || chaps != 0 {
+		t.Fatalf("delete left rows: recs=%d chaps=%d", recs, chaps)
+	}
+
+	if err := svc.DeleteRecording(bg(), "missing"); err == nil {
+		t.Fatal("expected error deleting a missing recording")
+	}
+}
+
+func TestGetQuotaUsage(t *testing.T) {
+	svc, db := newSvc(t)
+	db.Create(&models.Station{
+		ID: "st1", Name: "S",
+		RecordingQuotaBytes: 5000, RecordingQuotaMode: "block",
+		RecordingStorageUsed: 1200, RecordingDefaultFormat: "flac",
+	})
+	q, err := svc.GetQuotaUsage(bg(), "st1")
+	if err != nil {
+		t.Fatalf("quota: %v", err)
+	}
+	if q.StationQuotaBytes != 5000 || q.StationUsedBytes != 1200 || !q.QuotaEnabled {
+		t.Fatalf("quota info wrong: %+v", q)
+	}
+
+	// A station with a zero quota reports QuotaEnabled=false.
+	db.Create(&models.Station{ID: "st2", Name: "S2", RecordingQuotaBytes: 0})
+	q2, _ := svc.GetQuotaUsage(bg(), "st2")
+	if q2.QuotaEnabled {
+		t.Fatal("zero quota should report disabled")
+	}
+}

--- a/internal/smartblock/interleave_test.go
+++ b/internal/smartblock/interleave_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package smartblock
+
+import (
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+func music(id string, durMS int64) SequenceItem {
+	return SequenceItem{MediaID: id, StartsAtMS: 0, EndsAtMS: durMS}
+}
+
+func countInterstitials(items []SequenceItem) int {
+	n := 0
+	for _, it := range items {
+		if it.IsInterstitial {
+			n++
+		}
+	}
+	return n
+}
+
+func TestInterleaveInterstitials_EveryTwo(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	res := &GenerateResult{Items: []SequenceItem{
+		music("m1", 60000), music("m2", 60000), music("m3", 60000), music("m4", 60000),
+	}}
+	ads := []models.MediaItem{{ID: "ad1", Duration: 30 * time.Second}}
+
+	interleaveInterstitials(res, ads, 2, 1, rng)
+
+	// After every 2 music tracks, one ad => 4 music + 2 ads.
+	if len(res.Items) != 6 {
+		t.Fatalf("item count = %d, want 6", len(res.Items))
+	}
+	if got := countInterstitials(res.Items); got != 2 {
+		t.Fatalf("interstitials = %d, want 2", got)
+	}
+	// Timeline is contiguous and TotalMS is the sum.
+	var cursor int64
+	for i, it := range res.Items {
+		if it.StartsAtMS != cursor {
+			t.Fatalf("item %d starts at %d, want %d (gap in timeline)", i, it.StartsAtMS, cursor)
+		}
+		cursor = it.EndsAtMS
+	}
+	if res.TotalMS != cursor || res.TotalMS != 4*60000+2*30000 {
+		t.Fatalf("TotalMS = %d, want %d", res.TotalMS, 4*60000+2*30000)
+	}
+}
+
+func TestInterleaveInterstitials_Guards(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	base := []SequenceItem{music("m1", 1000), music("m2", 1000)}
+	ads := []models.MediaItem{{ID: "ad1", Duration: time.Second}}
+
+	// Each guard leaves the item list untouched.
+	for _, tc := range []struct {
+		name             string
+		everyN, perBreak int
+		ads              []models.MediaItem
+	}{
+		{"everyN<1", 0, 1, ads},
+		{"perBreak<1", 2, 0, ads},
+		{"no interstitials", 2, 1, nil},
+	} {
+		res := &GenerateResult{Items: append([]SequenceItem(nil), base...)}
+		interleaveInterstitials(res, tc.ads, tc.everyN, tc.perBreak, rng)
+		if len(res.Items) != 2 || countInterstitials(res.Items) != 0 {
+			t.Fatalf("%s: expected no-op, got %d items / %d ads", tc.name, len(res.Items), countInterstitials(res.Items))
+		}
+	}
+}
+
+func TestInterleaveInterstitials_WrapsAdPool(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	res := &GenerateResult{Items: []SequenceItem{music("m1", 1000), music("m2", 1000)}}
+	// One ad in the pool, but two ads per break => the pool index wraps.
+	ads := []models.MediaItem{{ID: "ad1", Duration: time.Second}}
+
+	interleaveInterstitials(res, ads, 1, 2, rng)
+
+	// 2 music + 2 breaks * 2 ads = 6 items, 4 interstitials.
+	if len(res.Items) != 6 || countInterstitials(res.Items) != 4 {
+		t.Fatalf("got %d items / %d ads, want 6 / 4", len(res.Items), countInterstitials(res.Items))
+	}
+}


### PR DESCRIPTION
Part of #255, continuing the bias toward code that guards against bad state.

| package | before | after |
|---|---|---|
| `internal/recording` | 0% | 26.2% |
| `internal/smartblock` | 76.3% | 79.9% |

Total statement coverage: **61.7% → 61.9%**.

## recording — quota + CRUD guards
- `StartRecording` quota rejections (station missing, station quota exceeded, per-DJ quota exceeded) — all fire **before** the media engine is contacted.
- `AddChapter` position sequencing + its active-only guard.
- `ListRecordings` pagination/total, `GetRecording` chapter preload + not-found, `UpdateRecording`.
- `DeleteRecording` refusing to remove an active recording, and cascading chapters otherwise.
- `GetQuotaUsage` enabled/disabled reporting.

The start/stop happy paths, chapter file embedding, and auto-record handler need a live media-engine client and real files → integration tier.

## smartblock — ad-break interleaving
`interleaveInterstitials`: every-N insertion with a contiguous rebuilt timeline and summed `TotalMS`, the three no-op guards (`everyN<1`, `perBreak<1`, empty pool), and ad-pool index wrap-around when a break needs more ads than the pool holds.

Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)