### PR TITLE
test(coverage): Redis cache/eventbus/leadership via miniredis (62.7%)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/friendsincode/grimnir_radio
 go 1.24.0
 
 require (
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/aws/aws-sdk-go-v2 v1.41.1
 	github.com/aws/aws-sdk-go-v2/config v1.32.7
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.7
@@ -102,6 +103,7 @@ require (
 	github.com/ysmood/got v0.40.0 // indirect
 	github.com/ysmood/gson v0.7.3 // indirect
 	github.com/ysmood/leakless v0.9.0 // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.24.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
 github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.4 h1:489krEF9xIGkOaaX3CE/Be2uWjiXrkCH6gUX+bZA/BU=
@@ -196,6 +198,8 @@ github.com/ysmood/gson v0.7.3 h1:QFkWbTH8MxyUTKPkVWAENJhxqdBa4lYTQWqZCiLG6kE=
 github.com/ysmood/gson v0.7.3/go.mod h1:3Kzs5zDl21g5F/BlLTNcuAGAYLKt2lV5G8D1zF3RNmg=
 github.com/ysmood/leakless v0.9.0 h1:qxCG5VirSBvmi3uynXFkcnLMzkphdh3xx5FtrORwDCU=
 github.com/ysmood/leakless v0.9.0/go.mod h1:R8iAXPRaG97QJwqxs74RdwzcRHT1SWCGTNqY8q0JvMQ=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0 h1:4Pp6oUg3+e/6M4C0A/3kJ2VYa++dsWVTtGgLVj5xtHg=
 go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.49.0/go.mod h1:Mjt1i1INqiaoZOMGR1RIUJN+i3ChKoFRqzrRQhlkbs0=
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.49.0 h1:jq9TW8u3so/bN+JPT166wjOI6/vQPF6Xe7nMNIltagk=

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,170 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/rs/zerolog"
+)
+
+func newTestCache(t *testing.T) *Cache {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("start miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+
+	cfg := DefaultConfig()
+	cfg.RedisAddr = mr.Addr()
+	c, err := New(cfg, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("new cache: %v", err)
+	}
+	t.Cleanup(func() { _ = c.Close() })
+	if !c.IsAvailable() {
+		t.Fatal("cache should be available against miniredis")
+	}
+	return c
+}
+
+func bg() context.Context { return context.Background() }
+
+func TestNew_UnreachableRedis_DisablesGracefully(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.RedisAddr = "127.0.0.1:1" // nothing listening
+	c, err := New(cfg, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("New should not error on unreachable Redis: %v", err)
+	}
+	if c.IsAvailable() {
+		t.Fatal("cache should be disabled when Redis is unreachable")
+	}
+	// Operations on a disabled cache are safe no-ops.
+	if err := c.SetStationList(bg(), []CachedStation{{ID: "s1"}}); err != nil {
+		t.Fatalf("disabled Set should be a no-op, got %v", err)
+	}
+	if _, ok := c.GetStationList(bg()); ok {
+		t.Fatal("disabled Get should miss")
+	}
+}
+
+func TestStationListRoundTrip(t *testing.T) {
+	c := newTestCache(t)
+	if _, ok := c.GetStationList(bg()); ok {
+		t.Fatal("expected miss before set")
+	}
+	want := []CachedStation{{ID: "s1", Name: "Rock"}, {ID: "s2", Name: "Jazz"}}
+	if err := c.SetStationList(bg(), want); err != nil {
+		t.Fatalf("set: %v", err)
+	}
+	got, ok := c.GetStationList(bg())
+	if !ok || len(got) != 2 || got[0].Name != "Rock" {
+		t.Fatalf("station list round-trip: ok=%v got=%+v", ok, got)
+	}
+	if err := c.InvalidateStationList(bg()); err != nil {
+		t.Fatalf("invalidate: %v", err)
+	}
+	if _, ok := c.GetStationList(bg()); ok {
+		t.Fatal("expected miss after invalidate")
+	}
+}
+
+func TestMountCaching(t *testing.T) {
+	c := newTestCache(t)
+	mount := &CachedMount{ID: "m1", StationID: "st1", Name: "main", URL: "/live/main"}
+
+	c.SetMount(bg(), mount)
+	if got, ok := c.GetMount(bg(), "m1"); !ok || got.URL != "/live/main" {
+		t.Fatalf("mount round-trip: ok=%v got=%+v", ok, got)
+	}
+
+	c.SetDefaultMount(bg(), "st1", mount)
+	if got, ok := c.GetDefaultMount(bg(), "st1"); !ok || got.ID != "m1" {
+		t.Fatalf("default mount: ok=%v got=%+v", ok, got)
+	}
+
+	// InvalidateMount clears the mount plus the station-level default.
+	if err := c.InvalidateMount(bg(), "m1", "st1"); err != nil {
+		t.Fatalf("invalidate mount: %v", err)
+	}
+	if _, ok := c.GetMount(bg(), "m1"); ok {
+		t.Fatal("mount should be gone")
+	}
+	if _, ok := c.GetDefaultMount(bg(), "st1"); ok {
+		t.Fatal("default mount should be gone")
+	}
+}
+
+func TestSmartBlockAndMediaAndClock(t *testing.T) {
+	c := newTestCache(t)
+
+	c.SetSmartBlock(bg(), &CachedSmartBlock{ID: "sb1", Name: "Drive", Rules: map[string]any{"k": "v"}})
+	if got, ok := c.GetSmartBlock(bg(), "sb1"); !ok || got.Name != "Drive" {
+		t.Fatalf("smartblock: ok=%v got=%+v", ok, got)
+	}
+	c.InvalidateSmartBlock(bg(), "sb1")
+	if _, ok := c.GetSmartBlock(bg(), "sb1"); ok {
+		t.Fatal("smartblock should be invalidated")
+	}
+
+	c.SetMediaItem(bg(), &CachedMediaItem{ID: "md1", Title: "Song", Artist: "Band"})
+	if got, ok := c.GetMediaItem(bg(), "md1"); !ok || got.Artist != "Band" {
+		t.Fatalf("media: ok=%v got=%+v", ok, got)
+	}
+	c.InvalidateMediaItem(bg(), "md1")
+	if _, ok := c.GetMediaItem(bg(), "md1"); ok {
+		t.Fatal("media should be invalidated")
+	}
+
+	c.SetClock(bg(), &CachedClock{ID: "ck1", Name: "Weekday"})
+	if _, ok := c.GetClock(bg(), "ck1"); !ok {
+		t.Fatal("clock miss after set")
+	}
+	c.SetClockHours(bg(), "st1", []CachedClockHour{{ID: "h1", Hour: 9}})
+	if got, ok := c.GetClockHours(bg(), "st1"); !ok || len(got) != 1 {
+		t.Fatalf("clock hours: ok=%v got=%+v", ok, got)
+	}
+}
+
+func TestInvalidateStation_ClearsRelatedKeys(t *testing.T) {
+	c := newTestCache(t)
+	c.SetStationList(bg(), []CachedStation{{ID: "st1"}})
+	c.SetDefaultMount(bg(), "st1", &CachedMount{ID: "m1", StationID: "st1"})
+	c.SetClockHours(bg(), "st1", []CachedClockHour{{ID: "h1"}})
+
+	if err := c.InvalidateStation(bg(), "st1"); err != nil {
+		t.Fatalf("invalidate station: %v", err)
+	}
+	if _, ok := c.GetStationList(bg()); ok {
+		t.Fatal("station list should be cleared")
+	}
+	if _, ok := c.GetDefaultMount(bg(), "st1"); ok {
+		t.Fatal("default mount should be cleared")
+	}
+	if _, ok := c.GetClockHours(bg(), "st1"); ok {
+		t.Fatal("clock hours should be cleared")
+	}
+}
+
+func TestFlushAll(t *testing.T) {
+	c := newTestCache(t)
+	c.SetStationList(bg(), []CachedStation{{ID: "s1"}})
+	c.SetMount(bg(), &CachedMount{ID: "m1"})
+	if err := c.FlushAll(bg()); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+	if _, ok := c.GetStationList(bg()); ok {
+		t.Fatal("station list should be gone after flush")
+	}
+	if _, ok := c.GetMount(bg(), "m1"); ok {
+		t.Fatal("mount should be gone after flush")
+	}
+}

--- a/internal/eventbus/redis_test.go
+++ b/internal/eventbus/redis_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package eventbus
+
+import (
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/rs/zerolog"
+
+	"github.com/friendsincode/grimnir_radio/internal/events"
+)
+
+func TestDefaultRedisConfig(t *testing.T) {
+	cfg := DefaultRedisConfig()
+	if cfg.Addr == "" || cfg.MaxFailures == 0 || cfg.DialTimeout == 0 {
+		t.Fatalf("default config looks unset: %+v", cfg)
+	}
+}
+
+func TestMarshalUnmarshalMessage(t *testing.T) {
+	data, err := marshalMessage(events.EventNowPlaying, events.Payload{"track": "Highway Star"}, "nodeA")
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	msg, err := unmarshalMessage(data)
+	if err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if msg.EventType != events.EventNowPlaying || msg.NodeID != "nodeA" || msg.Payload["track"] != "Highway Star" {
+		t.Fatalf("round-trip mismatch: %+v", msg)
+	}
+	if _, err := unmarshalMessage([]byte("not json")); err == nil {
+		t.Fatal("expected error on malformed message")
+	}
+}
+
+func TestNewRedisBus_FallbackDelivery(t *testing.T) {
+	// Unreachable Redis => circuit-breaker fallback to the in-memory bus.
+	cfg := DefaultRedisConfig()
+	cfg.Addr = "127.0.0.1:1"
+	bus, err := NewRedisBus(cfg, "node1", zerolog.Nop())
+	if err != nil {
+		t.Fatalf("NewRedisBus should not error on unreachable Redis: %v", err)
+	}
+	defer bus.Close()
+
+	// In fallback mode, same-node publish/subscribe delivers via the in-memory bus.
+	sub := bus.Subscribe(events.EventNowPlaying)
+	bus.Publish(events.EventNowPlaying, events.Payload{"n": 1})
+	select {
+	case p := <-sub:
+		if p["n"] != 1 {
+			t.Fatalf("payload = %v", p)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("fallback delivery timed out")
+	}
+}
+
+func TestRedisBus_CrossNodeDelivery(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	cfg := DefaultRedisConfig()
+	cfg.Addr = mr.Addr()
+
+	busA, err := NewRedisBus(cfg, "nodeA", zerolog.Nop())
+	if err != nil {
+		t.Fatalf("busA: %v", err)
+	}
+	defer busA.Close()
+	busB, err := NewRedisBus(cfg, "nodeB", zerolog.Nop())
+	if err != nil {
+		t.Fatalf("busB: %v", err)
+	}
+	defer busB.Close()
+
+	sub := busA.Subscribe(events.EventScheduleUpdate)
+
+	// Retry-publish from the other node until the subscriber receives it or we
+	// time out; this rides over pub/sub subscription setup latency without a
+	// fixed sleep, so it doesn't flake.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		busB.Publish(events.EventScheduleUpdate, events.Payload{"station_id": "st1"})
+		select {
+		case p := <-sub:
+			if p["station_id"] != "st1" {
+				t.Fatalf("cross-node payload = %v", p)
+			}
+			return // delivered
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	t.Fatal("cross-node delivery never arrived")
+}

--- a/internal/leadership/election_test.go
+++ b/internal/leadership/election_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package leadership
+
+import (
+	"context"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/rs/zerolog"
+)
+
+func newElection(t *testing.T, addr, instanceID string) *Election {
+	t.Helper()
+	cfg := DefaultConfig()
+	cfg.RedisAddr = addr
+	cfg.InstanceID = instanceID
+	e, err := NewElection(cfg, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("new election %s: %v", instanceID, err)
+	}
+	return e
+}
+
+func TestDefaultConfig(t *testing.T) {
+	cfg := DefaultConfig()
+	if cfg.InstanceID == "" || cfg.ElectionKey == "" || cfg.LeaseDuration == 0 {
+		t.Fatalf("default config unset: %+v", cfg)
+	}
+}
+
+func TestNewElection_UnreachableRedisErrors(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.RedisAddr = "127.0.0.1:1"
+	if _, err := NewElection(cfg, zerolog.Nop()); err == nil {
+		t.Fatal("expected an error connecting to unreachable Redis")
+	}
+}
+
+func TestElection_SingleLeaderAndHandover(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	ctx := context.Background()
+	a := newElection(t, mr.Addr(), "node-A")
+	b := newElection(t, mr.Addr(), "node-B")
+
+	// A campaigns first and wins.
+	a.attemptLeadership(ctx)
+	if !a.IsLeader() {
+		t.Fatal("A should have acquired leadership")
+	}
+	select {
+	case v := <-a.LeaderCh():
+		if !v {
+			t.Fatal("A's leader channel should report true")
+		}
+	default:
+		t.Fatal("A should have emitted a leadership change")
+	}
+
+	leader, err := a.GetLeader(ctx)
+	if err != nil || leader != "node-A" {
+		t.Fatalf("GetLeader = %q (err %v), want node-A", leader, err)
+	}
+
+	// B cannot acquire while A holds the lease.
+	acquired, err := b.acquireLock(ctx)
+	if err != nil {
+		t.Fatalf("B acquireLock: %v", err)
+	}
+	if acquired {
+		t.Fatal("B must not acquire the lock while A holds it")
+	}
+	b.attemptLeadership(ctx)
+	if b.IsLeader() {
+		t.Fatal("B should not be leader")
+	}
+
+	// A renews (it already owns the lock).
+	renewed, err := a.acquireLock(ctx)
+	if err != nil || !renewed {
+		t.Fatalf("A renew: acquired=%v err=%v", renewed, err)
+	}
+
+	// A steps down; the key is freed.
+	if err := a.releaseLock(ctx); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if l, _ := a.GetLeader(ctx); l != "" {
+		t.Fatalf("after release, leader = %q, want empty", l)
+	}
+
+	// Now B can take over.
+	b.attemptLeadership(ctx)
+	if !b.IsLeader() {
+		t.Fatal("B should acquire leadership after A releases")
+	}
+	if l, _ := b.GetLeader(ctx); l != "node-B" {
+		t.Fatalf("new leader = %q, want node-B", l)
+	}
+}
+
+func TestReleaseLock_NotOwnerLeavesKey(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	defer mr.Close()
+	ctx := context.Background()
+
+	a := newElection(t, mr.Addr(), "node-A")
+	b := newElection(t, mr.Addr(), "node-B")
+
+	a.attemptLeadership(ctx) // A is leader
+	// B tries to release a lock it does not own: the Lua guard is a no-op.
+	if err := b.releaseLock(ctx); err != nil {
+		t.Fatalf("B release: %v", err)
+	}
+	if l, _ := a.GetLeader(ctx); l != "node-A" {
+		t.Fatalf("A should still hold the lock, leader = %q", l)
+	}
+}


### PR DESCRIPTION
Part of #255. Adds **`github.com/alicebob/miniredis/v2`** as a test dependency to unlock the three Redis-backed packages that were stuck at 0% (they need a live server). miniredis runs in-process, so the tests stay hermetic — no external Redis, no flakiness.

| package | before | after |
|---|---|---|
| `internal/cache` | 0% | 78.3% |
| `internal/eventbus` | 0% | 26.9% |
| `internal/leadership` | 0% | 54.9% |

Total statement coverage: **61.9% → 62.7%**.

## cache
The graceful-disable path when Redis is unreachable (and that operations then no-op), plus round-trip + invalidate for the station list, mounts (including `InvalidateMount` clearing the station default), smart blocks, media items, clocks and clock hours, the multi-key `InvalidateStation`, and `FlushAll`.

## eventbus
`DefaultRedisConfig`, marshal/unmarshal round-trip + the malformed-message error, the circuit-breaker fallback to the in-memory bus when Redis is down, and real cross-node pub/sub delivery between two node IDs (retry-until-received so subscription setup latency can't flake it). The NATS transport needs a real server and is untouched.

## leadership
`DefaultConfig`, `NewElection`'s connect-or-error, single-leader election via `SetNX`, `GetLeader`, lease renewal by the owner, release-then-handover to the other node, and the Lua release guard that refuses to delete a lock owned by someone else.

Test-only apart from the new test dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)