### PR TITLE
test(coverage): recording start/stop via media-engine interface (63.1%)

### DIFF
--- a/internal/recording/service.go
+++ b/internal/recording/service.go
@@ -21,16 +21,24 @@ import (
 	"github.com/friendsincode/grimnir_radio/internal/models"
 )
 
+// MediaEngine is the subset of the media-engine client that the recording
+// service depends on. Declaring it as an interface lets tests inject a fake
+// without a live gRPC connection; *meclient.Client satisfies it in production.
+type MediaEngine interface {
+	StartRecording(ctx context.Context, req *meclient.StartRecordingRequest) error
+	StopRecording(ctx context.Context, stationID, recordingID string) (*meclient.StopRecordingResult, error)
+}
+
 // Service manages recordings: start, stop, quota, chapters, cleanup.
 type Service struct {
 	db        *gorm.DB
-	meClient  *meclient.Client
+	meClient  MediaEngine
 	mediaRoot string
 	logger    zerolog.Logger
 }
 
 // NewService creates a new recording service.
-func NewService(db *gorm.DB, meClient *meclient.Client, mediaRoot string, logger zerolog.Logger) *Service {
+func NewService(db *gorm.DB, meClient MediaEngine, mediaRoot string, logger zerolog.Logger) *Service {
 	return &Service{
 		db:        db,
 		meClient:  meClient,

--- a/internal/recording/service_mediaengine_test.go
+++ b/internal/recording/service_mediaengine_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package recording
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"gorm.io/gorm"
+
+	meclient "github.com/friendsincode/grimnir_radio/internal/mediaengine/client"
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+// fakeME is an injectable stand-in for the media-engine client.
+type fakeME struct {
+	startErr   error
+	stopResult *meclient.StopRecordingResult
+	stopErr    error
+	startCalls int
+	stopCalls  int
+}
+
+func (f *fakeME) StartRecording(ctx context.Context, req *meclient.StartRecordingRequest) error {
+	f.startCalls++
+	return f.startErr
+}
+
+func (f *fakeME) StopRecording(ctx context.Context, stationID, recordingID string) (*meclient.StopRecordingResult, error) {
+	f.stopCalls++
+	return f.stopResult, f.stopErr
+}
+
+func newSvcWithME(t *testing.T, me MediaEngine) (*Service, *gorm.DB) {
+	t.Helper()
+	svc, db := newSvc(t) // reuse the sqlite harness from service_test.go
+	svc.meClient = me
+	return svc, db
+}
+
+func TestStartRecording_Success(t *testing.T) {
+	me := &fakeME{}
+	svc, db := newSvcWithME(t, me)
+	db.Create(&models.Station{ID: "st1", Name: "S", RecordingQuotaBytes: 0})
+
+	rec, err := svc.StartRecording(bg(), StartRequest{StationID: "st1", UserID: "u1", Title: "Live Set"})
+	if err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if rec.Status != models.RecordingStatusActive {
+		t.Fatalf("status = %s, want active", rec.Status)
+	}
+	if me.startCalls != 1 {
+		t.Fatalf("media engine StartRecording calls = %d, want 1", me.startCalls)
+	}
+	var n int64
+	db.Model(&models.Recording{}).Count(&n)
+	if n != 1 {
+		t.Fatalf("expected 1 recording row, got %d", n)
+	}
+}
+
+func TestStartRecording_MediaEngineError_CleansUp(t *testing.T) {
+	me := &fakeME{startErr: errors.New("engine down")}
+	svc, db := newSvcWithME(t, me)
+	db.Create(&models.Station{ID: "st1", Name: "S"})
+
+	if _, err := svc.StartRecording(bg(), StartRequest{StationID: "st1", UserID: "u1"}); err == nil {
+		t.Fatal("expected error when the media engine fails")
+	}
+	// The DB entry must be rolled back so no orphan recording is left behind.
+	var n int64
+	db.Model(&models.Recording{}).Count(&n)
+	if n != 0 {
+		t.Fatalf("failed start should leave no recording rows, got %d", n)
+	}
+}
+
+func TestStopRecording_Success_UpdatesQuota(t *testing.T) {
+	me := &fakeME{stopResult: &meclient.StopRecordingResult{RecordingID: "r1", FileSizeBytes: 2048, DurationMs: 60000}}
+	svc, db := newSvcWithME(t, me)
+	db.Create(&models.Station{ID: "st1", Name: "S", RecordingStorageUsed: 100})
+	db.Create(&models.StationUser{UserID: "u1", StationID: "st1", RecordingStorageUsed: 100})
+	seedRecording(t, db, "r1", "st1", models.RecordingStatusActive, 0)
+
+	rec, err := svc.StopRecording(bg(), "r1")
+	if err != nil {
+		t.Fatalf("stop: %v", err)
+	}
+	if rec.Status != models.RecordingStatusComplete || rec.SizeBytes != 2048 || rec.DurationMs != 60000 {
+		t.Fatalf("stopped recording not finalized: %+v", rec)
+	}
+	if rec.StoppedAt == nil {
+		t.Fatal("StoppedAt should be set")
+	}
+	if me.stopCalls != 1 {
+		t.Fatalf("media engine StopRecording calls = %d, want 1", me.stopCalls)
+	}
+
+	// Station quota usage grows by the recorded size.
+	var station models.Station
+	db.First(&station, "id = ?", "st1")
+	if station.RecordingStorageUsed != 100+2048 {
+		t.Fatalf("station storage used = %d, want %d", station.RecordingStorageUsed, 100+2048)
+	}
+}
+
+func TestStopRecording_NotActive(t *testing.T) {
+	svc, db := newSvcWithME(t, &fakeME{})
+	seedRecording(t, db, "r1", "st1", models.RecordingStatusComplete, 0)
+	if _, err := svc.StopRecording(bg(), "r1"); err == nil {
+		t.Fatal("expected error stopping a non-active recording")
+	}
+}
+
+func TestStopRecording_MediaEngineError_MarksFailed(t *testing.T) {
+	me := &fakeME{stopErr: errors.New("engine down")}
+	svc, db := newSvcWithME(t, me)
+	db.Create(&models.Station{ID: "st1", Name: "S"})
+	seedRecording(t, db, "r1", "st1", models.RecordingStatusActive, 0)
+
+	if _, err := svc.StopRecording(bg(), "r1"); err == nil {
+		t.Fatal("expected error when the media engine stop fails")
+	}
+	var rec models.Recording
+	db.First(&rec, "id = ?", "r1")
+	if rec.Status != models.RecordingStatusFailed {
+		t.Fatalf("status = %s, want failed", rec.Status)
+	}
+}


### PR DESCRIPTION
Part of #255. Chosen direction: a media-engine stub so the recording orchestration becomes testable.

`internal/recording`: **26.2% → 43.9%**. Total statement coverage **63.0% → 63.1%**.

## The one production change
`recording.Service` held a concrete `*meclient.Client`, so its two media-engine calls (`StartRecording`, `StopRecording`) could only run against a live gRPC server. Extracted a 2-method `MediaEngine` interface the service depends on instead. `*meclient.Client` satisfies it unchanged, so the only change is the field/param type — the single caller (`server.go`) compiles as-is. The client package itself is already bufconn-covered (82.9%), so an interface is the right seam here.

## Now covered (with a fake injected)
- `StartRecording` success, and its **rollback that deletes the DB entry** when the engine fails (no orphan recordings).
- `StopRecording` finalizing status/size/duration, stamping `stopped_at`, and **incrementing station quota usage**.
- The not-active guard.
- The engine-stop-failure path that marks the recording `failed`.

Ran x3 to confirm the best-effort chapter-embed goroutine doesn't flake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)