### PR TITLE
test(coverage): 63.1% -> 66.8% across webdj, telemetry, analyzer, migration and models

### DIFF
--- a/internal/analyzer/service.go
+++ b/internal/analyzer/service.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/friendsincode/grimnir_radio/internal/mediaengine/client"
 	"github.com/friendsincode/grimnir_radio/internal/models"
+	pb "github.com/friendsincode/grimnir_radio/proto/mediaengine/v1"
 	"github.com/google/uuid"
 	"github.com/rs/zerolog"
 	"gorm.io/gorm"
@@ -32,6 +33,16 @@ type Config struct {
 	MediaEngineGRPCAddr string // gRPC address of the media engine (required)
 }
 
+// MediaEngine is the slice of the media engine client the analyzer depends on.
+// Narrowing it to an interface lets tests substitute a fake for the gRPC client.
+type MediaEngine interface {
+	Connect(ctx context.Context) error
+	IsConnected() bool
+	Close() error
+	AnalyzeMedia(ctx context.Context, filePath string) (*pb.AnalyzeMediaResponse, error)
+	ExtractArtwork(ctx context.Context, filePath string, maxWidth, maxHeight int32, format string, quality int32) (*pb.ExtractArtworkResponse, error)
+}
+
 // Service performs loudness and cue point analysis on media imports.
 // Analysis is performed by the media engine via gRPC.
 type Service struct {
@@ -39,7 +50,7 @@ type Service struct {
 	logger            zerolog.Logger
 	workDir           string
 	cfg               Config
-	mediaEngineClient *client.Client
+	mediaEngineClient MediaEngine
 }
 
 // New constructs an analyzer service without media engine support.

--- a/internal/analyzer/service_mediaengine_test.go
+++ b/internal/analyzer/service_mediaengine_test.go
@@ -1,0 +1,456 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package analyzer
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+	pb "github.com/friendsincode/grimnir_radio/proto/mediaengine/v1"
+)
+
+// fakeME is an injectable stand-in for the media-engine gRPC client.
+type fakeME struct {
+	connected    bool
+	connectErr   error
+	connectCalls int
+	closeErr     error
+
+	analyzeResp *pb.AnalyzeMediaResponse
+	analyzeErr  error
+	analyzePath string
+
+	artworkResp *pb.ExtractArtworkResponse
+	artworkErr  error
+}
+
+func (f *fakeME) Connect(context.Context) error {
+	f.connectCalls++
+	if f.connectErr != nil {
+		return f.connectErr
+	}
+	f.connected = true
+	return nil
+}
+
+func (f *fakeME) IsConnected() bool { return f.connected }
+func (f *fakeME) Close() error      { return f.closeErr }
+
+func (f *fakeME) AnalyzeMedia(_ context.Context, filePath string) (*pb.AnalyzeMediaResponse, error) {
+	f.analyzePath = filePath
+	return f.analyzeResp, f.analyzeErr
+}
+
+// The real client only ever returns a nil response alongside an error, so the
+// fake mirrors that: no configured response means an empty, unsuccessful one.
+func (f *fakeME) ExtractArtwork(context.Context, string, int32, int32, string, int32) (*pb.ExtractArtworkResponse, error) {
+	if f.artworkErr != nil {
+		return nil, f.artworkErr
+	}
+	if f.artworkResp == nil {
+		return &pb.ExtractArtworkResponse{}, nil
+	}
+	return f.artworkResp, nil
+}
+
+func newSvcWithME(t *testing.T, me MediaEngine) (*Service, *gorm.DB, string) {
+	t.Helper()
+	s, db, workDir := newSvc(t)
+	s.mediaEngineClient = me
+	s.cfg = Config{MediaEngineGRPCAddr: "127.0.0.1:9999"}
+	return s, db, workDir
+}
+
+func okAnalysis() *pb.AnalyzeMediaResponse {
+	return &pb.AnalyzeMediaResponse{
+		Success:      true,
+		DurationMs:   215000,
+		Bitrate:      320,
+		SampleRate:   44100,
+		LoudnessLufs: -14.5,
+		ReplayGain:   2.5,
+		IntroEnd:     8.25,
+		OutroIn:      190.5,
+		Metadata: &pb.MediaMetadata{
+			Title:  "Blue Monday",
+			Artist: "New Order",
+			Album:  "Power, Corruption & Lies",
+			Genre:  "Synth-pop",
+			Year:   "1983",
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// analyzeViaMediaEngine
+// ---------------------------------------------------------------------------
+
+func TestAnalyzeViaMediaEngine_MapsResponse(t *testing.T) {
+	me := &fakeME{connected: true, analyzeResp: okAnalysis()}
+	s, _, _ := newSvcWithME(t, me)
+
+	result, err := s.analyzeViaMediaEngine(bg(), "/media/track.mp3", "m1")
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+
+	if me.analyzePath != "/media/track.mp3" {
+		t.Fatalf("analyzed %q, want the full path", me.analyzePath)
+	}
+	if result.Duration != 215*time.Second {
+		t.Fatalf("duration = %v, want 215s", result.Duration)
+	}
+	if result.Bitrate != 320 || result.Samplerate != 44100 {
+		t.Fatalf("bitrate/samplerate = %d/%d", result.Bitrate, result.Samplerate)
+	}
+	if result.Loudness > -14.4 || result.Loudness < -14.6 {
+		t.Fatalf("loudness = %v, want ~-14.5", result.Loudness)
+	}
+	if result.IntroEnd < 8.2 || result.IntroEnd > 8.3 {
+		t.Fatalf("intro end = %v, want ~8.25", result.IntroEnd)
+	}
+	if result.Title != "Blue Monday" || result.Artist != "New Order" || result.Year != "1983" {
+		t.Fatalf("metadata = %+v", result)
+	}
+	if len(result.Artwork) != 0 {
+		t.Fatal("no artwork was offered, but some was recorded")
+	}
+}
+
+// A disconnected client is reconnected once before the analysis call.
+func TestAnalyzeViaMediaEngine_ConnectsWhenDisconnected(t *testing.T) {
+	me := &fakeME{connected: false, analyzeResp: okAnalysis()}
+	s, _, _ := newSvcWithME(t, me)
+
+	if _, err := s.analyzeViaMediaEngine(bg(), "/media/track.mp3", "m1"); err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if me.connectCalls != 1 {
+		t.Fatalf("connect calls = %d, want 1", me.connectCalls)
+	}
+}
+
+func TestAnalyzeViaMediaEngine_ConnectFailure(t *testing.T) {
+	me := &fakeME{connectErr: errors.New("dial tcp: refused")}
+	s, _, _ := newSvcWithME(t, me)
+
+	_, err := s.analyzeViaMediaEngine(bg(), "/media/track.mp3", "m1")
+	if !errors.Is(err, ErrAnalyzerUnavailable) {
+		t.Fatalf("err = %v, want ErrAnalyzerUnavailable", err)
+	}
+}
+
+func TestAnalyzeViaMediaEngine_RPCError(t *testing.T) {
+	rpcErr := errors.New("stream closed")
+	me := &fakeME{connected: true, analyzeErr: rpcErr}
+	s, _, _ := newSvcWithME(t, me)
+
+	if _, err := s.analyzeViaMediaEngine(bg(), "/media/track.mp3", "m1"); !errors.Is(err, rpcErr) {
+		t.Fatalf("err = %v, want the RPC error", err)
+	}
+}
+
+// A response with success=false carries the reason in Error, which must surface
+// rather than being treated as a clean zero-valued analysis.
+func TestAnalyzeViaMediaEngine_UnsuccessfulResponse(t *testing.T) {
+	me := &fakeME{connected: true, analyzeResp: &pb.AnalyzeMediaResponse{Success: false, Error: "unsupported codec"}}
+	s, _, _ := newSvcWithME(t, me)
+
+	_, err := s.analyzeViaMediaEngine(bg(), "/media/track.mp3", "m1")
+	if err == nil || err.Error() != "unsupported codec" {
+		t.Fatalf("err = %v, want the engine's reason", err)
+	}
+}
+
+func TestAnalyzeViaMediaEngine_ArtworkAttached(t *testing.T) {
+	me := &fakeME{
+		connected:   true,
+		analyzeResp: okAnalysis(),
+		artworkResp: &pb.ExtractArtworkResponse{Success: true, ArtworkData: []byte{0xff, 0xd8, 0xff}, MimeType: "image/jpeg"},
+	}
+	s, _, _ := newSvcWithME(t, me)
+
+	result, err := s.analyzeViaMediaEngine(bg(), "/media/track.mp3", "m1")
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if len(result.Artwork) != 3 || result.ArtworkMime != "image/jpeg" {
+		t.Fatalf("artwork = %v (%q)", result.Artwork, result.ArtworkMime)
+	}
+}
+
+// Artwork extraction is best-effort: its failure must not fail the analysis.
+func TestAnalyzeViaMediaEngine_ArtworkFailureIsNotFatal(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		me   *fakeME
+	}{
+		{"rpc error", &fakeME{connected: true, analyzeResp: okAnalysis(), artworkErr: errors.New("no artwork")}},
+		{"unsuccessful", &fakeME{connected: true, analyzeResp: okAnalysis(), artworkResp: &pb.ExtractArtworkResponse{Success: false}}},
+		{"empty data", &fakeME{connected: true, analyzeResp: okAnalysis(), artworkResp: &pb.ExtractArtworkResponse{Success: true}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s, _, _ := newSvcWithME(t, tc.me)
+			result, err := s.analyzeViaMediaEngine(bg(), "/media/track.mp3", "m1")
+			if err != nil {
+				t.Fatalf("analyze: %v", err)
+			}
+			if len(result.Artwork) != 0 {
+				t.Fatalf("artwork = %v, want none recorded", result.Artwork)
+			}
+			if result.Title != "Blue Monday" {
+				t.Fatal("analysis result was discarded along with the artwork failure")
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// processJob metadata merge
+// ---------------------------------------------------------------------------
+
+func TestProcessJob_WritesAnalysisAndFillsMissingMetadata(t *testing.T) {
+	me := &fakeME{
+		connected:   true,
+		analyzeResp: okAnalysis(),
+		artworkResp: &pb.ExtractArtworkResponse{Success: true, ArtworkData: []byte{0x89, 0x50}, MimeType: "image/png"},
+	}
+	s, db, workDir := newSvcWithME(t, me)
+	// Title equals the filename stem, which is how the importer seeds an
+	// un-analyzed item; that is the case where the tag title may replace it.
+	m := seedMediaFile(t, db, workDir, "media-1", "track.mp3")
+	job := &models.AnalysisJob{ID: "job-1", MediaID: m.ID, Status: "running"}
+	db.Create(job)
+
+	if err := s.processJob(bg(), job); err != nil {
+		t.Fatalf("processJob: %v", err)
+	}
+
+	var media models.MediaItem
+	if err := db.First(&media, "id = ?", m.ID).Error; err != nil {
+		t.Fatalf("reload media: %v", err)
+	}
+	if media.AnalysisState != models.AnalysisComplete {
+		t.Fatalf("analysis state = %q, want complete", media.AnalysisState)
+	}
+	if media.Duration != 215*time.Second {
+		t.Fatalf("duration = %v, want 215s", media.Duration)
+	}
+	if media.Bitrate != 320 || media.Samplerate != 44100 {
+		t.Fatalf("bitrate/samplerate = %d/%d", media.Bitrate, media.Samplerate)
+	}
+	if media.Title != "Blue Monday" {
+		t.Fatalf("title = %q, want the tag title to replace the filename stem", media.Title)
+	}
+	if media.Artist != "New Order" || media.Album != "Power, Corruption & Lies" {
+		t.Fatalf("artist/album = %q/%q", media.Artist, media.Album)
+	}
+	if media.Genre != "Synth-pop" || media.Year != "1983" {
+		t.Fatalf("genre/year = %q/%q", media.Genre, media.Year)
+	}
+	if len(media.Artwork) != 2 || media.ArtworkMime != "image/png" {
+		t.Fatalf("artwork = %v (%q)", media.Artwork, media.ArtworkMime)
+	}
+	if media.CuePoints.IntroEnd < 8.2 || media.CuePoints.IntroEnd > 8.3 {
+		t.Fatalf("intro cue = %v, want ~8.25", media.CuePoints.IntroEnd)
+	}
+
+	var row models.AnalysisJob
+	db.First(&row, "id = ?", "job-1")
+	if row.Status != "complete" {
+		t.Fatalf("job status = %q, want complete", row.Status)
+	}
+}
+
+// Metadata a human already curated wins over whatever the file tags say.
+func TestProcessJob_KeepsExistingMetadata(t *testing.T) {
+	me := &fakeME{
+		connected:   true,
+		analyzeResp: okAnalysis(),
+		artworkResp: &pb.ExtractArtworkResponse{Success: true, ArtworkData: []byte{0x89, 0x50}, MimeType: "image/png"},
+	}
+	s, db, workDir := newSvcWithME(t, me)
+	m := seedMediaFile(t, db, workDir, "media-1", "track.mp3")
+	db.Model(&models.MediaItem{}).Where("id = ?", m.ID).Updates(map[string]any{
+		"title":        "Curated Title",
+		"artist":       "Curated Artist",
+		"album":        "Curated Album",
+		"genre":        "Curated Genre",
+		"year":         "1999",
+		"artwork":      []byte{0x01},
+		"artwork_mime": "image/gif",
+	})
+	job := &models.AnalysisJob{ID: "job-1", MediaID: m.ID, Status: "running"}
+	db.Create(job)
+
+	if err := s.processJob(bg(), job); err != nil {
+		t.Fatalf("processJob: %v", err)
+	}
+
+	var media models.MediaItem
+	db.First(&media, "id = ?", m.ID)
+	if media.Title != "Curated Title" {
+		t.Fatalf("title = %q, want the curated value preserved", media.Title)
+	}
+	if media.Artist != "Curated Artist" || media.Album != "Curated Album" {
+		t.Fatalf("artist/album = %q/%q, want the curated values", media.Artist, media.Album)
+	}
+	if media.Genre != "Curated Genre" || media.Year != "1999" {
+		t.Fatalf("genre/year = %q/%q, want the curated values", media.Genre, media.Year)
+	}
+	if len(media.Artwork) != 1 || media.ArtworkMime != "image/gif" {
+		t.Fatalf("artwork = %v (%q), want the curated artwork kept", media.Artwork, media.ArtworkMime)
+	}
+	// Analysis numbers are always refreshed, curated or not.
+	if media.Duration != 215*time.Second {
+		t.Fatalf("duration = %v, want the analyzed value", media.Duration)
+	}
+}
+
+// Empty tag values must never blank out fields that already hold data.
+func TestProcessJob_EmptyTagsDoNotClearFields(t *testing.T) {
+	me := &fakeME{
+		connected: true,
+		analyzeResp: &pb.AnalyzeMediaResponse{
+			Success:    true,
+			DurationMs: 60000,
+			Metadata:   &pb.MediaMetadata{},
+		},
+	}
+	s, db, workDir := newSvcWithME(t, me)
+	m := seedMediaFile(t, db, workDir, "media-1", "track.mp3")
+	db.Model(&models.MediaItem{}).Where("id = ?", m.ID).Update("artist", "Known Artist")
+	job := &models.AnalysisJob{ID: "job-1", MediaID: m.ID, Status: "running"}
+	db.Create(job)
+
+	if err := s.processJob(bg(), job); err != nil {
+		t.Fatalf("processJob: %v", err)
+	}
+
+	var media models.MediaItem
+	db.First(&media, "id = ?", m.ID)
+	if media.Artist != "Known Artist" {
+		t.Fatalf("artist = %q, want it untouched by the empty tag", media.Artist)
+	}
+	if media.Title != "track" {
+		t.Fatalf("title = %q, want the filename stem retained", media.Title)
+	}
+}
+
+// A response with no Metadata block at all must not panic on the nil pointer.
+func TestProcessJob_NilMetadataBlock(t *testing.T) {
+	me := &fakeME{connected: true, analyzeResp: &pb.AnalyzeMediaResponse{Success: true, DurationMs: 1000}}
+	s, db, workDir := newSvcWithME(t, me)
+	m := seedMediaFile(t, db, workDir, "media-1", "track.mp3")
+	job := &models.AnalysisJob{ID: "job-1", MediaID: m.ID, Status: "running"}
+	db.Create(job)
+
+	if err := s.processJob(bg(), job); err != nil {
+		t.Fatalf("processJob: %v", err)
+	}
+	var media models.MediaItem
+	db.First(&media, "id = ?", m.ID)
+	if media.AnalysisState != models.AnalysisComplete {
+		t.Fatalf("state = %q, want complete", media.AnalysisState)
+	}
+}
+
+func TestProcessJob_EngineFailureMarksJobFailed(t *testing.T) {
+	me := &fakeME{connected: true, analyzeErr: errors.New("decoder crashed")}
+	s, db, workDir := newSvcWithME(t, me)
+	m := seedMediaFile(t, db, workDir, "media-1", "track.mp3")
+	job := &models.AnalysisJob{ID: "job-1", MediaID: m.ID, Status: "running"}
+	db.Create(job)
+
+	if err := s.processJob(bg(), job); err == nil {
+		t.Fatal("processJob succeeded despite an engine failure")
+	}
+
+	var row models.AnalysisJob
+	db.First(&row, "id = ?", "job-1")
+	if row.Status != "failed" || row.Error != "decoder crashed" {
+		t.Fatalf("job = %+v, want failed with the engine's message", row)
+	}
+	var media models.MediaItem
+	db.First(&media, "id = ?", m.ID)
+	if media.AnalysisState != models.AnalysisFailed {
+		t.Fatalf("media state = %q, want failed", media.AnalysisState)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// status and shutdown
+// ---------------------------------------------------------------------------
+
+func TestGetMediaEngineStatus_Connected(t *testing.T) {
+	s, _, _ := newSvcWithME(t, &fakeME{connected: true})
+
+	status := s.GetMediaEngineStatus(bg())
+	if !status.Configured || !status.Connected {
+		t.Fatalf("status = %+v, want configured and connected", status)
+	}
+	if status.Error != "" {
+		t.Fatalf("error = %q, want empty", status.Error)
+	}
+}
+
+func TestGetMediaEngineStatus_ReconnectsOnDemand(t *testing.T) {
+	me := &fakeME{connected: false}
+	s, _, _ := newSvcWithME(t, me)
+
+	status := s.GetMediaEngineStatus(bg())
+	if !status.Connected {
+		t.Fatalf("status = %+v, want the on-demand reconnect to succeed", status)
+	}
+	if me.connectCalls != 1 {
+		t.Fatalf("connect calls = %d, want 1", me.connectCalls)
+	}
+}
+
+func TestGetMediaEngineStatus_ReconnectFailureReported(t *testing.T) {
+	s, _, _ := newSvcWithME(t, &fakeME{connectErr: errors.New("connection refused")})
+
+	status := s.GetMediaEngineStatus(bg())
+	if status.Connected {
+		t.Fatal("reported connected after a failed reconnect")
+	}
+	if status.Error != "connection refused" {
+		t.Fatalf("error = %q, want the dial failure", status.Error)
+	}
+}
+
+func TestTestMediaEngine(t *testing.T) {
+	if err := (&Service{mediaEngineClient: &fakeME{connected: true}}).TestMediaEngine(bg()); err != nil {
+		t.Fatalf("connected engine = %v, want nil", err)
+	}
+
+	me := &fakeME{connected: false}
+	if err := (&Service{mediaEngineClient: me}).TestMediaEngine(bg()); err != nil {
+		t.Fatalf("reconnect = %v, want nil", err)
+	}
+	if me.connectCalls != 1 {
+		t.Fatalf("connect calls = %d, want 1", me.connectCalls)
+	}
+
+	dialErr := errors.New("no route to host")
+	if err := (&Service{mediaEngineClient: &fakeME{connectErr: dialErr}}).TestMediaEngine(bg()); !errors.Is(err, dialErr) {
+		t.Fatalf("err = %v, want the dial error", err)
+	}
+}
+
+func TestClose_ClosesClient(t *testing.T) {
+	closeErr := errors.New("already shut down")
+	s, _, _ := newSvcWithME(t, &fakeME{closeErr: closeErr})
+	if err := s.Close(); !errors.Is(err, closeErr) {
+		t.Fatalf("Close = %v, want the client's error", err)
+	}
+}

--- a/internal/analyzer/service_test.go
+++ b/internal/analyzer/service_test.go
@@ -1,0 +1,381 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package analyzer
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+// newSvc builds an analyzer over in-memory sqlite with no media engine
+// configured, which is the state every gRPC-free code path runs in.
+func newSvc(t *testing.T) (*Service, *gorm.DB, string) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(&models.AnalysisJob{}, &models.MediaItem{}); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	workDir := t.TempDir()
+	return New(db, workDir, zerolog.Nop()), db, workDir
+}
+
+func bg() context.Context { return context.Background() }
+
+// seedMediaFile creates both the DB row and the file on disk so performAnalysis
+// gets past its file-wait loop without sleeping.
+func seedMediaFile(t *testing.T, db *gorm.DB, workDir, id, name string) *models.MediaItem {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(workDir, name), []byte("not really audio"), 0o600); err != nil {
+		t.Fatalf("write media file: %v", err)
+	}
+	m := &models.MediaItem{ID: id, StationID: "st1", Path: name, Title: strings.TrimSuffix(name, filepath.Ext(name))}
+	if err := db.Create(m).Error; err != nil {
+		t.Fatalf("seed media: %v", err)
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// constructors
+// ---------------------------------------------------------------------------
+
+func TestNew_WithoutMediaEngine(t *testing.T) {
+	s, _, _ := newSvc(t)
+	if s.mediaEngineClient != nil {
+		t.Fatal("deprecated New must not build a media engine client")
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+	if err := s.TestMediaEngine(bg()); !errors.Is(err, ErrMediaEngineNotConfigured) {
+		t.Fatalf("TestMediaEngine = %v, want ErrMediaEngineNotConfigured", err)
+	}
+}
+
+func TestNewWithConfig_EmptyAddressSkipsClient(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	s := NewWithConfig(db, t.TempDir(), zerolog.Nop(), Config{})
+	if s.mediaEngineClient != nil {
+		t.Fatal("client built despite an empty gRPC address")
+	}
+	if err := s.Close(); err != nil {
+		t.Fatalf("close: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// queue
+// ---------------------------------------------------------------------------
+
+func TestEnqueue_CreatesPendingJob(t *testing.T) {
+	s, db, _ := newSvc(t)
+
+	jobID, err := s.Enqueue(bg(), "media-1")
+	if err != nil {
+		t.Fatalf("enqueue: %v", err)
+	}
+	if jobID == "" {
+		t.Fatal("empty job ID")
+	}
+
+	var job models.AnalysisJob
+	if err := db.First(&job, "id = ?", jobID).Error; err != nil {
+		t.Fatalf("load job: %v", err)
+	}
+	if job.Status != "pending" {
+		t.Fatalf("status = %q, want pending", job.Status)
+	}
+	if job.MediaID != "media-1" {
+		t.Fatalf("media = %q, want media-1", job.MediaID)
+	}
+}
+
+func TestEnqueue_PropagatesDBError(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	// No AutoMigrate: the analysis_jobs table does not exist.
+	s := New(db, t.TempDir(), zerolog.Nop())
+	if _, err := s.Enqueue(bg(), "media-1"); err == nil {
+		t.Fatal("enqueue succeeded against a missing table")
+	}
+}
+
+// Jobs are claimed oldest-first, and claiming flips the row to running so a
+// second worker can't pick up the same job.
+func TestNextPendingJob_ClaimsOldestFirst(t *testing.T) {
+	s, db, _ := newSvc(t)
+
+	base := time.Now().Add(-time.Hour)
+	db.Create(&models.AnalysisJob{ID: "newer", MediaID: "m2", Status: "pending", CreatedAt: base.Add(30 * time.Minute)})
+	db.Create(&models.AnalysisJob{ID: "older", MediaID: "m1", Status: "pending", CreatedAt: base})
+	db.Create(&models.AnalysisJob{ID: "done", MediaID: "m0", Status: "complete", CreatedAt: base.Add(-time.Hour)})
+
+	job, err := s.nextPendingJob(bg())
+	if err != nil {
+		t.Fatalf("next: %v", err)
+	}
+	if job == nil {
+		t.Fatal("no job claimed")
+	}
+	if job.ID != "older" {
+		t.Fatalf("claimed %q, want the oldest pending job", job.ID)
+	}
+	if job.Status != "running" {
+		t.Fatalf("returned status = %q, want running", job.Status)
+	}
+
+	var row models.AnalysisJob
+	db.First(&row, "id = ?", "older")
+	if row.Status != "running" {
+		t.Fatalf("persisted status = %q, want running", row.Status)
+	}
+
+	// The next claim moves on to the newer job, then the queue drains to nil.
+	job, err = s.nextPendingJob(bg())
+	if err != nil {
+		t.Fatalf("second next: %v", err)
+	}
+	if job == nil || job.ID != "newer" {
+		t.Fatalf("second claim = %+v, want newer", job)
+	}
+
+	job, err = s.nextPendingJob(bg())
+	if err != nil {
+		t.Fatalf("third next: %v", err)
+	}
+	if job != nil {
+		t.Fatalf("claimed %+v from an empty queue, want nil", job)
+	}
+}
+
+func TestNextPendingJob_EmptyQueue(t *testing.T) {
+	s, _, _ := newSvc(t)
+	job, err := s.nextPendingJob(bg())
+	if err != nil {
+		t.Fatalf("next: %v", err)
+	}
+	if job != nil {
+		t.Fatalf("got %+v, want nil", job)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// failure handling
+// ---------------------------------------------------------------------------
+
+func TestFailJob_MarksJobAndMedia(t *testing.T) {
+	s, db, workDir := newSvc(t)
+	m := seedMediaFile(t, db, workDir, "media-1", "track.mp3")
+	db.Create(&models.AnalysisJob{ID: "job-1", MediaID: m.ID, Status: "running"})
+
+	s.failJob(bg(), "job-1", m.ID, errors.New("decoder exploded"))
+
+	var job models.AnalysisJob
+	db.First(&job, "id = ?", "job-1")
+	if job.Status != "failed" {
+		t.Fatalf("job status = %q, want failed", job.Status)
+	}
+	if job.Error != "decoder exploded" {
+		t.Fatalf("job error = %q", job.Error)
+	}
+
+	var media models.MediaItem
+	db.First(&media, "id = ?", m.ID)
+	if media.AnalysisState != models.AnalysisFailed {
+		t.Fatalf("media analysis state = %q, want failed", media.AnalysisState)
+	}
+}
+
+// An empty media ID must not turn into a bare UPDATE across every media item.
+func TestFailJob_EmptyMediaIDLeavesLibraryAlone(t *testing.T) {
+	s, db, workDir := newSvc(t)
+	seedMediaFile(t, db, workDir, "media-1", "track.mp3")
+	db.Create(&models.AnalysisJob{ID: "job-1", Status: "running"})
+
+	s.failJob(bg(), "job-1", "", errors.New("no media"))
+
+	var media models.MediaItem
+	db.First(&media, "id = ?", "media-1")
+	if media.AnalysisState == models.AnalysisFailed {
+		t.Fatal("unrelated media item was marked failed")
+	}
+}
+
+func TestProcessJob_MissingMediaFailsJob(t *testing.T) {
+	s, db, _ := newSvc(t)
+	job := &models.AnalysisJob{ID: "job-1", MediaID: "ghost", Status: "running"}
+	db.Create(job)
+
+	if err := s.processJob(bg(), job); err == nil {
+		t.Fatal("processJob succeeded for a missing media item")
+	}
+
+	var row models.AnalysisJob
+	db.First(&row, "id = ?", "job-1")
+	if row.Status != "failed" {
+		t.Fatalf("job status = %q, want failed", row.Status)
+	}
+}
+
+// With the file present but no media engine configured, the job fails with a
+// clear reason rather than hanging in running forever.
+func TestProcessJob_WithoutMediaEngine(t *testing.T) {
+	s, db, workDir := newSvc(t)
+	m := seedMediaFile(t, db, workDir, "media-1", "track.mp3")
+	job := &models.AnalysisJob{ID: "job-1", MediaID: m.ID, Status: "running"}
+	db.Create(job)
+
+	err := s.processJob(bg(), job)
+	if !errors.Is(err, ErrMediaEngineNotConfigured) {
+		t.Fatalf("processJob = %v, want ErrMediaEngineNotConfigured", err)
+	}
+
+	var row models.AnalysisJob
+	db.First(&row, "id = ?", "job-1")
+	if row.Status != "failed" {
+		t.Fatalf("job status = %q, want failed", row.Status)
+	}
+	if !strings.Contains(row.Error, "not configured") {
+		t.Fatalf("job error = %q, want it to name the missing media engine", row.Error)
+	}
+
+	var media models.MediaItem
+	db.First(&media, "id = ?", m.ID)
+	if media.AnalysisState != models.AnalysisFailed {
+		t.Fatalf("media state = %q, want failed", media.AnalysisState)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// performAnalysis file wait
+// ---------------------------------------------------------------------------
+
+func TestPerformAnalysis_FilePresentButNoEngine(t *testing.T) {
+	s, db, workDir := newSvc(t)
+	m := seedMediaFile(t, db, workDir, "media-1", "track.mp3")
+
+	if _, err := s.performAnalysis(bg(), m); !errors.Is(err, ErrMediaEngineNotConfigured) {
+		t.Fatalf("err = %v, want ErrMediaEngineNotConfigured", err)
+	}
+}
+
+// The file-wait loop retries on ENOENT; a cancelled context has to break it
+// instead of burning the full 5 attempts.
+func TestPerformAnalysis_MissingFileHonoursCancellation(t *testing.T) {
+	s, _, _ := newSvc(t)
+	ctx, cancel := context.WithCancel(bg())
+	cancel()
+
+	start := time.Now()
+	_, err := s.performAnalysis(ctx, &models.MediaItem{ID: "m1", Path: "never-written.mp3"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("err = %v, want context.Canceled", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("waited %v before honouring cancellation", elapsed)
+	}
+}
+
+// A stat error that is not "does not exist" aborts immediately: retrying would
+// never fix a path whose parent is a regular file.
+func TestPerformAnalysis_NonExistenceStatErrorFailsFast(t *testing.T) {
+	s, _, workDir := newSvc(t)
+	if err := os.WriteFile(filepath.Join(workDir, "blocker"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+
+	start := time.Now()
+	_, err := s.performAnalysis(bg(), &models.MediaItem{ID: "m1", Path: "blocker/track.mp3"})
+	if err == nil {
+		t.Fatal("expected a stat error")
+	}
+	if errors.Is(err, ErrMediaEngineNotConfigured) {
+		t.Fatalf("err = %v, want the stat failure to short-circuit first", err)
+	}
+	if elapsed := time.Since(start); elapsed > 2*time.Second {
+		t.Fatalf("retried a permanent stat error for %v", elapsed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// status reporting
+// ---------------------------------------------------------------------------
+
+func TestGetMediaEngineStatus_NotConfigured(t *testing.T) {
+	s, _, _ := newSvc(t)
+	status := s.GetMediaEngineStatus(bg())
+
+	if status.Configured {
+		t.Fatal("reported as configured")
+	}
+	if status.Connected {
+		t.Fatal("reported as connected")
+	}
+	if status.Error == "" {
+		t.Fatal("expected an explanatory error string")
+	}
+}
+
+func TestGetMediaEngineStatus_ConfiguredButClientMissing(t *testing.T) {
+	s, _, _ := newSvc(t)
+	s.cfg = Config{MediaEngineGRPCAddr: "127.0.0.1:65000"}
+
+	status := s.GetMediaEngineStatus(bg())
+	if !status.Configured {
+		t.Fatal("should report configured once an address is set")
+	}
+	if status.Address != "127.0.0.1:65000" {
+		t.Fatalf("address = %q", status.Address)
+	}
+	if status.Connected {
+		t.Fatal("reported connected with no client")
+	}
+	if !strings.Contains(status.Error, "not initialized") {
+		t.Fatalf("error = %q, want it to name the uninitialized client", status.Error)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// run loop
+// ---------------------------------------------------------------------------
+
+func TestRun_StopsOnContextCancel(t *testing.T) {
+	s, _, _ := newSvc(t)
+	ctx, cancel := context.WithCancel(bg())
+	cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- s.Run(ctx) }()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Run = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Run did not return after context cancellation")
+	}
+}

--- a/internal/migration/analyze_api_test.go
+++ b/internal/migration/analyze_api_test.go
@@ -1,0 +1,723 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package migration
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// azuraAnalyzeServer answers the endpoints AnalyzeDetailed walks for a single
+// station, and returns Options pointed at it.
+func azuraAnalyzeServer(t *testing.T, handler http.HandlerFunc) Options {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return Options{AzuraCastAPIURL: srv.URL, AzuraCastAPIKey: "test-key"}
+}
+
+func ltAnalyzeServer(t *testing.T, handler http.HandlerFunc) Options {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return Options{LibreTimeAPIURL: srv.URL, LibreTimeAPIKey: "lt-key"}
+}
+
+// deadServerOptions returns options pointing at a closed port.
+func deadServerURL(t *testing.T) string {
+	t.Helper()
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	url := srv.URL
+	srv.Close()
+	return url
+}
+
+func newAzuraImporter() *AzuraCastImporter {
+	return NewAzuraCastImporter(nil, nil, zerolog.Nop())
+}
+
+func newLTImporter() *LibreTimeImporter {
+	return NewLibreTimeImporter(nil, nil, zerolog.Nop())
+}
+
+// ---------------------------------------------------------------------------
+// mode detection and small helpers
+// ---------------------------------------------------------------------------
+
+func TestIsAPIMode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts Options
+		want bool
+	}{
+		{"api key", Options{AzuraCastAPIURL: "https://a", AzuraCastAPIKey: "k"}, true},
+		{"credentials", Options{AzuraCastAPIURL: "https://a", AzuraCastUsername: "u", AzuraCastPassword: "p"}, true},
+		{"url alone is not enough", Options{AzuraCastAPIURL: "https://a"}, false},
+		{"key without url", Options{AzuraCastAPIKey: "k"}, false},
+		{"username without password", Options{AzuraCastAPIURL: "https://a", AzuraCastUsername: "u"}, false},
+		{"backup path only", Options{AzuraCastBackupPath: "/tmp/backup.tar.gz"}, false},
+	} {
+		if got := isAPIMode(tc.opts); got != tc.want {
+			t.Fatalf("%s: isAPIMode = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestIsLibreTimeAPIMode(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts Options
+		want bool
+	}{
+		{"url and key", Options{LibreTimeAPIURL: "https://lt", LibreTimeAPIKey: "k"}, true},
+		{"url alone", Options{LibreTimeAPIURL: "https://lt"}, false},
+		{"key alone", Options{LibreTimeAPIKey: "k"}, false},
+		{"db mode", Options{LibreTimeDBHost: "db", LibreTimeDBName: "libretime", LibreTimeDBUser: "lt"}, false},
+	} {
+		if got := isLibreTimeAPIMode(tc.opts); got != tc.want {
+			t.Fatalf("%s: isLibreTimeAPIMode = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestCreateAPIClient_PrefersAPIKey(t *testing.T) {
+	// A key never triggers a login round trip, so a dead URL is fine here.
+	client, err := createAPIClient(Options{AzuraCastAPIURL: "https://radio.example.com", AzuraCastAPIKey: "k"})
+	if err != nil {
+		t.Fatalf("key mode: %v", err)
+	}
+	if client.apiKey != "k" {
+		t.Fatalf("api key = %q", client.apiKey)
+	}
+	if client.sessionToken != "" {
+		t.Fatal("key mode should not perform a credential login")
+	}
+}
+
+func TestCreateAPIClient_CredentialsLogin(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/internal/login" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		writeJSON(t, w, map[string]any{"success": true, "token": "tok-77"})
+	}))
+	defer srv.Close()
+
+	client, err := createAPIClient(Options{AzuraCastAPIURL: srv.URL, AzuraCastUsername: "admin", AzuraCastPassword: "pw"})
+	if err != nil {
+		t.Fatalf("credential mode: %v", err)
+	}
+	if client.sessionToken != "tok-77" {
+		t.Fatalf("session token = %q", client.sessionToken)
+	}
+}
+
+func TestCalculateETA(t *testing.T) {
+	if got := calculateETA(time.Now(), 0, 100); got != "calculating..." {
+		t.Fatalf("no progress = %q", got)
+	}
+	if got := calculateETA(time.Now(), 10, 0); got != "calculating..." {
+		t.Fatalf("no total = %q", got)
+	}
+
+	// 10 items in 10s is 1s each; 20 remaining is 20s.
+	start := time.Now().Add(-10 * time.Second)
+	if got := calculateETA(start, 10, 30); !strings.HasSuffix(got, "s remaining") || strings.Contains(got, "m ") {
+		t.Fatalf("sub-minute ETA = %q, want a seconds-only estimate", got)
+	}
+
+	// 10 items in 100s is 10s each; 50 remaining is 500s, just over 8 minutes.
+	start = time.Now().Add(-100 * time.Second)
+	got := calculateETA(start, 10, 60)
+	if !strings.Contains(got, "m ") || !strings.HasSuffix(got, "s remaining") {
+		t.Fatalf("minutes ETA = %q, want a minutes and seconds estimate", got)
+	}
+
+	// 1 item in an hour, 5 remaining, is a 5 hour estimate.
+	start = time.Now().Add(-time.Hour)
+	got = calculateETA(start, 1, 6)
+	if !strings.Contains(got, "h ") || !strings.HasSuffix(got, "m remaining") {
+		t.Fatalf("hours ETA = %q, want an hours and minutes estimate", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// AzuraCast Validate
+// ---------------------------------------------------------------------------
+
+func TestAzuraCastValidate_RequiresOneImportMethod(t *testing.T) {
+	err := newAzuraImporter().Validate(actx(), Options{})
+	if err == nil {
+		t.Fatal("empty options accepted")
+	}
+	var verrs ValidationErrors
+	if !errors.As(err, &verrs) {
+		t.Fatalf("err = %T, want ValidationErrors", err)
+	}
+	if !strings.Contains(verrs[0].Message, "either backup path") {
+		t.Fatalf("message = %q", verrs[0].Message)
+	}
+}
+
+// Supplying both a backup and API credentials is ambiguous, and silently
+// picking one would import from a source the operator did not intend.
+func TestAzuraCastValidate_RejectsBothMethods(t *testing.T) {
+	dir := t.TempDir()
+	backup := filepath.Join(dir, "backup.tar.gz")
+	if err := os.WriteFile(backup, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write backup: %v", err)
+	}
+
+	err := newAzuraImporter().Validate(actx(), Options{
+		AzuraCastBackupPath: backup,
+		AzuraCastAPIURL:     "https://radio.example.com",
+		AzuraCastAPIKey:     "k",
+	})
+	if err == nil {
+		t.Fatal("both methods accepted")
+	}
+	if !strings.Contains(err.Error(), "cannot specify both") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestAzuraCastValidate_BackupFileChecks(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("missing file", func(t *testing.T) {
+		err := newAzuraImporter().Validate(actx(), Options{AzuraCastBackupPath: filepath.Join(dir, "absent.tar.gz")})
+		if err == nil || !strings.Contains(err.Error(), "does not exist") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+
+	t.Run("wrong extension", func(t *testing.T) {
+		zipPath := filepath.Join(dir, "backup.zip")
+		if err := os.WriteFile(zipPath, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		err := newAzuraImporter().Validate(actx(), Options{AzuraCastBackupPath: zipPath})
+		if err == nil {
+			t.Fatal("non-tar.gz accepted")
+		}
+		var verrs ValidationErrors
+		if !errors.As(err, &verrs) {
+			t.Fatalf("err = %T", err)
+		}
+		if !strings.Contains(verrs[0].Message, ".tar.gz") {
+			t.Fatalf("message = %q", verrs[0].Message)
+		}
+	})
+
+	t.Run("valid archive", func(t *testing.T) {
+		good := filepath.Join(dir, "good.tar.gz")
+		if err := os.WriteFile(good, []byte("x"), 0o600); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := newAzuraImporter().Validate(actx(), Options{AzuraCastBackupPath: good}); err != nil {
+			t.Fatalf("valid backup rejected: %v", err)
+		}
+	})
+}
+
+func TestAzuraCastValidate_APIConnection(t *testing.T) {
+	t.Run("reachable", func(t *testing.T) {
+		opts := azuraAnalyzeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, &AzuraCastAPIStatus{Online: true})
+		})
+		if err := newAzuraImporter().Validate(actx(), opts); err != nil {
+			t.Fatalf("validate: %v", err)
+		}
+	})
+
+	t.Run("unreachable", func(t *testing.T) {
+		err := newAzuraImporter().Validate(actx(), Options{AzuraCastAPIURL: deadServerURL(t), AzuraCastAPIKey: "k"})
+		if err == nil {
+			t.Fatal("dead server accepted")
+		}
+		if !strings.Contains(err.Error(), "API connection failed") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+
+	t.Run("bad credentials", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		defer srv.Close()
+
+		err := newAzuraImporter().Validate(actx(), Options{
+			AzuraCastAPIURL:   srv.URL,
+			AzuraCastUsername: "admin",
+			AzuraCastPassword: "wrong",
+		})
+		if err == nil {
+			t.Fatal("bad credentials accepted")
+		}
+		if !strings.Contains(err.Error(), "API authentication failed") {
+			t.Fatalf("err = %v", err)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// AzuraCast AnalyzeDetailed
+// ---------------------------------------------------------------------------
+
+func TestAzuraCastAnalyzeDetailed(t *testing.T) {
+	opts := azuraAnalyzeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/stations":
+			writeJSON(t, w, []AzuraCastAPIStation{
+				{ID: 1, Name: "Main", Description: "Primary"},
+				{ID: 2, Name: "Side", Description: "Secondary"},
+			})
+		case "/api/station/1/files":
+			writeJSON(t, w, []AzuraCastAPIMediaFile{
+				{ID: 10, Title: "A", Size: 5_000_000},
+				{ID: 11, Title: "B", Size: 3_000_000},
+			})
+		case "/api/station/2/files":
+			// No Size, so storage is estimated from Length at 192kbps.
+			writeJSON(t, w, []AzuraCastAPIMediaFile{{ID: 20, Title: "C", Length: 100}})
+		case "/api/station/1/playlists":
+			writeJSON(t, w, []AzuraCastAPIPlaylist{
+				{ID: 100, Name: "Morning", Type: "default", Source: "songs", NumSongs: 42,
+					ScheduleItems: []AzuraCastAPISchedule{{ID: 1}, {ID: 2}}},
+			})
+		case "/api/station/2/playlists":
+			writeJSON(t, w, []AzuraCastAPIPlaylist{{ID: 200, Name: "Night", NumSongs: 7}})
+		case "/api/station/1/mounts":
+			writeJSON(t, w, []AzuraCastAPIMount{{ID: 3, Name: "/radio.mp3", AutodjFormat: "mp3", AutodjBitrate: 192}})
+		case "/api/station/2/mounts":
+			writeJSON(t, w, []AzuraCastAPIMount{})
+		case "/api/station/1/streamers":
+			writeJSON(t, w, []AzuraCastAPIStreamer{{ID: 9, StreamerUsername: "dj_night", DisplayName: "Night DJ"}})
+		case "/api/station/2/streamers":
+			writeJSON(t, w, []AzuraCastAPIStreamer{})
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	report, err := newAzuraImporter().AnalyzeDetailed(actx(), opts)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+
+	if report.TotalStations != 2 {
+		t.Fatalf("stations = %d, want 2", report.TotalStations)
+	}
+	if report.TotalMedia != 3 {
+		t.Fatalf("media = %d, want 3", report.TotalMedia)
+	}
+	if report.TotalPlaylists != 2 {
+		t.Fatalf("playlists = %d, want 2", report.TotalPlaylists)
+	}
+	// Schedules come from the first station's two schedule_items.
+	if report.TotalSchedules != 2 {
+		t.Fatalf("schedules = %d, want 2", report.TotalSchedules)
+	}
+	if report.TotalStreamers != 1 {
+		t.Fatalf("streamers = %d, want 1", report.TotalStreamers)
+	}
+
+	// 8 MB of real sizes, plus 100s at 192kbps = 2,400,000 bytes estimated.
+	const wantBytes = 5_000_000 + 3_000_000 + 100*192*1000/8
+	if report.EstimatedStorageBytes != wantBytes {
+		t.Fatalf("storage = %d, want %d", report.EstimatedStorageBytes, wantBytes)
+	}
+	if !strings.HasSuffix(report.EstimatedStorageHuman, "MB") {
+		t.Fatalf("human storage = %q, want MB", report.EstimatedStorageHuman)
+	}
+
+	if len(report.Stations) != 2 {
+		t.Fatalf("station analyses = %d", len(report.Stations))
+	}
+	main := report.Stations[0]
+	if main.MediaCount != 2 || main.StorageBytes != 8_000_000 {
+		t.Fatalf("main station = %+v", main)
+	}
+	if len(main.Playlists) != 1 || main.Playlists[0].ItemCount != 42 {
+		t.Fatalf("main playlists = %+v", main.Playlists)
+	}
+	if len(main.Mounts) != 1 || main.Mounts[0].Bitrate != 192 || main.Mounts[0].Format != "mp3" {
+		t.Fatalf("main mounts = %+v", main.Mounts)
+	}
+	if len(main.Streamers) != 1 || main.Streamers[0].Username != "dj_night" {
+		t.Fatalf("main streamers = %+v", main.Streamers)
+	}
+
+	// Multiple stations get the deduplication caveat.
+	var sawDedup bool
+	for _, warn := range report.Warnings {
+		if strings.Contains(warn, "deduplication") {
+			sawDedup = true
+		}
+	}
+	if !sawDedup {
+		t.Fatalf("warnings = %v, want the multi-station deduplication note", report.Warnings)
+	}
+}
+
+// A station whose media endpoint 403s must produce a warning naming the
+// station, not abort the whole analysis.
+func TestAzuraCastAnalyzeDetailed_PartialFailuresBecomeWarnings(t *testing.T) {
+	opts := azuraAnalyzeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/stations":
+			writeJSON(t, w, []AzuraCastAPIStation{{ID: 1, Name: "Main"}})
+		case "/api/station/1/files":
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			// Playlists, mounts and streamers all fail too.
+			w.WriteHeader(http.StatusForbidden)
+		}
+	})
+
+	report, err := newAzuraImporter().AnalyzeDetailed(actx(), opts)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if report.TotalStations != 1 {
+		t.Fatalf("stations = %d", report.TotalStations)
+	}
+	if report.TotalMedia != 0 {
+		t.Fatalf("media = %d, want 0", report.TotalMedia)
+	}
+
+	var sawMediaWarning bool
+	for _, warn := range report.Warnings {
+		if strings.Contains(warn, "Could not fetch media for station Main") {
+			sawMediaWarning = true
+		}
+	}
+	if !sawMediaWarning {
+		t.Fatalf("warnings = %v, want one naming the station", report.Warnings)
+	}
+}
+
+// An API key scoped to nothing returns an empty station list; the report has
+// to say so rather than reporting a clean, empty migration.
+func TestAzuraCastAnalyzeDetailed_NoStations(t *testing.T) {
+	opts := azuraAnalyzeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/stations" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		writeJSON(t, w, []AzuraCastAPIStation{})
+	})
+
+	report, err := newAzuraImporter().AnalyzeDetailed(actx(), opts)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+
+	joined := strings.Join(report.Warnings, "|")
+	if !strings.Contains(joined, "No stations found") {
+		t.Fatalf("warnings = %v, want the permissions hint", report.Warnings)
+	}
+	if !strings.Contains(joined, "No media files found") {
+		t.Fatalf("warnings = %v, want the empty-media warning", report.Warnings)
+	}
+}
+
+func TestAzuraCastAnalyzeDetailed_StationsFetchFails(t *testing.T) {
+	opts := azuraAnalyzeServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := newAzuraImporter().AnalyzeDetailed(actx(), opts); err == nil {
+		t.Fatal("expected an error when stations cannot be listed")
+	}
+}
+
+// Analyze in API mode reduces the detailed report to the summary Result the
+// migration UI renders.
+func TestAzuraCastAnalyze_MapsReportToResult(t *testing.T) {
+	opts := azuraAnalyzeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/stations":
+			writeJSON(t, w, []AzuraCastAPIStation{{ID: 1, Name: "Main"}})
+		case "/api/station/1/files":
+			writeJSON(t, w, []AzuraCastAPIMediaFile{{ID: 10, Size: 100}, {ID: 11, Size: 200}})
+		case "/api/station/1/playlists":
+			writeJSON(t, w, []AzuraCastAPIPlaylist{{ID: 100, ScheduleItems: []AzuraCastAPISchedule{{ID: 1}}}})
+		case "/api/station/1/mounts":
+			writeJSON(t, w, []AzuraCastAPIMount{})
+		case "/api/station/1/streamers":
+			writeJSON(t, w, []AzuraCastAPIStreamer{{ID: 9}})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	result, err := newAzuraImporter().Analyze(actx(), opts)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if result.StationsCreated != 1 {
+		t.Fatalf("stations = %d", result.StationsCreated)
+	}
+	if result.MediaItemsImported != 2 {
+		t.Fatalf("media = %d, want 2", result.MediaItemsImported)
+	}
+	if result.PlaylistsCreated != 1 {
+		t.Fatalf("playlists = %d", result.PlaylistsCreated)
+	}
+	if result.SchedulesCreated != 1 {
+		t.Fatalf("schedules = %d", result.SchedulesCreated)
+	}
+	if result.UsersCreated != 1 {
+		t.Fatalf("streamers mapped to users = %d, want 1", result.UsersCreated)
+	}
+	if result.Skipped == nil || result.Mappings == nil {
+		t.Fatal("Skipped and Mappings must be initialized, not nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// LibreTime Validate
+// ---------------------------------------------------------------------------
+
+// Database mode reports every missing field at once so the operator fixes the
+// form in one pass.
+func TestLibreTimeValidate_DatabaseModeMissingFields(t *testing.T) {
+	err := newLTImporter().Validate(actx(), Options{})
+	if err == nil {
+		t.Fatal("empty options accepted")
+	}
+	var verrs ValidationErrors
+	if !errors.As(err, &verrs) {
+		t.Fatalf("err = %T, want ValidationErrors", err)
+	}
+	if len(verrs) != 3 {
+		t.Fatalf("errors = %d, want one each for host, name and user: %v", len(verrs), verrs)
+	}
+
+	fields := map[string]bool{}
+	for _, e := range verrs {
+		fields[e.Field] = true
+	}
+	for _, want := range []string{"libretime_db_host", "libretime_db_name", "libretime_db_user"} {
+		if !fields[want] {
+			t.Fatalf("missing %s in %v", want, verrs)
+		}
+	}
+}
+
+func TestLibreTimeValidate_APIMode(t *testing.T) {
+	t.Run("reachable", func(t *testing.T) {
+		opts := ltAnalyzeServer(t, func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/api/v2/version":
+				writeJSON(t, w, map[string]string{"api_version": "4.2.0"})
+			case "/api/v2/files":
+				writeJSON(t, w, []LTFile{})
+			default:
+				t.Errorf("unexpected path %q", r.URL.Path)
+			}
+		})
+		if err := newLTImporter().Validate(actx(), opts); err != nil {
+			t.Fatalf("validate: %v", err)
+		}
+	})
+
+	t.Run("unreachable", func(t *testing.T) {
+		err := newLTImporter().Validate(actx(), Options{
+			LibreTimeAPIURL: deadServerURL(t),
+			LibreTimeAPIKey: "k",
+		})
+		if err == nil {
+			t.Fatal("dead server accepted")
+		}
+		var verrs ValidationErrors
+		if !errors.As(err, &verrs) {
+			t.Fatalf("err = %T", err)
+		}
+		if verrs[0].Field != "libretime_api" {
+			t.Fatalf("field = %q", verrs[0].Field)
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// LibreTime AnalyzeDetailed
+// ---------------------------------------------------------------------------
+
+func TestLibreTimeAnalyzeDetailed(t *testing.T) {
+	opts := ltAnalyzeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/files":
+			writeJSON(t, w, []LTFile{
+				{ID: 1, Title: "A", Artist: "X", Size: 4_000_000, FileExists: true},
+				{ID: 2, Title: "B", Artist: "Y", Size: 2_000_000, FileExists: true},
+				// Hidden and missing files count toward the total but are
+				// excluded from the storage estimate and the file list.
+				{ID: 3, Title: "Hidden", Size: 9_000_000, FileExists: true, Hidden: true},
+				{ID: 4, Title: "Gone", Size: 9_000_000, FileExists: false},
+			})
+		case "/api/v2/playlists":
+			writeJSON(t, w, []LTPlaylist{
+				{ID: 10, Name: "Morning", Length: "01:00:00"},
+				{ID: 11, Name: "Empty"},
+			})
+		case "/api/v2/playlist-contents":
+			writeJSON(t, w, []LTPlaylistContent{
+				{ID: 1, PlaylistID: intPtr(10), FileID: intPtr(1)},
+				{ID: 2, PlaylistID: intPtr(10), FileID: intPtr(2)},
+				{ID: 3, PlaylistID: intPtr(10), BlockID: intPtr(5)},
+				{ID: 4, PlaylistID: intPtr(10), StreamID: intPtr(7)},
+			})
+		case "/api/v2/shows":
+			writeJSON(t, w, []LTShow{
+				{ID: 20, Name: "Nightshift", Description: "Late", Genre: "Electronic"},
+			})
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	report, err := newLTImporter().AnalyzeDetailed(actx(), opts)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+
+	if report.TotalFiles != 4 {
+		t.Fatalf("total files = %d, want all 4 counted", report.TotalFiles)
+	}
+	if len(report.Files) != 2 {
+		t.Fatalf("listed files = %d, want the 2 visible and present ones", len(report.Files))
+	}
+	if report.EstimatedStorageBytes != 6_000_000 {
+		t.Fatalf("storage = %d, want 6000000 (hidden and missing excluded)", report.EstimatedStorageBytes)
+	}
+	if report.EstimatedStorageHuman == "" {
+		t.Fatal("human storage empty")
+	}
+
+	if report.TotalPlaylists != 2 {
+		t.Fatalf("playlists = %d, want 2", report.TotalPlaylists)
+	}
+	morning := report.Playlists[0]
+	if morning.ItemCount != 4 {
+		t.Fatalf("morning items = %d, want 4", morning.ItemCount)
+	}
+	if morning.FileCount != 2 || morning.BlockCount != 1 || morning.StreamCount != 1 {
+		t.Fatalf("morning breakdown = %+v, want 2 files, 1 block, 1 stream", morning)
+	}
+	if report.Playlists[1].ItemCount != 0 {
+		t.Fatalf("empty playlist = %+v", report.Playlists[1])
+	}
+
+	if report.TotalShows != 1 || report.Shows[0].Genre != "Electronic" {
+		t.Fatalf("shows = %+v", report.Shows)
+	}
+	if len(report.Warnings) != 0 {
+		t.Fatalf("warnings = %v, want none", report.Warnings)
+	}
+}
+
+func TestLibreTimeAnalyzeDetailed_EmptyLibraryWarns(t *testing.T) {
+	opts := ltAnalyzeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/files":
+			writeJSON(t, w, []LTFile{})
+		case "/api/v2/playlists":
+			writeJSON(t, w, []LTPlaylist{})
+		case "/api/v2/shows":
+			writeJSON(t, w, []LTShow{})
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	})
+
+	report, err := newLTImporter().AnalyzeDetailed(actx(), opts)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if !strings.Contains(strings.Join(report.Warnings, "|"), "No media files found") {
+		t.Fatalf("warnings = %v", report.Warnings)
+	}
+}
+
+// Unlike AzuraCast, a failed file listing here is a warning rather than a hard
+// error, so the operator still sees the playlist and show counts.
+func TestLibreTimeAnalyzeDetailed_FileFetchFailureIsAWarning(t *testing.T) {
+	opts := ltAnalyzeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/files":
+			w.WriteHeader(http.StatusForbidden)
+		case "/api/v2/playlists":
+			writeJSON(t, w, []LTPlaylist{{ID: 10, Name: "Morning"}})
+		case "/api/v2/playlist-contents":
+			writeJSON(t, w, []LTPlaylistContent{})
+		case "/api/v2/shows":
+			writeJSON(t, w, []LTShow{{ID: 20, Name: "Nightshift"}})
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	})
+
+	report, err := newLTImporter().AnalyzeDetailed(actx(), opts)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if report.TotalPlaylists != 1 || report.TotalShows != 1 {
+		t.Fatalf("report = %+v, want playlist and show counts to survive", report)
+	}
+	if !strings.Contains(strings.Join(report.Warnings, "|"), "Could not fetch files") {
+		t.Fatalf("warnings = %v", report.Warnings)
+	}
+}
+
+func TestLibreTimeAnalyze_MapsReportToResult(t *testing.T) {
+	opts := ltAnalyzeServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/files":
+			writeJSON(t, w, []LTFile{{ID: 1, FileExists: true, Size: 100}})
+		case "/api/v2/playlists":
+			writeJSON(t, w, []LTPlaylist{{ID: 10}, {ID: 11}})
+		case "/api/v2/playlist-contents":
+			writeJSON(t, w, []LTPlaylistContent{})
+		case "/api/v2/shows":
+			writeJSON(t, w, []LTShow{{ID: 20}, {ID: 21}, {ID: 22}})
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	})
+
+	result, err := newLTImporter().Analyze(actx(), opts)
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	// LibreTime is single-station by design.
+	if result.StationsCreated != 1 {
+		t.Fatalf("stations = %d, want 1", result.StationsCreated)
+	}
+	if result.MediaItemsImported != 1 {
+		t.Fatalf("media = %d", result.MediaItemsImported)
+	}
+	if result.PlaylistsCreated != 2 {
+		t.Fatalf("playlists = %d", result.PlaylistsCreated)
+	}
+	if result.SchedulesCreated != 3 {
+		t.Fatalf("shows mapped to schedules = %d, want 3", result.SchedulesCreated)
+	}
+	if result.UsersCreated != 0 {
+		t.Fatalf("users = %d, want 0", result.UsersCreated)
+	}
+}

--- a/internal/migration/azuracast_api_test.go
+++ b/internal/migration/azuracast_api_test.go
@@ -1,0 +1,554 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package migration
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// azuraServer stands up an httptest server and returns a client pointed at it,
+// plus the paths the client requested in order.
+func azuraServer(t *testing.T, handler http.HandlerFunc) (*AzuraCastAPIClient, *[]string) {
+	t.Helper()
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.RequestURI())
+		handler(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := NewAzuraCastAPIClient(srv.URL, "test-key")
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	return client, &paths
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		t.Errorf("encode: %v", err)
+	}
+}
+
+func actx() context.Context { return context.Background() }
+
+// ---------------------------------------------------------------------------
+// construction
+// ---------------------------------------------------------------------------
+
+func TestNewAzuraCastAPIClient_NormalizesBaseURL(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"https://radio.example.com", "https://radio.example.com"},
+		{"https://radio.example.com/", "https://radio.example.com"},
+		{"http://192.168.1.10:8080", "http://192.168.1.10:8080"},
+		// A bare host gets https, not http: imports carry an API key.
+		{"radio.example.com", "https://radio.example.com"},
+		{"radio.example.com/", "https://radio.example.com"},
+	} {
+		client, err := NewAzuraCastAPIClient(tc.in, "k")
+		if err != nil {
+			t.Fatalf("new(%q): %v", tc.in, err)
+		}
+		if client.baseURL != tc.want {
+			t.Fatalf("new(%q) baseURL = %q, want %q", tc.in, client.baseURL, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// request plumbing
+// ---------------------------------------------------------------------------
+
+func TestAzuraCastDoRequest_SendsAPIKeyHeaders(t *testing.T) {
+	var gotKey, gotAuth, gotAccept string
+	client, _ := azuraServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("X-API-Key")
+		gotAuth = r.Header.Get("Authorization")
+		gotAccept = r.Header.Get("Accept")
+		writeJSON(t, w, &AzuraCastAPIStatus{Online: true})
+	})
+
+	if _, err := client.TestConnection(actx()); err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if gotKey != "test-key" {
+		t.Fatalf("X-API-Key = %q", gotKey)
+	}
+	if gotAuth != "Bearer test-key" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if gotAccept != "application/json" {
+		t.Fatalf("Accept = %q", gotAccept)
+	}
+}
+
+// With no API key, the session token from a username/password login carries the
+// request instead.
+func TestAzuraCastDoRequest_FallsBackToSessionToken(t *testing.T) {
+	var gotKey, gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotKey = r.Header.Get("X-API-Key")
+		gotAuth = r.Header.Get("Authorization")
+		writeJSON(t, w, &AzuraCastAPIStatus{Online: true})
+	}))
+	defer srv.Close()
+
+	client, err := NewAzuraCastAPIClient(srv.URL, "")
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	client.sessionToken = "sess-abc"
+
+	if _, err := client.TestConnection(actx()); err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if gotKey != "" {
+		t.Fatalf("X-API-Key = %q, want empty", gotKey)
+	}
+	if gotAuth != "Bearer sess-abc" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+}
+
+func TestAzuraCastDecode_ErrorStatusIncludesBody(t *testing.T) {
+	client, _ := azuraServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, "insufficient permissions")
+	})
+
+	_, err := client.GetStations(actx())
+	if err == nil {
+		t.Fatal("expected an error for a 403")
+	}
+	if !strings.Contains(err.Error(), "403") || !strings.Contains(err.Error(), "insufficient permissions") {
+		t.Fatalf("err = %v, want the status and body echoed", err)
+	}
+}
+
+func TestAzuraCastDecode_MalformedJSON(t *testing.T) {
+	client, _ := azuraServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "<html>login page</html>")
+	})
+
+	if _, err := client.GetStations(actx()); err == nil {
+		t.Fatal("expected a decode error for a non-JSON body")
+	}
+}
+
+// A dead host must surface as an error rather than a nil response.
+func TestAzuraCastDoRequest_TransportError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	client, err := NewAzuraCastAPIClient(srv.URL, "k")
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	srv.Close() // nothing is listening now
+
+	if _, err := client.GetStations(actx()); err == nil {
+		t.Fatal("expected a transport error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// read endpoints
+// ---------------------------------------------------------------------------
+
+func TestAzuraCastReadEndpoints(t *testing.T) {
+	client, paths := azuraServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/status":
+			writeJSON(t, w, &AzuraCastAPIStatus{Online: true, Station: "Grimnir"})
+		case "/api/stations":
+			writeJSON(t, w, []AzuraCastAPIStation{{ID: 1, Name: "Main", ShortName: "main"}})
+		case "/api/station/7/files":
+			writeJSON(t, w, []AzuraCastAPIMediaFile{{ID: 42, Title: "Blue Monday", Artist: "New Order", Length: 449.5}})
+		case "/api/station/7/mounts":
+			writeJSON(t, w, []AzuraCastAPIMount{{ID: 3, Name: "/radio.mp3", IsDefault: true}})
+		case "/api/station/7/streamers":
+			writeJSON(t, w, []AzuraCastAPIStreamer{{ID: 9, StreamerUsername: "dj_night", IsActive: true}})
+		case "/api/station/7/profile":
+			writeJSON(t, w, &AzuraCastAPIStationProfile{Name: "Main", Timezone: "Europe/Oslo"})
+		case "/api/station/7/webhooks":
+			writeJSON(t, w, []AzuraCastAPIWebhook{{ID: 2, Type: "generic", IsEnabled: true, Triggers: []string{"song_changed"}}})
+		case "/api/station/7/podcasts":
+			writeJSON(t, w, []AzuraCastAPIPodcast{{ID: 5, Title: "Nightshift"}})
+		case "/api/station/7/podcast/5/episodes":
+			writeJSON(t, w, []AzuraCastAPIPodcastEpisode{{ID: 11, Title: "Episode 1"}})
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	status, err := client.TestConnection(actx())
+	if err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if !status.Online || status.Station != "Grimnir" {
+		t.Fatalf("status = %+v", status)
+	}
+
+	stations, err := client.GetStations(actx())
+	if err != nil {
+		t.Fatalf("stations: %v", err)
+	}
+	if len(stations) != 1 || stations[0].ShortName != "main" {
+		t.Fatalf("stations = %+v", stations)
+	}
+
+	media, err := client.GetMedia(actx(), 7)
+	if err != nil {
+		t.Fatalf("media: %v", err)
+	}
+	if len(media) != 1 || media[0].Title != "Blue Monday" || media[0].Length != 449.5 {
+		t.Fatalf("media = %+v", media)
+	}
+
+	mounts, err := client.GetMounts(actx(), 7)
+	if err != nil {
+		t.Fatalf("mounts: %v", err)
+	}
+	if len(mounts) != 1 || !mounts[0].IsDefault {
+		t.Fatalf("mounts = %+v", mounts)
+	}
+
+	streamers, err := client.GetStreamers(actx(), 7)
+	if err != nil {
+		t.Fatalf("streamers: %v", err)
+	}
+	if len(streamers) != 1 || streamers[0].StreamerUsername != "dj_night" {
+		t.Fatalf("streamers = %+v", streamers)
+	}
+
+	profile, err := client.GetStationProfile(actx(), 7)
+	if err != nil {
+		t.Fatalf("profile: %v", err)
+	}
+	if profile.Timezone != "Europe/Oslo" {
+		t.Fatalf("profile = %+v", profile)
+	}
+
+	webhooks, err := client.GetWebhooks(actx(), 7)
+	if err != nil {
+		t.Fatalf("webhooks: %v", err)
+	}
+	if len(webhooks) != 1 || webhooks[0].Triggers[0] != "song_changed" {
+		t.Fatalf("webhooks = %+v", webhooks)
+	}
+
+	podcasts, err := client.GetPodcasts(actx(), 7)
+	if err != nil {
+		t.Fatalf("podcasts: %v", err)
+	}
+	if len(podcasts) != 1 || podcasts[0].Title != "Nightshift" {
+		t.Fatalf("podcasts = %+v", podcasts)
+	}
+
+	episodes, err := client.GetPodcastEpisodes(actx(), 7, 5)
+	if err != nil {
+		t.Fatalf("episodes: %v", err)
+	}
+	if len(episodes) != 1 || episodes[0].Title != "Episode 1" {
+		t.Fatalf("episodes = %+v", episodes)
+	}
+
+	if len(*paths) != 9 {
+		t.Fatalf("requests = %d, want 9: %v", len(*paths), *paths)
+	}
+}
+
+// AzuraCast has no standalone schedules endpoint; schedules live inside each
+// playlist's schedule_items and must come back stamped with the playlist ID.
+func TestAzuraCastGetSchedules_FlattensPlaylistScheduleItems(t *testing.T) {
+	client, paths := azuraServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/station/7/playlists" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		writeJSON(t, w, []AzuraCastAPIPlaylist{
+			{
+				ID:   10,
+				Name: "Morning",
+				ScheduleItems: []AzuraCastAPISchedule{
+					{ID: 100, StartTime: 21600, EndTime: 36000, Days: []int{1, 2, 3}},
+					{ID: 101, StartTime: 36000, EndTime: 43200, Days: []int{6}},
+				},
+			},
+			{ID: 11, Name: "Overnight"}, // no schedule items
+			{
+				ID:            12,
+				Name:          "Weekend",
+				ScheduleItems: []AzuraCastAPISchedule{{ID: 102, LoopOnce: true}},
+			},
+		})
+	})
+
+	schedules, err := client.GetSchedules(actx(), 7)
+	if err != nil {
+		t.Fatalf("schedules: %v", err)
+	}
+	if len(schedules) != 3 {
+		t.Fatalf("schedules = %d, want 3", len(schedules))
+	}
+	// Only one HTTP call: schedules are derived, not fetched.
+	if len(*paths) != 1 {
+		t.Fatalf("requests = %v, want a single playlists call", *paths)
+	}
+
+	wantPlaylist := map[int]int{100: 10, 101: 10, 102: 12}
+	for _, s := range schedules {
+		if got := wantPlaylist[s.ID]; s.PlaylistID != got {
+			t.Fatalf("schedule %d playlist = %d, want %d", s.ID, s.PlaylistID, got)
+		}
+	}
+	if schedules[0].StartTime != 21600 || len(schedules[0].Days) != 3 {
+		t.Fatalf("first schedule = %+v", schedules[0])
+	}
+}
+
+func TestAzuraCastGetSchedules_PropagatesPlaylistFailure(t *testing.T) {
+	client, _ := azuraServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := client.GetSchedules(actx(), 7); err == nil {
+		t.Fatal("expected the playlist failure to surface")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// downloads
+// ---------------------------------------------------------------------------
+
+func TestAzuraCastDownloadMedia(t *testing.T) {
+	payload := "ID3fake-audio-bytes"
+	client, paths := azuraServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/station/7/file/42/play" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, payload)
+	})
+
+	body, size, err := client.DownloadMedia(actx(), 7, 42)
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	defer body.Close()
+
+	got, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != payload {
+		t.Fatalf("body = %q", got)
+	}
+	if size != int64(len(payload)) {
+		t.Fatalf("content length = %d, want %d", size, len(payload))
+	}
+	if (*paths)[0] != "/api/station/7/file/42/play" {
+		t.Fatalf("path = %q", (*paths)[0])
+	}
+}
+
+func TestAzuraCastDownloadMedia_ErrorStatus(t *testing.T) {
+	client, _ := azuraServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = io.WriteString(w, "file missing")
+	})
+
+	_, _, err := client.DownloadMedia(actx(), 7, 42)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "404") || !strings.Contains(err.Error(), "file missing") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// Artwork is optional everywhere it appears, so a missing or broken art
+// endpoint returns empty rather than failing the whole import.
+func TestAzuraCastArtworkDownloads(t *testing.T) {
+	art := []byte{0xff, 0xd8, 0xff, 0xe0}
+
+	for _, tc := range []struct {
+		name        string
+		status      int
+		contentType string
+		wantData    bool
+		wantMime    string
+	}{
+		{"png artwork", http.StatusOK, "image/png", true, "image/png"},
+		{"missing content type defaults to jpeg", http.StatusOK, "", true, "image/jpeg"},
+		{"not found", http.StatusNotFound, "", false, ""},
+		{"no content", http.StatusNoContent, "", false, ""},
+		{"server error is skipped silently", http.StatusInternalServerError, "", false, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := func(w http.ResponseWriter, _ *http.Request) {
+				if tc.contentType != "" {
+					w.Header().Set("Content-Type", tc.contentType)
+				} else {
+					// Stop net/http from sniffing a type onto the body.
+					w.Header()["Content-Type"] = nil
+				}
+				w.WriteHeader(tc.status)
+				if tc.status == http.StatusOK {
+					_, _ = w.Write(art)
+				}
+			}
+			client, _ := azuraServer(t, handler)
+
+			for _, call := range []struct {
+				label string
+				fn    func() ([]byte, string, error)
+			}{
+				{"media art", func() ([]byte, string, error) { return client.DownloadMediaArt(actx(), 7, 42) }},
+				{"station art", func() ([]byte, string, error) { return client.DownloadStationArt(actx(), 7) }},
+				{"streamer art", func() ([]byte, string, error) { return client.DownloadStreamerArt(actx(), 7, 9) }},
+			} {
+				data, mime, err := call.fn()
+				if err != nil {
+					t.Fatalf("%s: %v", call.label, err)
+				}
+				if tc.wantData {
+					if string(data) != string(art) {
+						t.Fatalf("%s data = %v", call.label, data)
+					}
+					if mime != tc.wantMime {
+						t.Fatalf("%s mime = %q, want %q", call.label, mime, tc.wantMime)
+					}
+				} else if len(data) != 0 {
+					t.Fatalf("%s returned %d bytes, want none", call.label, len(data))
+				}
+			}
+		})
+	}
+}
+
+func TestAzuraCastArtworkPaths(t *testing.T) {
+	client, paths := azuraServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	if _, _, err := client.DownloadMediaArt(actx(), 7, 42); err != nil {
+		t.Fatalf("media art: %v", err)
+	}
+	if _, _, err := client.DownloadStationArt(actx(), 7); err != nil {
+		t.Fatalf("station art: %v", err)
+	}
+	if _, _, err := client.DownloadStreamerArt(actx(), 7, 9); err != nil {
+		t.Fatalf("streamer art: %v", err)
+	}
+
+	want := []string{"/api/station/7/art/42", "/api/station/7/art", "/api/station/7/streamer/9/art"}
+	for i, w := range want {
+		if (*paths)[i] != w {
+			t.Fatalf("request %d = %q, want %q", i, (*paths)[i], w)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// username/password login
+// ---------------------------------------------------------------------------
+
+func TestNewAzuraCastAPIClientWithCredentials_Token(t *testing.T) {
+	var gotBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/internal/login" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		_ = json.NewDecoder(r.Body).Decode(&gotBody)
+		writeJSON(t, w, map[string]any{"success": true, "token": "tok-123"})
+	}))
+	defer srv.Close()
+
+	client, err := NewAzuraCastAPIClientWithCredentials(srv.URL, "admin", "hunter2")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if client.sessionToken != "tok-123" {
+		t.Fatalf("session token = %q", client.sessionToken)
+	}
+	if gotBody["username"] != "admin" || gotBody["password"] != "hunter2" {
+		t.Fatalf("login body = %v", gotBody)
+	}
+	if client.apiKey != "" {
+		t.Fatalf("api key = %q, want empty for a credential login", client.apiKey)
+	}
+}
+
+func TestNewAzuraCastAPIClientWithCredentials_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	_, err := NewAzuraCastAPIClientWithCredentials(srv.URL, "admin", "wrong")
+	if err == nil {
+		t.Fatal("expected an authentication error")
+	}
+	if !strings.Contains(err.Error(), "invalid username or password") {
+		t.Fatalf("err = %v, want the credential message rather than a raw status", err)
+	}
+}
+
+func TestNewAzuraCastAPIClientWithCredentials_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = io.WriteString(w, "upstream down")
+	}))
+	defer srv.Close()
+
+	_, err := NewAzuraCastAPIClientWithCredentials(srv.URL, "admin", "hunter2")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "502") || !strings.Contains(err.Error(), "upstream down") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+// Older AzuraCast builds answer the login with an HTML page and a PHP session
+// cookie instead of a JSON token.
+func TestNewAzuraCastAPIClientWithCredentials_SessionCookieFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.SetCookie(w, &http.Cookie{Name: "PHPSESSID", Value: "php-sess-9"})
+		_, _ = io.WriteString(w, "<html>welcome</html>")
+	}))
+	defer srv.Close()
+
+	client, err := NewAzuraCastAPIClientWithCredentials(srv.URL, "admin", "hunter2")
+	if err != nil {
+		t.Fatalf("login: %v", err)
+	}
+	if client.sessionToken != "php-sess-9" {
+		t.Fatalf("session token = %q, want the cookie value", client.sessionToken)
+	}
+}
+
+// No token and no session cookie is a failed login, not a silent success.
+func TestNewAzuraCastAPIClientWithCredentials_NoTokenNoCookie(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, "<html>no session for you</html>")
+	}))
+	defer srv.Close()
+
+	if _, err := NewAzuraCastAPIClientWithCredentials(srv.URL, "admin", "hunter2"); err == nil {
+		t.Fatal("expected a failure when no session token is issued")
+	}
+}

--- a/internal/migration/fileops_copy_test.go
+++ b/internal/migration/fileops_copy_test.go
@@ -1,0 +1,360 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package migration
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"testing"
+
+	"github.com/rs/zerolog"
+
+	"github.com/friendsincode/grimnir_radio/internal/config"
+	"github.com/friendsincode/grimnir_radio/internal/media"
+)
+
+// newFileOps builds a FileOperations backed by filesystem storage rooted in a
+// temp dir, and returns the source dir and the media root.
+func newFileOps(t *testing.T) (*FileOperations, string, string) {
+	t.Helper()
+	sourceDir := t.TempDir()
+	mediaRoot := t.TempDir()
+
+	mediaSvc, err := media.NewService(&config.Config{MediaRoot: mediaRoot}, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("media service: %v", err)
+	}
+	return NewFileOperations(mediaSvc, zerolog.Nop()), sourceDir, mediaRoot
+}
+
+func writeSource(t *testing.T, dir, name, content string) (string, int64) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path, int64(len(content))
+}
+
+func sha256Hex(s string) string {
+	sum := sha256.Sum256([]byte(s))
+	return hex.EncodeToString(sum[:])
+}
+
+// ---------------------------------------------------------------------------
+// options and small helpers
+// ---------------------------------------------------------------------------
+
+func TestDefaultCopyOptions(t *testing.T) {
+	opts := DefaultCopyOptions()
+	if !opts.VerifyChecksum {
+		t.Fatal("checksum verification should be on by default")
+	}
+	if !opts.SkipExisting {
+		t.Fatal("SkipExisting should default true")
+	}
+	if opts.Concurrency != 4 {
+		t.Fatalf("concurrency = %d, want 4", opts.Concurrency)
+	}
+}
+
+func TestGetFileSize(t *testing.T) {
+	dir := t.TempDir()
+	path, size := writeSource(t, dir, "track.mp3", "twelve bytes")
+
+	got, err := GetFileSize(path)
+	if err != nil {
+		t.Fatalf("size: %v", err)
+	}
+	if got != size {
+		t.Fatalf("size = %d, want %d", got, size)
+	}
+
+	if _, err := GetFileSize(filepath.Join(dir, "absent.mp3")); err == nil {
+		t.Fatal("expected an error for a missing file")
+	}
+}
+
+func TestVerifyFile(t *testing.T) {
+	fo, sourceDir, _ := newFileOps(t)
+	const content = "the actual audio bytes"
+	path, _ := writeSource(t, sourceDir, "track.mp3", content)
+
+	ok, err := fo.VerifyFile(path, sha256Hex(content))
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if !ok {
+		t.Fatal("matching checksum reported as a mismatch")
+	}
+
+	ok, err = fo.VerifyFile(path, sha256Hex("different bytes"))
+	if err != nil {
+		t.Fatalf("verify mismatch: %v", err)
+	}
+	if ok {
+		t.Fatal("mismatched checksum reported as a match")
+	}
+
+	if _, err := fo.VerifyFile(filepath.Join(sourceDir, "absent.mp3"), "abc"); err == nil {
+		t.Fatal("expected an error for a missing file")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CopyFiles
+// ---------------------------------------------------------------------------
+
+func TestCopyFiles_CopiesAndChecksums(t *testing.T) {
+	fo, sourceDir, mediaRoot := newFileOps(t)
+
+	contents := map[string]string{
+		"media-1": "first track bytes",
+		"media-2": "second track bytes, a little longer",
+		"media-3": "third",
+	}
+	var jobs []FileCopyJob
+	for id, body := range contents {
+		path, size := writeSource(t, sourceDir, id+".mp3", body)
+		jobs = append(jobs, FileCopyJob{SourcePath: path, StationID: "st1", MediaID: id, FileSize: size})
+	}
+
+	results, err := fo.CopyFiles(context.Background(), jobs, DefaultCopyOptions())
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if len(results) != 3 {
+		t.Fatalf("results = %d, want 3", len(results))
+	}
+
+	for _, r := range results {
+		if !r.Success {
+			t.Fatalf("%s failed: %v", r.MediaID, r.Error)
+		}
+		if r.StorageKey == "" {
+			t.Fatalf("%s has no storage key", r.MediaID)
+		}
+		body := contents[r.MediaID]
+		if r.BytesCopied != int64(len(body)) {
+			t.Fatalf("%s copied %d bytes, want %d", r.MediaID, r.BytesCopied, len(body))
+		}
+		if r.Checksum != sha256Hex(body) {
+			t.Fatalf("%s checksum = %q, want the sha256 of its contents", r.MediaID, r.Checksum)
+		}
+
+		// The bytes must actually be on disk under the media root, and the
+		// checksum reset must not have truncated the upload.
+		stored, err := os.ReadFile(filepath.Join(mediaRoot, r.StorageKey))
+		if err != nil {
+			t.Fatalf("read stored %s: %v", r.MediaID, err)
+		}
+		if string(stored) != body {
+			t.Fatalf("%s stored %q, want %q", r.MediaID, stored, body)
+		}
+	}
+}
+
+// With verification off, no checksum is computed and the file pointer is never
+// rewound, so this is the path where a truncated upload would show up.
+func TestCopyFiles_WithoutChecksumStillStoresFullFile(t *testing.T) {
+	fo, sourceDir, mediaRoot := newFileOps(t)
+	const body = "unverified but complete"
+	path, size := writeSource(t, sourceDir, "track.mp3", body)
+
+	opts := DefaultCopyOptions()
+	opts.VerifyChecksum = false
+
+	results, err := fo.CopyFiles(context.Background(), []FileCopyJob{
+		{SourcePath: path, StationID: "st1", MediaID: "media-1", FileSize: size},
+	}, opts)
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if len(results) != 1 || !results[0].Success {
+		t.Fatalf("results = %+v", results)
+	}
+	if results[0].Checksum != "" {
+		t.Fatalf("checksum = %q, want empty when verification is off", results[0].Checksum)
+	}
+
+	stored, err := os.ReadFile(filepath.Join(mediaRoot, results[0].StorageKey))
+	if err != nil {
+		t.Fatalf("read stored: %v", err)
+	}
+	if string(stored) != body {
+		t.Fatalf("stored %q, want %q", stored, body)
+	}
+}
+
+// A source file listed in the source DB but missing from disk is the common
+// case in a half-migrated library. It fails that one job, not the batch.
+func TestCopyFiles_MissingSourceFailsOnlyThatJob(t *testing.T) {
+	fo, sourceDir, _ := newFileOps(t)
+	good, size := writeSource(t, sourceDir, "present.mp3", "here")
+
+	results, err := fo.CopyFiles(context.Background(), []FileCopyJob{
+		{SourcePath: good, StationID: "st1", MediaID: "media-ok", FileSize: size},
+		{SourcePath: filepath.Join(sourceDir, "gone.mp3"), StationID: "st1", MediaID: "media-gone", FileSize: 99},
+	}, DefaultCopyOptions())
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+
+	byID := map[string]FileCopyResult{}
+	for _, r := range results {
+		byID[r.MediaID] = r
+	}
+	if !byID["media-ok"].Success {
+		t.Fatalf("good job failed: %v", byID["media-ok"].Error)
+	}
+	missing := byID["media-gone"]
+	if missing.Success {
+		t.Fatal("missing source reported as a success")
+	}
+	if missing.Error == nil {
+		t.Fatal("missing source has no error")
+	}
+	if missing.BytesCopied != 0 {
+		t.Fatalf("missing source counted %d bytes copied", missing.BytesCopied)
+	}
+}
+
+func TestCopyFiles_ProgressCallback(t *testing.T) {
+	fo, sourceDir, _ := newFileOps(t)
+
+	var jobs []FileCopyJob
+	for i := 0; i < 5; i++ {
+		name := string(rune('a'+i)) + ".mp3"
+		path, size := writeSource(t, sourceDir, name, "body-"+name)
+		jobs = append(jobs, FileCopyJob{SourcePath: path, StationID: "st1", MediaID: name, FileSize: size})
+	}
+
+	var mu sync.Mutex
+	var copied []int
+	var sawTotal int
+	opts := DefaultCopyOptions()
+	opts.ProgressCallback = func(c, total int) {
+		mu.Lock()
+		defer mu.Unlock()
+		copied = append(copied, c)
+		sawTotal = total
+	}
+
+	results, err := fo.CopyFiles(context.Background(), jobs, opts)
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if len(results) != 5 {
+		t.Fatalf("results = %d, want 5", len(results))
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(copied) != 5 {
+		t.Fatalf("callback fired %d times, want once per file", len(copied))
+	}
+	if sawTotal != 5 {
+		t.Fatalf("callback total = %d, want 5", sawTotal)
+	}
+	sort.Ints(copied)
+	if copied[len(copied)-1] != 5 {
+		t.Fatalf("final copied count = %d, want 5", copied[len(copied)-1])
+	}
+}
+
+func TestCopyFiles_EmptyJobList(t *testing.T) {
+	fo, _, _ := newFileOps(t)
+
+	results, err := fo.CopyFiles(context.Background(), nil, DefaultCopyOptions())
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("results = %d, want 0", len(results))
+	}
+}
+
+// Concurrency is a required field, not an optional one: with zero workers no
+// job is ever consumed and CopyFiles returns no results while reporting no
+// error. Both production callers use DefaultCopyOptions, which sets 4.
+func TestCopyFiles_ZeroConcurrencyCopiesNothing(t *testing.T) {
+	fo, sourceDir, _ := newFileOps(t)
+	path, size := writeSource(t, sourceDir, "track.mp3", "body")
+
+	results, err := fo.CopyFiles(context.Background(), []FileCopyJob{
+		{SourcePath: path, StationID: "st1", MediaID: "media-1", FileSize: size},
+	}, CopyOptions{Concurrency: 0})
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if len(results) != 0 {
+		t.Fatalf("results = %d; if this now copies, the zero-worker trap was fixed and this test should assert the fix", len(results))
+	}
+}
+
+// Single-worker copies keep the whole batch serialized, which is what the
+// importer falls back to on constrained hosts.
+func TestCopyFiles_SingleWorker(t *testing.T) {
+	fo, sourceDir, _ := newFileOps(t)
+
+	var jobs []FileCopyJob
+	for i := 0; i < 4; i++ {
+		name := string(rune('a'+i)) + ".mp3"
+		path, size := writeSource(t, sourceDir, name, "body-"+name)
+		jobs = append(jobs, FileCopyJob{SourcePath: path, StationID: "st1", MediaID: name, FileSize: size})
+	}
+
+	opts := DefaultCopyOptions()
+	opts.Concurrency = 1
+
+	results, err := fo.CopyFiles(context.Background(), jobs, opts)
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if len(results) != 4 {
+		t.Fatalf("results = %d, want 4", len(results))
+	}
+	for _, r := range results {
+		if !r.Success {
+			t.Fatalf("%s failed: %v", r.MediaID, r.Error)
+		}
+	}
+}
+
+// Two stations importing at once must not collide in storage.
+func TestCopyFiles_SeparatesStations(t *testing.T) {
+	fo, sourceDir, _ := newFileOps(t)
+	pathA, sizeA := writeSource(t, sourceDir, "a.mp3", "station one audio")
+	pathB, sizeB := writeSource(t, sourceDir, "b.mp3", "station two audio")
+
+	results, err := fo.CopyFiles(context.Background(), []FileCopyJob{
+		{SourcePath: pathA, StationID: "st1", MediaID: "media-1", FileSize: sizeA},
+		{SourcePath: pathB, StationID: "st2", MediaID: "media-2", FileSize: sizeB},
+	}, DefaultCopyOptions())
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+
+	keys := map[string]string{}
+	for _, r := range results {
+		if !r.Success {
+			t.Fatalf("%s failed: %v", r.MediaID, r.Error)
+		}
+		keys[r.MediaID] = r.StorageKey
+	}
+	if keys["media-1"] == keys["media-2"] {
+		t.Fatalf("both stations stored to the same key %q", keys["media-1"])
+	}
+}

--- a/internal/migration/libretime_api.go
+++ b/internal/migration/libretime_api.go
@@ -86,6 +86,11 @@ func decodeResponse[T any](resp *http.Response) (T, error) {
 	return result, nil
 }
 
+// ltVersionInfo is the /api/v2/version response.
+type ltVersionInfo struct {
+	APIVersion string `json:"api_version"`
+}
+
 // LibreTimeConnectionStatus represents the status of a connection test.
 type LibreTimeConnectionStatus struct {
 	Online          bool   `json:"online"`
@@ -102,10 +107,10 @@ func (c *LibreTimeAPIClient) TestConnection(ctx context.Context) (*LibreTimeConn
 		return nil, fmt.Errorf("API unreachable: %w", err)
 	}
 
-	var versionInfo struct {
-		APIVersion string `json:"api_version"`
-	}
-	if _, err := decodeResponse[any](resp); err != nil {
+	// Decode into the version struct rather than discarding the body, so
+	// status.Version below reports what /version actually returned.
+	versionInfo, err := decodeResponse[ltVersionInfo](resp)
+	if err != nil {
 		// Try alternate version detection
 		resp2, err2 := c.doRequest(ctx, "GET", "/api/v2/info")
 		if err2 != nil {

--- a/internal/migration/libretime_api_test.go
+++ b/internal/migration/libretime_api_test.go
@@ -1,0 +1,605 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package migration
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ltServer stands up an httptest server and returns a client pointed at it,
+// plus the request URIs the client sent, in order.
+func ltServer(t *testing.T, handler http.HandlerFunc) (*LibreTimeAPIClient, *[]string) {
+	t.Helper()
+	var paths []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.RequestURI())
+		handler(w, r)
+	}))
+	t.Cleanup(srv.Close)
+
+	client, err := NewLibreTimeAPIClient(srv.URL, "lt-key")
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	return client, &paths
+}
+
+func intPtr(v int) *int { return &v }
+
+// ---------------------------------------------------------------------------
+// construction and plumbing
+// ---------------------------------------------------------------------------
+
+func TestNewLibreTimeAPIClient_NormalizesBaseURL(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"https://lt.example.com", "https://lt.example.com"},
+		{"https://lt.example.com/", "https://lt.example.com"},
+		{"http://10.0.0.5:8080", "http://10.0.0.5:8080"},
+		{"lt.example.com", "https://lt.example.com"},
+	} {
+		client, err := NewLibreTimeAPIClient(tc.in, "k")
+		if err != nil {
+			t.Fatalf("new(%q): %v", tc.in, err)
+		}
+		if client.baseURL != tc.want {
+			t.Fatalf("new(%q) baseURL = %q, want %q", tc.in, client.baseURL, tc.want)
+		}
+	}
+}
+
+// LibreTime uses "Api-Key <key>", not Bearer.
+func TestLibreTimeDoRequest_SendsApiKeyAuthorization(t *testing.T) {
+	var gotAuth, gotAccept string
+	client, _ := ltServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotAccept = r.Header.Get("Accept")
+		writeJSON(t, w, []LTFile{})
+	})
+
+	if _, err := client.GetFiles(actx()); err != nil {
+		t.Fatalf("get files: %v", err)
+	}
+	if gotAuth != "Api-Key lt-key" {
+		t.Fatalf("Authorization = %q", gotAuth)
+	}
+	if gotAccept != "application/json" {
+		t.Fatalf("Accept = %q", gotAccept)
+	}
+}
+
+func TestLibreTimeDecode_ErrorStatusIncludesBody(t *testing.T) {
+	client, _ := ltServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = io.WriteString(w, "invalid api key")
+	})
+
+	_, err := client.GetFiles(actx())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "401") || !strings.Contains(err.Error(), "invalid api key") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestLibreTimeDoRequest_TransportError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	client, err := NewLibreTimeAPIClient(srv.URL, "k")
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	srv.Close()
+
+	if _, err := client.GetFiles(actx()); err == nil {
+		t.Fatal("expected a transport error")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// read endpoints
+// ---------------------------------------------------------------------------
+
+func TestLibreTimeReadEndpoints(t *testing.T) {
+	client, paths := ltServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/files":
+			writeJSON(t, w, []LTFile{{ID: 1, Title: "Blue Monday", Artist: "New Order", Length: "00:07:29.000", Size: 7180000}})
+		case "/api/v2/playlists":
+			writeJSON(t, w, []LTPlaylist{{ID: 4, Name: "Morning", Length: "01:00:00"}})
+		case "/api/v2/shows":
+			writeJSON(t, w, []LTShow{{ID: 8, Name: "Nightshift", Genre: "Electronic", Timezone: "Europe/Oslo"}})
+		case "/api/v2/show-days":
+			writeJSON(t, w, []LTShowDays{{ID: 3, ShowID: 8, Day: 0, StartTime: "22:00:00", Duration: "02:00:00", RepeatType: 0}})
+		case "/api/v2/webstreams":
+			writeJSON(t, w, []LTWebstream{{ID: 2, Name: "Relay", URL: "http://upstream.example/live"}})
+		case "/api/v2/smart-blocks":
+			writeJSON(t, w, []LTSmartBlock{{ID: 6, Name: "Recent Adds", Kind: "dynamic"}})
+		case "/api/v2/info":
+			writeJSON(t, w, &LTStationInfo{StationName: "Grimnir", StationTimezone: "Europe/Oslo"})
+		case "/api/v2/listener-count":
+			writeJSON(t, w, &LTListenerStats{ListenerCount: 137})
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	files, err := client.GetFiles(actx())
+	if err != nil {
+		t.Fatalf("files: %v", err)
+	}
+	if len(files) != 1 || files[0].Title != "Blue Monday" || files[0].Size != 7180000 {
+		t.Fatalf("files = %+v", files)
+	}
+
+	playlists, err := client.GetPlaylists(actx())
+	if err != nil {
+		t.Fatalf("playlists: %v", err)
+	}
+	if len(playlists) != 1 || playlists[0].Name != "Morning" {
+		t.Fatalf("playlists = %+v", playlists)
+	}
+
+	shows, err := client.GetShows(actx())
+	if err != nil {
+		t.Fatalf("shows: %v", err)
+	}
+	if len(shows) != 1 || shows[0].Timezone != "Europe/Oslo" {
+		t.Fatalf("shows = %+v", shows)
+	}
+
+	days, err := client.GetShowDays(actx())
+	if err != nil {
+		t.Fatalf("show days: %v", err)
+	}
+	if len(days) != 1 || days[0].StartTime != "22:00:00" {
+		t.Fatalf("show days = %+v", days)
+	}
+
+	streams, err := client.GetWebstreams(actx())
+	if err != nil {
+		t.Fatalf("webstreams: %v", err)
+	}
+	if len(streams) != 1 || streams[0].URL != "http://upstream.example/live" {
+		t.Fatalf("webstreams = %+v", streams)
+	}
+
+	blocks, err := client.GetSmartBlocks(actx())
+	if err != nil {
+		t.Fatalf("smart blocks: %v", err)
+	}
+	if len(blocks) != 1 || blocks[0].Kind != "dynamic" {
+		t.Fatalf("smart blocks = %+v", blocks)
+	}
+
+	info, err := client.GetStationInfo(actx())
+	if err != nil {
+		t.Fatalf("station info: %v", err)
+	}
+	if info.StationName != "Grimnir" {
+		t.Fatalf("station info = %+v", info)
+	}
+
+	stats, err := client.GetListenerStats(actx())
+	if err != nil {
+		t.Fatalf("listener stats: %v", err)
+	}
+	if stats.ListenerCount != 137 {
+		t.Fatalf("listeners = %d, want 137", stats.ListenerCount)
+	}
+
+	if len(*paths) != 8 {
+		t.Fatalf("requests = %d, want 8: %v", len(*paths), *paths)
+	}
+}
+
+// Show instances are fetched unfiltered when no show ID is given, and with a
+// ?show= filter when one is.
+func TestLibreTimeGetShowInstances_FilterQuery(t *testing.T) {
+	client, paths := ltServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, []LTShowInstance{{ID: 1, ShowID: 8, Starts: time.Now(), Ends: time.Now().Add(time.Hour)}})
+	})
+
+	if _, err := client.GetShowInstances(actx(), 0); err != nil {
+		t.Fatalf("unfiltered: %v", err)
+	}
+	if _, err := client.GetShowInstances(actx(), 8); err != nil {
+		t.Fatalf("filtered: %v", err)
+	}
+
+	if (*paths)[0] != "/api/v2/show-instances" {
+		t.Fatalf("unfiltered path = %q", (*paths)[0])
+	}
+	if (*paths)[1] != "/api/v2/show-instances?show=8" {
+		t.Fatalf("filtered path = %q", (*paths)[1])
+	}
+}
+
+func TestLibreTimeGetSmartBlockCriteria_FilterQuery(t *testing.T) {
+	client, paths := ltServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, []LTSmartBlockCriteria{{ID: 1, BlockID: 6, Criteria: "genre", Condition: "is", Value: "Electronic"}})
+	})
+
+	criteria, err := client.GetSmartBlockCriteria(actx(), 6)
+	if err != nil {
+		t.Fatalf("criteria: %v", err)
+	}
+	if len(criteria) != 1 || criteria[0].Value != "Electronic" {
+		t.Fatalf("criteria = %+v", criteria)
+	}
+	if (*paths)[0] != "/api/v2/smart-block-criteria?block=6" {
+		t.Fatalf("path = %q", (*paths)[0])
+	}
+}
+
+func TestLibreTimeGetSchedule_EncodesTimeRange(t *testing.T) {
+	client, paths := ltServer(t, func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("starts_after") == "" || q.Get("ends_before") == "" {
+			t.Errorf("missing range params: %v", r.URL.RawQuery)
+		}
+		writeJSON(t, w, []LTScheduleEntry{{ID: 1, InstanceID: 5, ClipLength: "00:03:30"}})
+	})
+
+	start := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 7, 8, 0, 0, 0, 0, time.UTC)
+
+	entries, err := client.GetSchedule(actx(), start, end)
+	if err != nil {
+		t.Fatalf("schedule: %v", err)
+	}
+	if len(entries) != 1 || entries[0].ClipLength != "00:03:30" {
+		t.Fatalf("entries = %+v", entries)
+	}
+	if !strings.Contains((*paths)[0], "2026-07-01T00%3A00%3A00Z") {
+		t.Fatalf("path = %q, want the RFC3339 start escaped into the query", (*paths)[0])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// playlist contents caching
+// ---------------------------------------------------------------------------
+
+// The LibreTime API ignores the playlist filter, so the client fetches every
+// row once and filters client-side. Re-requesting per playlist on a library
+// with hundreds of playlists is what the cache exists to prevent.
+func TestLibreTimeGetPlaylistContents_CachesAndFilters(t *testing.T) {
+	client, paths := ltServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(t, w, []LTPlaylistContent{
+			{ID: 1, PlaylistID: intPtr(4), FileID: intPtr(100), Position: 0},
+			{ID: 2, PlaylistID: intPtr(4), FileID: intPtr(101), Position: 1},
+			{ID: 3, PlaylistID: intPtr(9), FileID: intPtr(102), Position: 0},
+			{ID: 4, PlaylistID: nil, FileID: intPtr(103), Position: 0}, // orphaned row
+		})
+	})
+
+	four, err := client.GetPlaylistContents(actx(), 4)
+	if err != nil {
+		t.Fatalf("playlist 4: %v", err)
+	}
+	if len(four) != 2 {
+		t.Fatalf("playlist 4 items = %d, want 2", len(four))
+	}
+	if four[0].ID != 1 || four[1].ID != 2 {
+		t.Fatalf("playlist 4 = %+v", four)
+	}
+
+	nine, err := client.GetPlaylistContents(actx(), 9)
+	if err != nil {
+		t.Fatalf("playlist 9: %v", err)
+	}
+	if len(nine) != 1 || nine[0].ID != 3 {
+		t.Fatalf("playlist 9 = %+v", nine)
+	}
+
+	// A playlist with no rows returns empty, not an error.
+	empty, err := client.GetPlaylistContents(actx(), 999)
+	if err != nil {
+		t.Fatalf("playlist 999: %v", err)
+	}
+	if len(empty) != 0 {
+		t.Fatalf("playlist 999 = %+v, want empty", empty)
+	}
+
+	if len(*paths) != 1 {
+		t.Fatalf("requests = %d, want 1 cached fetch: %v", len(*paths), *paths)
+	}
+	if (*paths)[0] != "/api/v2/playlist-contents" {
+		t.Fatalf("path = %q", (*paths)[0])
+	}
+}
+
+func TestLibreTimeGetPlaylistContents_FetchErrorIsNotCached(t *testing.T) {
+	var calls int
+	client, _ := ltServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := client.GetPlaylistContents(actx(), 4); err == nil {
+		t.Fatal("expected an error")
+	}
+	if _, err := client.GetPlaylistContents(actx(), 4); err == nil {
+		t.Fatal("expected an error on the retry too")
+	}
+	if calls != 2 {
+		t.Fatalf("upstream calls = %d, want the failure to be retried rather than cached", calls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// downloads
+// ---------------------------------------------------------------------------
+
+func TestLibreTimeDownloadFile(t *testing.T) {
+	payload := "fake-ogg-bytes"
+	client, paths := ltServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, payload)
+	})
+
+	body, size, err := client.DownloadFile(actx(), 42)
+	if err != nil {
+		t.Fatalf("download: %v", err)
+	}
+	defer body.Close()
+
+	got, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != payload {
+		t.Fatalf("body = %q", got)
+	}
+	if size != int64(len(payload)) {
+		t.Fatalf("size = %d, want %d", size, len(payload))
+	}
+	if (*paths)[0] != "/api/v2/files/42/download" {
+		t.Fatalf("path = %q", (*paths)[0])
+	}
+}
+
+func TestLibreTimeDownloadFile_ErrorStatus(t *testing.T) {
+	client, _ := ltServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = io.WriteString(w, "storage offline")
+	})
+
+	_, _, err := client.DownloadFile(actx(), 42)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "403") || !strings.Contains(err.Error(), "storage offline") {
+		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestLibreTimeDownloadShowImage(t *testing.T) {
+	img := []byte{0x89, 0x50, 0x4e, 0x47}
+
+	for _, tc := range []struct {
+		name        string
+		status      int
+		contentType string
+		wantData    bool
+		wantMime    string
+	}{
+		{"png image", http.StatusOK, "image/png", true, "image/png"},
+		{"missing content type defaults to jpeg", http.StatusOK, "", true, "image/jpeg"},
+		{"not found", http.StatusNotFound, "", false, ""},
+		{"no content", http.StatusNoContent, "", false, ""},
+		{"server error is skipped silently", http.StatusInternalServerError, "", false, ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client, paths := ltServer(t, func(w http.ResponseWriter, _ *http.Request) {
+				if tc.contentType != "" {
+					w.Header().Set("Content-Type", tc.contentType)
+				} else {
+					w.Header()["Content-Type"] = nil
+				}
+				w.WriteHeader(tc.status)
+				if tc.status == http.StatusOK {
+					_, _ = w.Write(img)
+				}
+			})
+
+			data, mime, err := client.DownloadShowImage(actx(), 8)
+			if err != nil {
+				t.Fatalf("download: %v", err)
+			}
+			if tc.wantData {
+				if string(data) != string(img) {
+					t.Fatalf("data = %v", data)
+				}
+				if mime != tc.wantMime {
+					t.Fatalf("mime = %q, want %q", mime, tc.wantMime)
+				}
+			} else if len(data) != 0 {
+				t.Fatalf("got %d bytes, want none", len(data))
+			}
+			if (*paths)[0] != "/api/v2/shows/8/image" {
+				t.Fatalf("path = %q", (*paths)[0])
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestConnection
+// ---------------------------------------------------------------------------
+
+func TestLibreTimeTestConnection_Healthy(t *testing.T) {
+	client, _ := ltServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/version":
+			writeJSON(t, w, map[string]string{"api_version": "4.2.0"})
+		case "/api/v2/files":
+			writeJSON(t, w, []LTFile{{ID: 1, Title: "Blue Monday"}})
+		case "/api/v2/files/1/download":
+			_, _ = io.WriteString(w, "audio")
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	})
+
+	status, err := client.TestConnection(actx())
+	if err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if !status.Online || !status.FilesAccessible {
+		t.Fatalf("status = %+v", status)
+	}
+	if status.Version != "4.2.0" {
+		t.Fatalf("version = %q, want the value from /version", status.Version)
+	}
+	if status.Warning != "" {
+		t.Fatalf("warning = %q, want none", status.Warning)
+	}
+}
+
+// An empty library is a valid LibreTime install, so no download is attempted
+// and nothing is flagged.
+func TestLibreTimeTestConnection_EmptyLibrary(t *testing.T) {
+	client, paths := ltServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/version":
+			writeJSON(t, w, map[string]string{"api_version": "4.2.0"})
+		case "/api/v2/files":
+			writeJSON(t, w, []LTFile{})
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	})
+
+	status, err := client.TestConnection(actx())
+	if err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if !status.FilesAccessible || status.Warning != "" {
+		t.Fatalf("status = %+v", status)
+	}
+	if len(*paths) != 2 {
+		t.Fatalf("requests = %v, want no download attempt", *paths)
+	}
+}
+
+// The API answering but the file listing failing is reported as a warning, not
+// a hard failure: the operator can still see the connection works.
+func TestLibreTimeTestConnection_FileListingFails(t *testing.T) {
+	client, _ := ltServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/version":
+			writeJSON(t, w, map[string]string{"api_version": "4.2.0"})
+		case "/api/v2/files":
+			w.WriteHeader(http.StatusForbidden)
+			_, _ = io.WriteString(w, "no permission")
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	})
+
+	status, err := client.TestConnection(actx())
+	if err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if !status.Online {
+		t.Fatal("should still report online")
+	}
+	if !strings.Contains(status.Warning, "file listing may fail") {
+		t.Fatalf("warning = %q", status.Warning)
+	}
+}
+
+// Listing works but downloads 403: that is the case where an import would
+// create every DB row and fetch no audio, so it has to be flagged up front.
+func TestLibreTimeTestConnection_DownloadsBlocked(t *testing.T) {
+	client, _ := ltServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/version":
+			writeJSON(t, w, map[string]string{"api_version": "4.2.0"})
+		case "/api/v2/files":
+			writeJSON(t, w, []LTFile{{ID: 1}})
+		case "/api/v2/files/1/download":
+			w.WriteHeader(http.StatusForbidden)
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	})
+
+	status, err := client.TestConnection(actx())
+	if err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if status.FilesAccessible {
+		t.Fatal("FilesAccessible should be false when downloads are refused")
+	}
+	if !strings.Contains(status.Warning, "file downloads may fail") {
+		t.Fatalf("warning = %q", status.Warning)
+	}
+}
+
+// Older builds have no /version endpoint; the client falls back to /info.
+func TestLibreTimeTestConnection_FallsBackToInfo(t *testing.T) {
+	client, paths := ltServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v2/version":
+			w.WriteHeader(http.StatusNotFound)
+		case "/api/v2/info":
+			writeJSON(t, w, &LTStationInfo{StationName: "Grimnir"})
+		case "/api/v2/files":
+			writeJSON(t, w, []LTFile{})
+		default:
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+	})
+
+	status, err := client.TestConnection(actx())
+	if err != nil {
+		t.Fatalf("test connection: %v", err)
+	}
+	if !status.Online {
+		t.Fatal("should report online via the /info fallback")
+	}
+	if status.Version != "" {
+		t.Fatalf("version = %q, want empty when /version is absent", status.Version)
+	}
+	if len(*paths) < 2 || (*paths)[1] != "/api/v2/info" {
+		t.Fatalf("paths = %v, want the /info fallback", *paths)
+	}
+}
+
+// Both endpoints failing is a genuine connection failure.
+func TestLibreTimeTestConnection_BothEndpointsFail(t *testing.T) {
+	client, _ := ltServer(t, func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	})
+
+	if _, err := client.TestConnection(actx()); err == nil {
+		t.Fatal("expected a connection failure")
+	}
+}
+
+func TestLibreTimeTestConnection_Unreachable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	client, err := NewLibreTimeAPIClient(srv.URL, "k")
+	if err != nil {
+		t.Fatalf("new client: %v", err)
+	}
+	srv.Close()
+
+	_, err = client.TestConnection(actx())
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "API unreachable") {
+		t.Fatalf("err = %v", err)
+	}
+}

--- a/internal/models/permissions_test.go
+++ b/internal/models/permissions_test.go
@@ -1,0 +1,596 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package models
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// station role permissions
+// ---------------------------------------------------------------------------
+
+// The permission matrix is what the API authorizes against, so each role's
+// grants are pinned explicitly rather than derived from the code under test.
+func TestDefaultPermissionsForRole(t *testing.T) {
+	t.Run("owner and admin get everything", func(t *testing.T) {
+		for _, role := range []StationRole{StationRoleOwner, StationRoleAdmin} {
+			p := DefaultPermissionsForRole(role)
+			for name, granted := range map[string]bool{
+				"CanUploadMedia":       p.CanUploadMedia,
+				"CanDeleteMedia":       p.CanDeleteMedia,
+				"CanEditMetadata":      p.CanEditMetadata,
+				"CanManagePlaylists":   p.CanManagePlaylists,
+				"CanManageSmartBlocks": p.CanManageSmartBlocks,
+				"CanManageSchedule":    p.CanManageSchedule,
+				"CanManageClocks":      p.CanManageClocks,
+				"CanGoLive":            p.CanGoLive,
+				"CanKickDJ":            p.CanKickDJ,
+				"CanRecord":            p.CanRecord,
+				"CanManageRecordings":  p.CanManageRecordings,
+				"CanManageUsers":       p.CanManageUsers,
+				"CanManageSettings":    p.CanManageSettings,
+				"CanViewAnalytics":     p.CanViewAnalytics,
+				"CanManageMounts":      p.CanManageMounts,
+			} {
+				if !granted {
+					t.Fatalf("%s: %s not granted", role, name)
+				}
+			}
+		}
+	})
+
+	// A manager runs the schedule but cannot change who has access, alter
+	// station settings, reconfigure mounts, or kick a live DJ off air.
+	t.Run("manager stops short of user and station control", func(t *testing.T) {
+		p := DefaultPermissionsForRole(StationRoleManager)
+		for name, granted := range map[string]bool{
+			"CanUploadMedia":       p.CanUploadMedia,
+			"CanDeleteMedia":       p.CanDeleteMedia,
+			"CanManagePlaylists":   p.CanManagePlaylists,
+			"CanManageSmartBlocks": p.CanManageSmartBlocks,
+			"CanManageSchedule":    p.CanManageSchedule,
+			"CanManageClocks":      p.CanManageClocks,
+			"CanGoLive":            p.CanGoLive,
+			"CanRecord":            p.CanRecord,
+			"CanManageRecordings":  p.CanManageRecordings,
+			"CanViewAnalytics":     p.CanViewAnalytics,
+		} {
+			if !granted {
+				t.Fatalf("manager should have %s", name)
+			}
+		}
+		for name, granted := range map[string]bool{
+			"CanKickDJ":         p.CanKickDJ,
+			"CanManageUsers":    p.CanManageUsers,
+			"CanManageSettings": p.CanManageSettings,
+			"CanManageMounts":   p.CanManageMounts,
+		} {
+			if granted {
+				t.Fatalf("manager should not have %s", name)
+			}
+		}
+	})
+
+	// A DJ can add and tag their own material and go on air, and nothing else.
+	t.Run("dj is upload, tag, live and record only", func(t *testing.T) {
+		p := DefaultPermissionsForRole(StationRoleDJ)
+		for name, granted := range map[string]bool{
+			"CanUploadMedia":  p.CanUploadMedia,
+			"CanEditMetadata": p.CanEditMetadata,
+			"CanGoLive":       p.CanGoLive,
+			"CanRecord":       p.CanRecord,
+		} {
+			if !granted {
+				t.Fatalf("dj should have %s", name)
+			}
+		}
+		for name, granted := range map[string]bool{
+			"CanDeleteMedia":       p.CanDeleteMedia,
+			"CanManagePlaylists":   p.CanManagePlaylists,
+			"CanManageSmartBlocks": p.CanManageSmartBlocks,
+			"CanManageSchedule":    p.CanManageSchedule,
+			"CanManageClocks":      p.CanManageClocks,
+			"CanKickDJ":            p.CanKickDJ,
+			"CanManageRecordings":  p.CanManageRecordings,
+			"CanManageUsers":       p.CanManageUsers,
+			"CanManageSettings":    p.CanManageSettings,
+			"CanViewAnalytics":     p.CanViewAnalytics,
+			"CanManageMounts":      p.CanManageMounts,
+		} {
+			if granted {
+				t.Fatalf("dj should not have %s", name)
+			}
+		}
+	})
+
+	// Viewer and any unrecognized role both fall through to no permissions,
+	// so a typo in a role string cannot escalate.
+	t.Run("viewer and unknown roles get nothing", func(t *testing.T) {
+		for _, role := range []StationRole{StationRoleViewer, StationRole("superuser"), StationRole(""), StationRole("ADMIN")} {
+			if DefaultPermissionsForRole(role) != (StationPermissions{}) {
+				t.Fatalf("role %q granted permissions", role)
+			}
+		}
+	})
+}
+
+func TestStationUser_GetEffectivePermissions(t *testing.T) {
+	dj := &StationUser{Role: StationRoleDJ}
+	if perms := dj.GetEffectivePermissions(); perms != DefaultPermissionsForRole(StationRoleDJ) {
+		t.Fatalf("dj effective permissions = %+v", perms)
+	}
+
+	owner := &StationUser{Role: StationRoleOwner}
+	if !owner.GetEffectivePermissions().CanManageUsers {
+		t.Fatal("owner cannot manage users")
+	}
+}
+
+func TestStationPermissions_ValueScan(t *testing.T) {
+	orig := DefaultPermissionsForRole(StationRoleManager)
+
+	v, err := orig.Value()
+	if err != nil {
+		t.Fatalf("value: %v", err)
+	}
+	raw, ok := v.([]byte)
+	if !ok {
+		t.Fatalf("Value returned %T, want []byte", v)
+	}
+
+	var back StationPermissions
+	if err := back.Scan(raw); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if back != orig {
+		t.Fatalf("round trip = %+v, want %+v", back, orig)
+	}
+
+	// A NULL column and an empty blob both mean "no custom permissions",
+	// not an error and not a partially-populated struct.
+	var fromNil StationPermissions
+	if err := fromNil.Scan(nil); err != nil {
+		t.Fatalf("scan nil: %v", err)
+	}
+	if fromNil != (StationPermissions{}) {
+		t.Fatalf("nil scan = %+v, want zero", fromNil)
+	}
+
+	var fromEmpty StationPermissions
+	if err := fromEmpty.Scan([]byte{}); err != nil {
+		t.Fatalf("scan empty: %v", err)
+	}
+	if fromEmpty != (StationPermissions{}) {
+		t.Fatalf("empty scan = %+v, want zero", fromEmpty)
+	}
+
+	// A non-blob value is a schema mismatch and must not be silently ignored.
+	var bad StationPermissions
+	if err := bad.Scan(42); err == nil {
+		t.Fatal("scanning an int was accepted")
+	}
+
+	var malformed StationPermissions
+	if err := malformed.Scan([]byte("{not json")); err == nil {
+		t.Fatal("scanning malformed JSON was accepted")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// platform roles
+// ---------------------------------------------------------------------------
+
+func TestUser_RoleAndPlatformChecks(t *testing.T) {
+	for _, tc := range []struct {
+		platform PlatformRole
+		wantRole RoleName
+		admin    bool
+		mod      bool
+	}{
+		{PlatformRoleAdmin, RoleAdmin, true, true},
+		{PlatformRole("admin"), RoleAdmin, true, true},
+		{PlatformRoleMod, RoleManager, false, true},
+		{PlatformRole("moderator"), RoleManager, false, true},
+		{PlatformRole("manager"), RoleManager, false, true},
+		{PlatformRoleUser, RoleDJ, false, false},
+		{PlatformRole(""), RoleDJ, false, false},
+		{PlatformRole("nonsense"), RoleDJ, false, false},
+	} {
+		u := &User{PlatformRole: tc.platform}
+		if got := u.Role(); got != tc.wantRole {
+			t.Fatalf("%q Role() = %q, want %q", tc.platform, got, tc.wantRole)
+		}
+		if got := u.IsPlatformAdmin(); got != tc.admin {
+			t.Fatalf("%q IsPlatformAdmin() = %v, want %v", tc.platform, got, tc.admin)
+		}
+		if got := u.IsPlatformMod(); got != tc.mod {
+			t.Fatalf("%q IsPlatformMod() = %v, want %v", tc.platform, got, tc.mod)
+		}
+	}
+}
+
+// Legacy role strings are normalized on the way into and out of storage, so a
+// row written before the platform_ prefix still authorizes correctly.
+func TestUser_BeforeSaveAfterFindNormalize(t *testing.T) {
+	for _, legacy := range []PlatformRole{"admin", "ADMIN", " admin ", "mod", "moderator", "manager", "user", ""} {
+		u := &User{PlatformRole: legacy}
+		if err := u.BeforeSave(nil); err != nil {
+			t.Fatalf("before save %q: %v", legacy, err)
+		}
+		normalized := u.PlatformRole
+		if strings.EqualFold(string(legacy), "admin") && normalized != PlatformRoleAdmin {
+			t.Fatalf("%q normalized to %q, want %q", legacy, normalized, PlatformRoleAdmin)
+		}
+
+		v := &User{PlatformRole: legacy}
+		if err := v.AfterFind(nil); err != nil {
+			t.Fatalf("after find %q: %v", legacy, err)
+		}
+		if v.PlatformRole != normalized {
+			t.Fatalf("%q: AfterFind gave %q but BeforeSave gave %q", legacy, v.PlatformRole, normalized)
+		}
+	}
+}
+
+func TestStation_IsOwnedBy(t *testing.T) {
+	s := &Station{OwnerID: "user-1"}
+	if !s.IsOwnedBy("user-1") {
+		t.Fatal("owner not recognized")
+	}
+	if s.IsOwnedBy("user-2") {
+		t.Fatal("non-owner reported as owner")
+	}
+	// IsOwnedBy is a plain string comparison, so a station with no owner does
+	// match the empty user ID an unauthenticated request would carry. Callers
+	// must reject the empty subject before asking; this pins that contract.
+	if !(&Station{}).IsOwnedBy("") {
+		t.Fatal("behavior changed: empty owner no longer matches an empty user ID, so callers relying on this comparison should be rechecked")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// mount names
+// ---------------------------------------------------------------------------
+
+func TestGenerateMountName(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"Radio One", "radio-one"},
+		{"RADIO ONE", "radio-one"},
+		{"Radio  One", "radio-one"},
+		{"Radio_One!", "radioone"},
+		{"Rádio Uno", "rdio-uno"},
+		{"  spaced  ", "spaced"},
+		{"---", "radio"},
+		{"", "radio"},
+		{"!!!", "radio"},
+		{"station-1", "station-1"},
+		{"a--b", "a-b"},
+	} {
+		if got := GenerateMountName(tc.in); got != tc.want {
+			t.Fatalf("GenerateMountName(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// Whatever the input, the result is safe to put in a URL path.
+func TestGenerateMountName_AlwaysURLSafe(t *testing.T) {
+	for _, in := range []string{"../../etc/passwd", "a b/c?d=e#f", "日本語ラジオ", "%00null"} {
+		got := GenerateMountName(in)
+		if got == "" {
+			t.Fatalf("GenerateMountName(%q) returned empty", in)
+		}
+		for _, r := range got {
+			isLower := r >= 'a' && r <= 'z'
+			isDigit := r >= '0' && r <= '9'
+			if !isLower && !isDigit && r != '-' {
+				t.Fatalf("GenerateMountName(%q) = %q contains %q", in, got, r)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// play history metadata
+// ---------------------------------------------------------------------------
+
+func TestPlayHistory_MetadataString(t *testing.T) {
+	p := PlayHistory{
+		Artist:   "New Order",
+		Title:    "Blue Monday",
+		Album:    "Power, Corruption & Lies",
+		Label:    "Factory",
+		Metadata: map[string]any{"artist": "Metadata Artist", "listeners": 42},
+	}
+
+	// The metadata map wins over the struct field when it holds a string.
+	if got := p.MetadataString("artist"); got != "Metadata Artist" {
+		t.Fatalf("artist = %q", got)
+	}
+	// A non-string metadata value falls through to the struct field, and
+	// "listeners" has no struct fallback.
+	if got := p.MetadataString("listeners"); got != "" {
+		t.Fatalf("listeners = %q, want empty", got)
+	}
+	// Keys absent from the map use the struct fields, case-insensitively.
+	if got := p.MetadataString("title"); got != "Blue Monday" {
+		t.Fatalf("title = %q", got)
+	}
+	if got := p.MetadataString("Album"); got != "Power, Corruption & Lies" {
+		t.Fatalf("album = %q", got)
+	}
+	if got := p.MetadataString("LABEL"); got != "Factory" {
+		t.Fatalf("label = %q", got)
+	}
+	if got := p.MetadataString("unknown"); got != "" {
+		t.Fatalf("unknown = %q, want empty", got)
+	}
+
+	// A nil map is the common case for rows written before metadata existed.
+	bare := PlayHistory{Artist: "Depeche Mode"}
+	if got := bare.MetadataString("artist"); got != "Depeche Mode" {
+		t.Fatalf("nil metadata artist = %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// schedule exceptions and locks
+// ---------------------------------------------------------------------------
+
+// A deleted occurrence has to stay deleted across schedule rebuilds, and the
+// comparison is by local calendar day so a timezone offset cannot resurrect it.
+func TestScheduleEntry_IsExceptedOn(t *testing.T) {
+	oslo, err := time.LoadLocation("Europe/Oslo")
+	if err != nil {
+		t.Skipf("tzdata unavailable: %v", err)
+	}
+
+	e := &ScheduleEntry{RecurrenceExceptions: []string{"2026-07-16", "2026-08-01"}}
+
+	if !e.IsExceptedOn(time.Date(2026, 7, 16, 12, 0, 0, 0, time.UTC), time.UTC) {
+		t.Fatal("excepted date not matched")
+	}
+	if e.IsExceptedOn(time.Date(2026, 7, 17, 12, 0, 0, 0, time.UTC), time.UTC) {
+		t.Fatal("non-excepted date matched")
+	}
+
+	// 2026-07-16 22:30 UTC is 2026-07-17 in Oslo (UTC+2), so it is not the
+	// excepted day in that zone.
+	instant := time.Date(2026, 7, 16, 22, 30, 0, 0, time.UTC)
+	if !e.IsExceptedOn(instant, time.UTC) {
+		t.Fatal("should be excepted when compared in UTC")
+	}
+	if e.IsExceptedOn(instant, oslo) {
+		t.Fatal("should not be excepted when compared in Oslo local time")
+	}
+
+	// A nil location falls back to UTC rather than panicking.
+	if !e.IsExceptedOn(instant, nil) {
+		t.Fatal("nil location should behave as UTC")
+	}
+
+	// No exceptions at all short-circuits.
+	if (&ScheduleEntry{}).IsExceptedOn(time.Now(), time.UTC) {
+		t.Fatal("entry with no exceptions reported one")
+	}
+}
+
+func TestScheduleLock_IsLocked(t *testing.T) {
+	lock := &ScheduleLock{LockBeforeDays: 7}
+
+	// Anything inside the 7-day window is locked, including the past.
+	if !lock.IsLocked(time.Now().AddDate(0, 0, 3)) {
+		t.Fatal("date inside the lock window is not locked")
+	}
+	if !lock.IsLocked(time.Now().AddDate(0, 0, -1)) {
+		t.Fatal("past date is not locked")
+	}
+	// Beyond the window a DJ can still edit.
+	if lock.IsLocked(time.Now().AddDate(0, 0, 30)) {
+		t.Fatal("date beyond the lock window is locked")
+	}
+
+	// An explicitly locked date stays locked even when it is far out.
+	far := time.Now().AddDate(0, 0, 60)
+	withDate := &ScheduleLock{LockBeforeDays: 7, LockedDates: []time.Time{far}}
+	if !withDate.IsLocked(far) {
+		t.Fatal("explicitly locked date is not locked")
+	}
+	// Matching is by calendar day, so a different clock time on the same day
+	// is still locked.
+	sameDay := time.Date(far.Year(), far.Month(), far.Day(), 23, 59, 0, 0, far.Location())
+	if !withDate.IsLocked(sameDay) {
+		t.Fatal("same calendar day at a different time is not locked")
+	}
+	if withDate.IsLocked(far.AddDate(0, 0, 1)) {
+		t.Fatal("the day after an explicitly locked date is locked")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// priority and executor state
+// ---------------------------------------------------------------------------
+
+func TestPriorityLevel_String(t *testing.T) {
+	for level, want := range map[PriorityLevel]string{
+		PriorityEmergency:     "Emergency",
+		PriorityLiveOverride:  "Live Override",
+		PriorityLiveScheduled: "Live Scheduled",
+		PriorityAutomation:    "Automation",
+		PriorityFallback:      "Fallback",
+		PriorityLevel(999):    "Unknown",
+	} {
+		if got := level.String(); got != want {
+			t.Fatalf("PriorityLevel(%d) = %q, want %q", level, got, want)
+		}
+	}
+}
+
+// The health check is what decides whether the scheduler considers an executor
+// alive, so the 10-second boundary matters.
+func TestExecutorState_IsHealthy(t *testing.T) {
+	if !(&ExecutorState{LastHeartbeat: time.Now()}).IsHealthy() {
+		t.Fatal("a just-received heartbeat is unhealthy")
+	}
+	if !(&ExecutorState{LastHeartbeat: time.Now().Add(-5 * time.Second)}).IsHealthy() {
+		t.Fatal("a 5s-old heartbeat is unhealthy")
+	}
+	if (&ExecutorState{LastHeartbeat: time.Now().Add(-11 * time.Second)}).IsHealthy() {
+		t.Fatal("an 11s-old heartbeat is healthy")
+	}
+	if (&ExecutorState{}).IsHealthy() {
+		t.Fatal("an executor that never sent a heartbeat is healthy")
+	}
+}
+
+func TestExecutorState_IsPlaying(t *testing.T) {
+	for _, state := range []ExecutorStateEnum{
+		ExecutorStatePlaying, ExecutorStateFading, ExecutorStateLive, ExecutorStateEmergency,
+	} {
+		if !(&ExecutorState{State: state}).IsPlaying() {
+			t.Fatalf("state %q not playing", state)
+		}
+	}
+	for _, state := range []ExecutorStateEnum{ExecutorStateIdle, ExecutorStateEnum("stopped"), ExecutorStateEnum("")} {
+		if (&ExecutorState{State: state}).IsPlaying() {
+			t.Fatalf("state %q reported as playing", state)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// formatting and defaults
+// ---------------------------------------------------------------------------
+
+func TestFormatBytesAndScanResultFormatSize(t *testing.T) {
+	for _, tc := range []struct {
+		bytes int64
+		want  string
+	}{
+		{0, "0 B"},
+		{512, "512 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1024 * 1024, "1.0 MB"},
+		{1024 * 1024 * 1024, "1.0 GB"},
+		{1024 * 1024 * 1024 * 1024, "1.0 TB"},
+	} {
+		if got := formatBytes(tc.bytes); got != tc.want {
+			t.Fatalf("formatBytes(%d) = %q, want %q", tc.bytes, got, tc.want)
+		}
+	}
+
+	r := &ScanResult{TotalSize: 2 * 1024 * 1024}
+	if got := r.FormatSize(); got != "2.0 MB" {
+		t.Fatalf("FormatSize = %q, want 2.0 MB", got)
+	}
+}
+
+func TestDefaultNotificationPreferences(t *testing.T) {
+	prefs := DefaultNotificationPreferences("user-1")
+	if len(prefs) == 0 {
+		t.Fatal("no default preferences")
+	}
+
+	seen := map[NotificationType]bool{}
+	for _, p := range prefs {
+		if p.UserID != "user-1" {
+			t.Fatalf("preference %+v has the wrong user", p)
+		}
+		if p.NotificationType == "" || p.Channel == "" {
+			t.Fatalf("preference %+v is missing a type or channel", p)
+		}
+		seen[p.NotificationType] = true
+	}
+
+	// Show reminders are the one default that carries config, and the lead
+	// time is what a DJ actually feels if it changes.
+	var reminder *NotificationPreference
+	for i := range prefs {
+		if prefs[i].NotificationType == NotificationTypeShowReminder {
+			reminder = &prefs[i]
+			break
+		}
+	}
+	if reminder == nil {
+		t.Fatal("no show-reminder default")
+	}
+	if !reminder.Enabled {
+		t.Fatal("show reminders default to off")
+	}
+	if reminder.Config["reminder_minutes"] != 30 {
+		t.Fatalf("reminder lead time = %v, want 30", reminder.Config["reminder_minutes"])
+	}
+
+	// The defaults must survive the JSON round trip they take into jsonb.
+	raw, err := json.Marshal(prefs)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back []NotificationPreference
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(back) != len(prefs) {
+		t.Fatalf("round trip = %d preferences, want %d", len(back), len(prefs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GORM table names
+// ---------------------------------------------------------------------------
+
+// Every TableName override pins a physical table that migrations and raw SQL
+// already reference. Renaming one silently repoints reads and writes at a
+// table that does not exist, so the mapping is asserted rather than derived.
+func TestTableNames(t *testing.T) {
+	for _, tc := range []struct {
+		got  string
+		want string
+	}{
+		{AuditLog{}.TableName(), "audit_logs"},
+		{DJAvailability{}.TableName(), "dj_availability"},
+		{ExecutorState{}.TableName(), "executor_states"},
+		{ListenerSample{}.TableName(), "listener_samples"},
+		{LiveSession{}.TableName(), "live_sessions"},
+		{Network{}.TableName(), "networks"},
+		{NetworkShow{}.TableName(), "network_shows"},
+		{NetworkSubscription{}.TableName(), "network_subscriptions"},
+		{Notification{}.TableName(), "notifications"},
+		{NotificationPreference{}.TableName(), "notification_preferences"},
+		{OrphanMedia{}.TableName(), "orphan_media"},
+		{PlayoutQueueItem{}.TableName(), "playout_queue_items"},
+		{PrioritySource{}.TableName(), "priority_sources"},
+		{ScheduleAnalytics{}.TableName(), "schedule_analytics"},
+		{ScheduleAnalyticsDaily{}.TableName(), "schedule_analytics_daily"},
+		{ScheduleLock{}.TableName(), "schedule_locks"},
+		{ScheduleRequest{}.TableName(), "schedule_requests"},
+		{ScheduleRule{}.TableName(), "schedule_rules"},
+		{ScheduleTemplate{}.TableName(), "schedule_templates"},
+		{ScheduleVersion{}.TableName(), "schedule_versions"},
+		{Show{}.TableName(), "shows"},
+		{ShowInstance{}.TableName(), "show_instances"},
+		{Sponsor{}.TableName(), "sponsors"},
+		{StagedImport{}.TableName(), "staged_imports"},
+		{SystemSettings{}.TableName(), "system_settings"},
+		{UnderwritingObligation{}.TableName(), "underwriting_obligations"},
+		{UnderwritingSpot{}.TableName(), "underwriting_spots"},
+		{WaveformCache{}.TableName(), "waveform_cache"},
+		{WebDJSession{}.TableName(), "webdj_sessions"},
+		{WebhookLog{}.TableName(), "webhook_logs"},
+		{WebhookTarget{}.TableName(), "webhook_targets"},
+		{Webstream{}.TableName(), "webstreams"},
+	} {
+		if tc.got != tc.want {
+			t.Errorf("table name = %q, want %q", tc.got, tc.want)
+		}
+	}
+}

--- a/internal/telemetry/metrics_test.go
+++ b/internal/telemetry/metrics_test.go
@@ -1,0 +1,426 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package telemetry
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+	"unicode/utf8"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/rs/zerolog"
+	"go.opentelemetry.io/otel/trace"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+// ---------------------------------------------------------------------------
+// label sanitization
+// ---------------------------------------------------------------------------
+
+// Prometheus panics on invalid UTF-8 label values, so safeLabel is the guard
+// between arbitrary ID3 tags and the metrics registry.
+func TestSafeLabel(t *testing.T) {
+	t.Run("short string passes through", func(t *testing.T) {
+		if got := safeLabel("New Order", 60); got != "New Order" {
+			t.Fatalf("got %q", got)
+		}
+	})
+
+	t.Run("empty string", func(t *testing.T) {
+		if got := safeLabel("", 60); got != "" {
+			t.Fatalf("got %q", got)
+		}
+	})
+
+	t.Run("truncates to exactly maxRunes", func(t *testing.T) {
+		got := safeLabel(strings.Repeat("a", 200), 60)
+		if utf8.RuneCountInString(got) != 60 {
+			t.Fatalf("length = %d runes, want 60", utf8.RuneCountInString(got))
+		}
+		if !strings.HasSuffix(got, "...") {
+			t.Fatalf("got %q, want an ellipsis suffix", got)
+		}
+	})
+
+	t.Run("exact length is untouched", func(t *testing.T) {
+		in := strings.Repeat("b", 10)
+		if got := safeLabel(in, 10); got != in {
+			t.Fatalf("got %q, want the input unchanged", got)
+		}
+	})
+
+	// Truncation counts runes, not bytes, so a multi-byte title cannot be cut
+	// mid-sequence into invalid UTF-8.
+	t.Run("multi-byte runes are not split", func(t *testing.T) {
+		got := safeLabel(strings.Repeat("日", 40), 10)
+		if !utf8.ValidString(got) {
+			t.Fatalf("got invalid UTF-8: %q", got)
+		}
+		if utf8.RuneCountInString(got) != 10 {
+			t.Fatalf("length = %d runes, want 10", utf8.RuneCountInString(got))
+		}
+	})
+
+	t.Run("invalid UTF-8 is stripped", func(t *testing.T) {
+		got := safeLabel(string([]byte{'o', 'k', 0xff, 0xfe}), 60)
+		if !utf8.ValidString(got) {
+			t.Fatalf("got invalid UTF-8: %q", got)
+		}
+		if got != "ok" {
+			t.Fatalf("got %q, want %q", got, "ok")
+		}
+	})
+}
+
+// ---------------------------------------------------------------------------
+// HTTP middleware
+// ---------------------------------------------------------------------------
+
+func TestMetricsMiddleware_RecordsStatusAndPath(t *testing.T) {
+	const path = "/telemetry-test/plain"
+	before := testutil.ToFloat64(APIRequestsTotal.WithLabelValues("GET", path, "404"))
+
+	h := MetricsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rec.Code)
+	}
+	after := testutil.ToFloat64(APIRequestsTotal.WithLabelValues("GET", path, "404"))
+	if after != before+1 {
+		t.Fatalf("request counter = %v, want %v", after, before+1)
+	}
+	if got := testutil.ToFloat64(APIActiveConnections); got != 0 {
+		t.Fatalf("active connections = %v after the request completed, want 0", got)
+	}
+}
+
+// A handler that writes a body without calling WriteHeader is a 200; the wrapper
+// has to infer that rather than reporting the zero value.
+func TestMetricsMiddleware_DefaultsToStatus200(t *testing.T) {
+	const path = "/telemetry-test/implicit"
+	before := testutil.ToFloat64(APIRequestsTotal.WithLabelValues("POST", path, "200"))
+
+	h := MetricsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if _, err := w.Write([]byte("hello")); err != nil {
+			t.Errorf("write: %v", err)
+		}
+	}))
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, path, nil))
+
+	if rec.Body.String() != "hello" {
+		t.Fatalf("body = %q", rec.Body.String())
+	}
+	if after := testutil.ToFloat64(APIRequestsTotal.WithLabelValues("POST", path, "200")); after != before+1 {
+		t.Fatalf("counter = %v, want %v", after, before+1)
+	}
+}
+
+// Only the first WriteHeader wins, so a handler that double-writes doesn't
+// corrupt the recorded status label.
+func TestMetricsMiddleware_FirstStatusWins(t *testing.T) {
+	const path = "/telemetry-test/double"
+	before := testutil.ToFloat64(APIRequestsTotal.WithLabelValues("GET", path, "503"))
+
+	h := MetricsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.WriteHeader(http.StatusOK)
+	}))
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, path, nil))
+
+	if after := testutil.ToFloat64(APIRequestsTotal.WithLabelValues("GET", path, "503")); after != before+1 {
+		t.Fatalf("counter for 503 = %v, want %v", after, before+1)
+	}
+}
+
+// With a chi router in front, the endpoint label must be the route pattern.
+// Otherwise every ID in a URL becomes its own time series.
+func TestMetricsMiddleware_UsesChiRoutePattern(t *testing.T) {
+	before := testutil.ToFloat64(APIRequestsTotal.WithLabelValues("GET", "/stations/{id}", "200"))
+
+	r := chi.NewRouter()
+	r.Use(MetricsMiddleware)
+	r.Get("/stations/{id}", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	rec := httptest.NewRecorder()
+	r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/stations/abc-123", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d", rec.Code)
+	}
+	after := testutil.ToFloat64(APIRequestsTotal.WithLabelValues("GET", "/stations/{id}", "200"))
+	if after != before+1 {
+		t.Fatalf("counter = %v, want %v; the raw path was probably used as the label", after, before+1)
+	}
+}
+
+// hijackableRecorder stands in for a real connection so the WebSocket upgrade
+// path can be exercised without a live listener.
+type hijackableRecorder struct {
+	*httptest.ResponseRecorder
+	hijacked bool
+}
+
+func (h *hijackableRecorder) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h.hijacked = true
+	client, server := net.Pipe()
+	_ = server.Close()
+	return client, bufio.NewReadWriter(bufio.NewReader(client), bufio.NewWriter(client)), nil
+}
+
+// WebSocket routes go through this middleware; if the wrapper swallowed
+// http.Hijacker, every upgrade under /api would fail.
+func TestMetricsMiddleware_PassesThroughHijack(t *testing.T) {
+	var hijackErr error
+	h := MetricsMiddleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			hijackErr = errors.New("wrapped writer does not implement http.Hijacker")
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			hijackErr = err
+			return
+		}
+		_ = conn.Close()
+	}))
+
+	rec := &hijackableRecorder{ResponseRecorder: httptest.NewRecorder()}
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/telemetry-test/ws", nil))
+
+	if hijackErr != nil {
+		t.Fatalf("hijack failed: %v", hijackErr)
+	}
+	if !rec.hijacked {
+		t.Fatal("Hijack was not forwarded to the underlying ResponseWriter")
+	}
+}
+
+func TestResponseWriter_HijackUnsupported(t *testing.T) {
+	rw := &responseWriter{ResponseWriter: httptest.NewRecorder(), statusCode: http.StatusOK}
+	conn, buf, err := rw.Hijack()
+	if !errors.Is(err, http.ErrNotSupported) {
+		t.Fatalf("err = %v, want http.ErrNotSupported", err)
+	}
+	if conn != nil || buf != nil {
+		t.Fatal("expected nil conn and buffer when hijacking is unsupported")
+	}
+}
+
+func TestTracingMiddleware(t *testing.T) {
+	t.Run("plain path", func(t *testing.T) {
+		called := false
+		h := TracingMiddleware("grimnir-test")(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusTeapot)
+		}))
+
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/telemetry-test/trace", nil))
+
+		if !called {
+			t.Fatal("next handler was not invoked")
+		}
+		if rec.Code != http.StatusTeapot {
+			t.Fatalf("status = %d, want 418", rec.Code)
+		}
+	})
+
+	t.Run("chi route pattern", func(t *testing.T) {
+		r := chi.NewRouter()
+		r.Use(TracingMiddleware("grimnir-test"))
+		r.Get("/mounts/{id}", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+
+		rec := httptest.NewRecorder()
+		r.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/mounts/m1", nil))
+		if rec.Code != http.StatusOK {
+			t.Fatalf("status = %d", rec.Code)
+		}
+	})
+}
+
+func TestHandler_ServesMetrics(t *testing.T) {
+	StationsTotal.Set(3)
+
+	rec := httptest.NewRecorder()
+	Handler().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "grimnir_stations_total") {
+		t.Fatal("metrics output missing grimnir_stations_total")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DB-driven gauges
+// ---------------------------------------------------------------------------
+
+func newMetricsDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.Station{},
+		&models.MediaItem{},
+		&models.MountPlayoutState{},
+		&models.PlayHistory{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	return db
+}
+
+func TestUpdateStationMetrics(t *testing.T) {
+	db := newMetricsDB(t)
+
+	db.Create(&models.Station{ID: "st1", Name: "One"})
+	db.Create(&models.Station{ID: "st2", Name: "Two"})
+	db.Create(&models.MountPlayoutState{MountID: "m1", StationID: "st1", StartedAt: time.Now()})
+
+	// 2 minutes + 3 minutes = 5 minutes = 300000ms = 0.08333 hours.
+	db.Create(&models.MediaItem{ID: "a", StationID: "st1", Path: "a.mp3", Duration: 2 * time.Minute})
+	db.Create(&models.MediaItem{ID: "b", StationID: "st1", Path: "b.mp3", Duration: 3 * time.Minute})
+	// Excluded: failed analysis and zero duration are not part of the library size.
+	db.Create(&models.MediaItem{ID: "c", StationID: "st1", Path: "c.mp3", Duration: time.Minute, AnalysisState: models.AnalysisFailed})
+	db.Create(&models.MediaItem{ID: "d", StationID: "st1", Path: "d.mp3", Duration: 0})
+
+	db.Create(&models.PlayHistory{ID: "p1", StationID: "st1", StartedAt: time.Now().Add(-time.Hour)})
+	db.Create(&models.PlayHistory{ID: "p2", StationID: "st1", StartedAt: time.Now().Add(-2 * time.Hour)})
+	// Older than the 24h window.
+	db.Create(&models.PlayHistory{ID: "p3", StationID: "st1", StartedAt: time.Now().Add(-48 * time.Hour)})
+
+	UpdateStationMetrics(db)
+
+	if got := testutil.ToFloat64(StationsTotal); got != 2 {
+		t.Fatalf("stations total = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(StationsActive); got != 1 {
+		t.Fatalf("stations active = %v, want 1", got)
+	}
+	if got := testutil.ToFloat64(MediaItemsTotal.WithLabelValues("st1")); got != 2 {
+		t.Fatalf("media items for st1 = %v, want 2 (failed and zero-duration excluded)", got)
+	}
+	// 5 minutes of media. Duration is a time.Duration stored as nanoseconds, so
+	// the SQL conversion has to divide by nanoseconds-per-hour.
+	hours := testutil.ToFloat64(MediaLibraryDurationHours.WithLabelValues("st1"))
+	if hours < 0.0833 || hours > 0.0834 {
+		t.Fatalf("library hours = %v, want ~0.08333", hours)
+	}
+	if got := testutil.ToFloat64(PlayHistoryTotal.WithLabelValues("st1")); got != 2 {
+		t.Fatalf("24h plays = %v, want 2", got)
+	}
+	if got := testutil.ToFloat64(UptimeSeconds); got <= 0 {
+		t.Fatalf("uptime = %v, want a positive value", got)
+	}
+}
+
+// The deferred recover exists so a bad row can't take down the ticker loop that
+// calls this every cycle. Pointing it at a DB with no tables must not panic.
+func TestUpdateStationMetrics_SurvivesBrokenSchema(t *testing.T) {
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	UpdateStationMetrics(db) // no tables exist; must return without panicking
+}
+
+func TestUpdateListenerMetrics(t *testing.T) {
+	UpdateListenerMetrics(map[string]int{"st1": 42, "st2": 7})
+
+	if got := testutil.ToFloat64(ListenersCurrentTotal.WithLabelValues("st1")); got != 42 {
+		t.Fatalf("st1 listeners = %v, want 42", got)
+	}
+	if got := testutil.ToFloat64(ListenersCurrentTotal.WithLabelValues("st2")); got != 7 {
+		t.Fatalf("st2 listeners = %v, want 7", got)
+	}
+
+	// Each refresh resets first, so a station that drops out of the map does not
+	// keep reporting its last listener count forever.
+	UpdateListenerMetrics(map[string]int{"st1": 5})
+	if got := testutil.ToFloat64(ListenersCurrentTotal.WithLabelValues("st1")); got != 5 {
+		t.Fatalf("st1 listeners = %v, want 5", got)
+	}
+	if count := testutil.CollectAndCount(ListenersCurrentTotal); count != 1 {
+		t.Fatalf("listener series = %d, want 1 after the reset", count)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// tracing
+// ---------------------------------------------------------------------------
+
+func TestInitTracer_Disabled(t *testing.T) {
+	tp, err := InitTracer(context.Background(), TracerConfig{
+		ServiceName: "grimnir-test",
+		Enabled:     false,
+	}, zerolog.Nop())
+	if err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if tp == nil {
+		t.Fatal("nil provider")
+	}
+
+	// Shutdown on a disabled provider is a no-op, not a nil dereference.
+	if err := tp.Shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+}
+
+func TestStartSpanAndAttributes(t *testing.T) {
+	ctx, span := StartSpan(context.Background(), "grimnir-test", "unit-span")
+	if span == nil {
+		t.Fatal("nil span")
+	}
+	if ctx == nil {
+		t.Fatal("nil context")
+	}
+
+	AddSpanAttributes(span, map[string]any{
+		"station_id": "st1",
+		"count":      3,
+		"bytes":      int64(4096),
+		"ratio":      0.75,
+		"live":       true,
+		"ignored":    []string{"unsupported types are skipped, not panicked on"},
+	})
+	RecordError(span, errors.New("boom"))
+	RecordError(span, nil) // nil errors are ignored
+	span.End()
+
+	if tr := Tracer("grimnir-test"); tr == nil {
+		t.Fatal("nil tracer")
+	}
+	var _ trace.Span = span
+}

--- a/internal/telemetry/station_metrics.go
+++ b/internal/telemetry/station_metrics.go
@@ -61,8 +61,10 @@ func UpdateStationMetrics(db *gorm.DB) {
 		DurationHours float64
 	}
 	var stationMediaStats []stationMedia
+	// media_items.duration holds a Go time.Duration, which gorm persists as
+	// nanoseconds — divide by nanoseconds-per-hour, not milliseconds-per-hour.
 	db.Table("media_items").
-		Select("station_id, COUNT(*) as item_count, COALESCE(SUM(duration), 0) / 3600000.0 as duration_hours").
+		Select("station_id, COUNT(*) as item_count, COALESCE(SUM(duration), 0) / 3600000000000.0 as duration_hours").
 		Where("analysis_state <> 'failed' AND duration > 0").
 		Group("station_id").
 		Scan(&stationMediaStats)

--- a/internal/webdj/service_test.go
+++ b/internal/webdj/service_test.go
@@ -1,0 +1,699 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package webdj
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/events"
+	"github.com/friendsincode/grimnir_radio/internal/live"
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+// newSvc builds a WebDJ service backed by in-memory sqlite. meClient stays nil,
+// so every media-engine branch takes the "not connected" path and only the
+// DB/in-memory state machine is exercised.
+func newSvc(t *testing.T) (*Service, *gorm.DB) {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	if err := db.AutoMigrate(
+		&models.WebDJSession{},
+		&models.MediaItem{},
+		&models.WaveformCache{},
+		&models.Mount{},
+		&models.LiveSession{},
+		&models.Station{},
+	); err != nil {
+		t.Fatalf("migrate: %v", err)
+	}
+	bus := events.NewBus()
+	liveSvc := live.NewService(db, nil, bus, zerolog.Nop())
+	return NewService(db, liveSvc, nil, nil, bus, zerolog.Nop()), db
+}
+
+func bg() context.Context { return context.Background() }
+
+// startSession creates a session through the service so both the DB row and the
+// in-memory Session exist, which is what the deck/mixer setters assume.
+func startSession(t *testing.T, s *Service, stationID string) *models.WebDJSession {
+	t.Helper()
+	sess, err := s.StartSession(bg(), StartSessionRequest{
+		StationID: stationID,
+		UserID:    "user-1",
+		Username:  "dj",
+	})
+	if err != nil {
+		t.Fatalf("start session: %v", err)
+	}
+	return sess
+}
+
+func seedMedia(t *testing.T, db *gorm.DB, id, stationID string) *models.MediaItem {
+	t.Helper()
+	m := &models.MediaItem{
+		ID:        id,
+		StationID: stationID,
+		Path:      id + ".mp3",
+		Title:     "Blue Monday",
+		Artist:    "New Order",
+		Duration:  7*time.Minute + 29*time.Second,
+	}
+	if err := db.Create(m).Error; err != nil {
+		t.Fatalf("seed media: %v", err)
+	}
+	return m
+}
+
+// ---------------------------------------------------------------------------
+// session lifecycle
+// ---------------------------------------------------------------------------
+
+func TestStartSession_CreatesActiveSessionAndLiveToken(t *testing.T) {
+	s, db := newSvc(t)
+
+	sess := startSession(t, s, "st1")
+	if sess.ID == "" {
+		t.Fatal("session ID empty")
+	}
+	if !sess.Active {
+		t.Fatal("new session should be active")
+	}
+	if sess.CrossfaderCurve != string(models.CrossfaderLinear) {
+		t.Fatalf("crossfader curve = %q, want linear", sess.CrossfaderCurve)
+	}
+	if sess.LiveSessionID == nil || *sess.LiveSessionID == "" {
+		t.Fatal("expected a live handover token on the session")
+	}
+
+	var count int64
+	db.Model(&models.WebDJSession{}).Where("id = ?", sess.ID).Count(&count)
+	if count != 1 {
+		t.Fatalf("persisted rows = %d, want 1", count)
+	}
+}
+
+// A second StartSession for the same station+user must reuse the existing row
+// rather than stacking sessions, otherwise the console opens a fresh set of
+// decks every time the browser reconnects.
+func TestStartSession_ReusesExistingSession(t *testing.T) {
+	s, db := newSvc(t)
+
+	first := startSession(t, s, "st1")
+	second := startSession(t, s, "st1")
+
+	if first.ID != second.ID {
+		t.Fatalf("second session ID = %s, want %s", second.ID, first.ID)
+	}
+	var count int64
+	db.Model(&models.WebDJSession{}).Count(&count)
+	if count != 1 {
+		t.Fatalf("session rows = %d, want 1", count)
+	}
+}
+
+func TestEndSession_MarksInactiveAndDropsMemory(t *testing.T) {
+	s, db := newSvc(t)
+	sess := startSession(t, s, "st1")
+
+	if err := s.EndSession(bg(), sess.ID); err != nil {
+		t.Fatalf("end session: %v", err)
+	}
+
+	var row models.WebDJSession
+	if err := db.First(&row, "id = ?", sess.ID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	if row.Active {
+		t.Fatal("session still active after EndSession")
+	}
+
+	s.mu.RLock()
+	_, stillCached := s.sessions[sess.ID]
+	s.mu.RUnlock()
+	if stillCached {
+		t.Fatal("in-memory session not cleaned up")
+	}
+
+	// Operations on the ended session must now be refused.
+	if err := s.SetCrossfader(bg(), sess.ID, 0.5); !errors.Is(err, ErrSessionNotActive) {
+		t.Fatalf("SetCrossfader after end = %v, want ErrSessionNotActive", err)
+	}
+}
+
+func TestEndSession_UnknownSession(t *testing.T) {
+	s, _ := newSvc(t)
+	if err := s.EndSession(bg(), "nope"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("err = %v, want ErrSessionNotFound", err)
+	}
+}
+
+func TestGetSession_FallsBackToDatabase(t *testing.T) {
+	s, db := newSvc(t)
+	db.Create(&models.WebDJSession{ID: "db-only", StationID: "st1", UserID: "u1", Active: true})
+
+	got, err := s.GetSession(bg(), "db-only")
+	if err != nil {
+		t.Fatalf("get session: %v", err)
+	}
+	if got.StationID != "st1" {
+		t.Fatalf("station = %q, want st1", got.StationID)
+	}
+
+	if _, err := s.GetSession(bg(), "missing"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("missing session err = %v, want ErrSessionNotFound", err)
+	}
+}
+
+func TestLoadSessionFromDB(t *testing.T) {
+	s, db := newSvc(t)
+	db.Create(&models.WebDJSession{ID: "s1", StationID: "st1", UserID: "u1", Active: true})
+
+	if err := s.LoadSessionFromDB(bg(), "s1"); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	s.mu.RLock()
+	_, cached := s.sessions["s1"]
+	s.mu.RUnlock()
+	if !cached {
+		t.Fatal("session not loaded into memory")
+	}
+
+	// Loading twice is a no-op, not an error.
+	if err := s.LoadSessionFromDB(bg(), "s1"); err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+
+	if err := s.LoadSessionFromDB(bg(), "ghost"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("ghost err = %v, want ErrSessionNotFound", err)
+	}
+
+	// gorm's `default:true` ignores an explicit false at Create, so flip it after.
+	db.Create(&models.WebDJSession{ID: "s2", StationID: "st1", UserID: "u1"})
+	db.Model(&models.WebDJSession{}).Where("id = ?", "s2").Update("active", false)
+	if err := s.LoadSessionFromDB(bg(), "s2"); !errors.Is(err, ErrSessionNotActive) {
+		t.Fatalf("inactive err = %v, want ErrSessionNotActive", err)
+	}
+}
+
+func TestGetActiveSessions(t *testing.T) {
+	s, db := newSvc(t)
+	startSession(t, s, "st1")
+	other, err := s.StartSession(bg(), StartSessionRequest{StationID: "st2", UserID: "user-2"})
+	if err != nil {
+		t.Fatalf("start second: %v", err)
+	}
+	db.Create(&models.WebDJSession{ID: "closed", StationID: "st1", UserID: "u9"})
+	db.Model(&models.WebDJSession{}).Where("id = ?", "closed").Update("active", false)
+
+	all, err := s.GetActiveSessions(bg(), "")
+	if err != nil {
+		t.Fatalf("all: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("active sessions = %d, want 2", len(all))
+	}
+
+	scoped, err := s.GetActiveSessions(bg(), "st2")
+	if err != nil {
+		t.Fatalf("scoped: %v", err)
+	}
+	if len(scoped) != 1 || scoped[0].ID != other.ID {
+		t.Fatalf("scoped = %+v, want only %s", scoped, other.ID)
+	}
+}
+
+func TestIsLive_DefaultsFalse(t *testing.T) {
+	s, _ := newSvc(t)
+	sess := startSession(t, s, "st1")
+
+	if s.IsLive(sess.ID) {
+		t.Fatal("fresh session reported live")
+	}
+	if s.IsLive("unknown") {
+		t.Fatal("unknown session reported live")
+	}
+}
+
+// GoLive/GoOffAir both need the media engine; with meClient nil they must fail
+// cleanly instead of dereferencing it.
+func TestGoLive_WithoutMediaEngine(t *testing.T) {
+	s, _ := newSvc(t)
+	sess := startSession(t, s, "st1")
+
+	err := s.GoLive(bg(), GoLiveRequest{SessionID: sess.ID, MountID: "m1", InputType: "webrtc"})
+	if !errors.Is(err, ErrMediaEngineUnavailable) {
+		t.Fatalf("GoLive = %v, want ErrMediaEngineUnavailable", err)
+	}
+}
+
+func TestGoOffAir_WhenNotLive(t *testing.T) {
+	s, _ := newSvc(t)
+	sess := startSession(t, s, "st1")
+
+	if err := s.GoOffAir(bg(), sess.ID); !errors.Is(err, ErrNotLive) {
+		t.Fatalf("GoOffAir = %v, want ErrNotLive", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// deck loading
+// ---------------------------------------------------------------------------
+
+func TestLoadTrack_PopulatesDeckAndCuePoints(t *testing.T) {
+	s, db := newSvc(t)
+	sess := startSession(t, s, "st1")
+	m := seedMedia(t, db, "media-1", "st1")
+	// Analysis markers become pre-seeded hot cues 1 and 2.
+	db.Model(&models.MediaItem{}).Where("id = ?", m.ID).
+		Update("cue_points", models.CuePointSet{IntroEnd: 12.5, OutroIn: 400})
+
+	deck, err := s.LoadTrack(bg(), LoadTrackRequest{SessionID: sess.ID, Deck: models.DeckA, MediaID: m.ID})
+	if err != nil {
+		t.Fatalf("load track: %v", err)
+	}
+
+	if deck.MediaID != m.ID || deck.Title != "Blue Monday" {
+		t.Fatalf("deck = %+v", deck)
+	}
+	if deck.State != string(models.DeckStateCued) {
+		t.Fatalf("state = %q, want cued", deck.State)
+	}
+	if deck.DurationMS != m.Duration.Milliseconds() {
+		t.Fatalf("duration = %d, want %d", deck.DurationMS, m.Duration.Milliseconds())
+	}
+	if deck.Volume != 1.0 {
+		t.Fatalf("volume = %v, want 1.0", deck.Volume)
+	}
+	if len(deck.HotCues) != 2 {
+		t.Fatalf("hot cues = %d, want 2 (intro + outro)", len(deck.HotCues))
+	}
+	if deck.HotCues[0].PositionMS != 12500 {
+		t.Fatalf("intro cue = %dms, want 12500", deck.HotCues[0].PositionMS)
+	}
+	if deck.HotCues[1].PositionMS != 400000 {
+		t.Fatalf("outro cue = %dms, want 400000", deck.HotCues[1].PositionMS)
+	}
+
+	// The deck state must survive a round trip through the DB column.
+	var row models.WebDJSession
+	if err := db.First(&row, "id = ?", sess.ID).Error; err != nil {
+		t.Fatalf("reload session: %v", err)
+	}
+	if row.DeckAState.MediaID != m.ID {
+		t.Fatalf("persisted deck A media = %q, want %q", row.DeckAState.MediaID, m.ID)
+	}
+	if row.DeckBState.MediaID != "" {
+		t.Fatal("deck B should be untouched")
+	}
+}
+
+// Loading media owned by another station is the cross-tenant leak worth
+// guarding: the check happens before any deck state is written.
+func TestLoadTrack_RejectsForeignStationMedia(t *testing.T) {
+	s, db := newSvc(t)
+	sess := startSession(t, s, "st1")
+	seedMedia(t, db, "media-other", "st2")
+
+	_, err := s.LoadTrack(bg(), LoadTrackRequest{SessionID: sess.ID, Deck: models.DeckA, MediaID: "media-other"})
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("err = %v, want ErrUnauthorized", err)
+	}
+
+	var row models.WebDJSession
+	db.First(&row, "id = ?", sess.ID)
+	if row.DeckAState.MediaID != "" {
+		t.Fatal("deck A was written despite the authorization failure")
+	}
+}
+
+func TestLoadTrack_Errors(t *testing.T) {
+	s, db := newSvc(t)
+	sess := startSession(t, s, "st1")
+	seedMedia(t, db, "media-1", "st1")
+
+	if _, err := s.LoadTrack(bg(), LoadTrackRequest{SessionID: sess.ID, Deck: models.DeckA, MediaID: "ghost"}); !errors.Is(err, ErrMediaNotFound) {
+		t.Fatalf("missing media = %v, want ErrMediaNotFound", err)
+	}
+	if _, err := s.LoadTrack(bg(), LoadTrackRequest{SessionID: "ghost", Deck: models.DeckA, MediaID: "media-1"}); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("missing session = %v, want ErrSessionNotFound", err)
+	}
+	if _, err := s.LoadTrack(bg(), LoadTrackRequest{SessionID: sess.ID, Deck: models.DeckID("c"), MediaID: "media-1"}); !errors.Is(err, ErrInvalidDeck) {
+		t.Fatalf("bad deck = %v, want ErrInvalidDeck", err)
+	}
+}
+
+func TestEjectTrack_ResetsDeck(t *testing.T) {
+	s, db := newSvc(t)
+	sess := startSession(t, s, "st1")
+	seedMedia(t, db, "media-1", "st1")
+	if _, err := s.LoadTrack(bg(), LoadTrackRequest{SessionID: sess.ID, Deck: models.DeckB, MediaID: "media-1"}); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if err := s.EjectTrack(bg(), sess.ID, models.DeckB); err != nil {
+		t.Fatalf("eject: %v", err)
+	}
+
+	deck, err := s.getDeckState(bg(), sess.ID, models.DeckB)
+	if err != nil {
+		t.Fatalf("deck state: %v", err)
+	}
+	if deck.MediaID != "" {
+		t.Fatalf("deck still holds %q after eject", deck.MediaID)
+	}
+
+	if err := s.EjectTrack(bg(), sess.ID, models.DeckID("z")); !errors.Is(err, ErrInvalidDeck) {
+		t.Fatalf("bad deck = %v, want ErrInvalidDeck", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// transport
+// ---------------------------------------------------------------------------
+
+func TestPlayPause_RequireLoadedTrack(t *testing.T) {
+	s, _ := newSvc(t)
+	sess := startSession(t, s, "st1")
+
+	if err := s.Play(bg(), sess.ID, models.DeckA); !errors.Is(err, ErrNoTrackLoaded) {
+		t.Fatalf("play empty deck = %v, want ErrNoTrackLoaded", err)
+	}
+	if err := s.Pause(bg(), sess.ID, models.DeckA); !errors.Is(err, ErrNoTrackLoaded) {
+		t.Fatalf("pause empty deck = %v, want ErrNoTrackLoaded", err)
+	}
+	if err := s.Seek(bg(), sess.ID, models.DeckA, 1000); !errors.Is(err, ErrNoTrackLoaded) {
+		t.Fatalf("seek empty deck = %v, want ErrNoTrackLoaded", err)
+	}
+}
+
+func TestPlayPause_TransitionsDeckState(t *testing.T) {
+	s, db := newSvc(t)
+	sess := startSession(t, s, "st1")
+	seedMedia(t, db, "media-1", "st1")
+	if _, err := s.LoadTrack(bg(), LoadTrackRequest{SessionID: sess.ID, Deck: models.DeckA, MediaID: "media-1"}); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if err := s.Play(bg(), sess.ID, models.DeckA); err != nil {
+		t.Fatalf("play: %v", err)
+	}
+	deck, _ := s.getDeckState(bg(), sess.ID, models.DeckA)
+	if deck.State != string(models.DeckStatePlaying) {
+		t.Fatalf("state = %q, want playing", deck.State)
+	}
+
+	if err := s.Pause(bg(), sess.ID, models.DeckA); err != nil {
+		t.Fatalf("pause: %v", err)
+	}
+	deck, _ = s.getDeckState(bg(), sess.ID, models.DeckA)
+	if deck.State != string(models.DeckStatePaused) {
+		t.Fatalf("state = %q, want paused", deck.State)
+	}
+}
+
+// Seek clamps to [0, duration]; a position past the end would otherwise ask the
+// media engine to cue past EOF.
+func TestSeek_ClampsToTrackBounds(t *testing.T) {
+	s, db := newSvc(t)
+	sess := startSession(t, s, "st1")
+	m := seedMedia(t, db, "media-1", "st1")
+	if _, err := s.LoadTrack(bg(), LoadTrackRequest{SessionID: sess.ID, Deck: models.DeckA, MediaID: m.ID}); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	durMS := m.Duration.Milliseconds()
+
+	for _, tc := range []struct{ in, want int64 }{
+		{-5000, 0},
+		{1234, 1234},
+		{durMS + 60000, durMS},
+	} {
+		if err := s.Seek(bg(), sess.ID, models.DeckA, tc.in); err != nil {
+			t.Fatalf("seek %d: %v", tc.in, err)
+		}
+		deck, _ := s.getDeckState(bg(), sess.ID, models.DeckA)
+		if deck.PositionMS != tc.want {
+			t.Fatalf("seek(%d) position = %d, want %d", tc.in, deck.PositionMS, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// hot cues
+// ---------------------------------------------------------------------------
+
+func TestSetCue_RangeAndUpdate(t *testing.T) {
+	s, db := newSvc(t)
+	sess := startSession(t, s, "st1")
+	seedMedia(t, db, "media-1", "st1")
+	if _, err := s.LoadTrack(bg(), LoadTrackRequest{SessionID: sess.ID, Deck: models.DeckA, MediaID: "media-1"}); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	for _, bad := range []int{0, 9, -1} {
+		if err := s.SetCue(bg(), sess.ID, models.DeckA, bad, 100); err == nil {
+			t.Fatalf("cue ID %d accepted, want rejection", bad)
+		}
+	}
+
+	if err := s.SetCue(bg(), sess.ID, models.DeckA, 3, 5000); err != nil {
+		t.Fatalf("set cue: %v", err)
+	}
+	deck, _ := s.getDeckState(bg(), sess.ID, models.DeckA)
+	if len(deck.HotCues) != 1 || deck.HotCues[0].ID != 3 || deck.HotCues[0].PositionMS != 5000 {
+		t.Fatalf("hot cues = %+v", deck.HotCues)
+	}
+
+	// Setting the same ID again moves it rather than appending a duplicate.
+	if err := s.SetCue(bg(), sess.ID, models.DeckA, 3, 9000); err != nil {
+		t.Fatalf("move cue: %v", err)
+	}
+	deck, _ = s.getDeckState(bg(), sess.ID, models.DeckA)
+	if len(deck.HotCues) != 1 || deck.HotCues[0].PositionMS != 9000 {
+		t.Fatalf("after move, hot cues = %+v", deck.HotCues)
+	}
+}
+
+func TestDeleteCue(t *testing.T) {
+	s, db := newSvc(t)
+	sess := startSession(t, s, "st1")
+	seedMedia(t, db, "media-1", "st1")
+	if _, err := s.LoadTrack(bg(), LoadTrackRequest{SessionID: sess.ID, Deck: models.DeckA, MediaID: "media-1"}); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if err := s.SetCue(bg(), sess.ID, models.DeckA, 1, 1000); err != nil {
+		t.Fatalf("cue 1: %v", err)
+	}
+	if err := s.SetCue(bg(), sess.ID, models.DeckA, 2, 2000); err != nil {
+		t.Fatalf("cue 2: %v", err)
+	}
+
+	if err := s.DeleteCue(bg(), sess.ID, models.DeckA, 1); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	deck, _ := s.getDeckState(bg(), sess.ID, models.DeckA)
+	for _, c := range deck.HotCues {
+		if c.ID == 1 {
+			t.Fatalf("cue 1 survived deletion: %+v", deck.HotCues)
+		}
+	}
+	if len(deck.HotCues) != 1 {
+		t.Fatalf("remaining cues = %d, want 1", len(deck.HotCues))
+	}
+
+	// Deleting a cue that was never set leaves the list alone.
+	if err := s.DeleteCue(bg(), sess.ID, models.DeckA, 7); err != nil {
+		t.Fatalf("delete missing: %v", err)
+	}
+	deck, _ = s.getDeckState(bg(), sess.ID, models.DeckA)
+	if len(deck.HotCues) != 1 {
+		t.Fatalf("cues after no-op delete = %d, want 1", len(deck.HotCues))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// deck and mixer clamping
+// ---------------------------------------------------------------------------
+
+func TestSetVolumeAndPitch_Clamp(t *testing.T) {
+	s, _ := newSvc(t)
+	sess := startSession(t, s, "st1")
+
+	for _, tc := range []struct{ in, want float64 }{{-2, 0}, {0.25, 0.25}, {5, 1}} {
+		if err := s.SetVolume(bg(), sess.ID, models.DeckA, tc.in); err != nil {
+			t.Fatalf("set volume %v: %v", tc.in, err)
+		}
+		deck, _ := s.getDeckState(bg(), sess.ID, models.DeckA)
+		if deck.Volume != tc.want {
+			t.Fatalf("SetVolume(%v) = %v, want %v", tc.in, deck.Volume, tc.want)
+		}
+	}
+
+	for _, tc := range []struct{ in, want float64 }{{-50, -8}, {3.5, 3.5}, {50, 8}} {
+		if err := s.SetPitch(bg(), sess.ID, models.DeckA, tc.in); err != nil {
+			t.Fatalf("set pitch %v: %v", tc.in, err)
+		}
+		deck, _ := s.getDeckState(bg(), sess.ID, models.DeckA)
+		if deck.Pitch != tc.want {
+			t.Fatalf("SetPitch(%v) = %v, want %v", tc.in, deck.Pitch, tc.want)
+		}
+	}
+}
+
+// EQ is clamped to the ±12 dB the mixer UI exposes.
+func TestSetEQ_ClampsAllThreeBands(t *testing.T) {
+	s, _ := newSvc(t)
+	sess := startSession(t, s, "st1")
+
+	if err := s.SetEQ(bg(), sess.ID, models.DeckB, 30, -30, 6); err != nil {
+		t.Fatalf("set eq: %v", err)
+	}
+	deck, _ := s.getDeckState(bg(), sess.ID, models.DeckB)
+	if deck.EQHigh != 12 || deck.EQMid != -12 || deck.EQLow != 6 {
+		t.Fatalf("eq = (%v, %v, %v), want (12, -12, 6)", deck.EQHigh, deck.EQMid, deck.EQLow)
+	}
+}
+
+func TestMixerSetters(t *testing.T) {
+	s, db := newSvc(t)
+	sess := startSession(t, s, "st1")
+
+	if err := s.SetCrossfader(bg(), sess.ID, 7); err != nil {
+		t.Fatalf("crossfader: %v", err)
+	}
+	if err := s.SetMasterVolume(bg(), sess.ID, -3); err != nil {
+		t.Fatalf("master volume: %v", err)
+	}
+	if err := s.SetHeadphoneVolume(bg(), sess.ID, 0.42); err != nil {
+		t.Fatalf("headphone volume: %v", err)
+	}
+	if err := s.SetCueSplit(bg(), sess.ID, true); err != nil {
+		t.Fatalf("cue split: %v", err)
+	}
+	if err := s.SetCueMixLevel(bg(), sess.ID, 0.8); err != nil {
+		t.Fatalf("cue mix: %v", err)
+	}
+	if err := s.SetHeadphoneCue(bg(), sess.ID, "a", true); err != nil {
+		t.Fatalf("headphone cue a: %v", err)
+	}
+	if err := s.SetHeadphoneCue(bg(), sess.ID, "b", true); err != nil {
+		t.Fatalf("headphone cue b: %v", err)
+	}
+	if err := s.SetHeadphoneCue(bg(), sess.ID, "c", true); !errors.Is(err, ErrInvalidDeck) {
+		t.Fatalf("headphone cue c = %v, want ErrInvalidDeck", err)
+	}
+
+	var row models.WebDJSession
+	if err := db.First(&row, "id = ?", sess.ID).Error; err != nil {
+		t.Fatalf("reload: %v", err)
+	}
+	mix := row.MixerState
+	if mix.Crossfader != 1 {
+		t.Fatalf("crossfader = %v, want clamped to 1", mix.Crossfader)
+	}
+	if mix.MasterVolume != 0 {
+		t.Fatalf("master volume = %v, want clamped to 0", mix.MasterVolume)
+	}
+	if mix.HeadphoneVol != 0.42 {
+		t.Fatalf("headphone vol = %v, want 0.42", mix.HeadphoneVol)
+	}
+	if !mix.CueSplit || !mix.HeadphoneCueA || !mix.HeadphoneCueB {
+		t.Fatalf("toggles not persisted: %+v", mix)
+	}
+	if mix.CueMixLevel != 0.8 {
+		t.Fatalf("cue mix level = %v, want 0.8", mix.CueMixLevel)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// subscriptions
+// ---------------------------------------------------------------------------
+
+func TestSubscribe_ReceivesBroadcastsAndUnsubscribes(t *testing.T) {
+	s, db := newSvc(t)
+	sess := startSession(t, s, "st1")
+	seedMedia(t, db, "media-1", "st1")
+
+	ch, unsubscribe, err := s.Subscribe(sess.ID)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	if _, err := s.LoadTrack(bg(), LoadTrackRequest{SessionID: sess.ID, Deck: models.DeckA, MediaID: "media-1"}); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	select {
+	case update := <-ch:
+		if update.Type != "deck_loaded" {
+			t.Fatalf("update type = %q, want deck_loaded", update.Type)
+		}
+		if update.Deck != string(models.DeckA) {
+			t.Fatalf("update deck = %q, want a", update.Deck)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("no state update delivered to subscriber")
+	}
+
+	unsubscribe()
+	if err := s.SetVolume(bg(), sess.ID, models.DeckA, 0.5); err != nil {
+		t.Fatalf("set volume: %v", err)
+	}
+	select {
+	case update := <-ch:
+		t.Fatalf("received %q after unsubscribe", update.Type)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestSubscribe_UnknownSession(t *testing.T) {
+	s, _ := newSvc(t)
+	if _, _, err := s.Subscribe("ghost"); !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("err = %v, want ErrSessionNotFound", err)
+	}
+}
+
+// A subscriber that stops reading must not block the broadcaster: the buffered
+// channel fills at 16 and further sends are dropped.
+func TestBroadcastUpdate_DropsOnFullSubscriber(t *testing.T) {
+	s, _ := newSvc(t)
+	sess := startSession(t, s, "st1")
+
+	ch, _, err := s.Subscribe(sess.ID)
+	if err != nil {
+		t.Fatalf("subscribe: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for i := 0; i < 50; i++ {
+			s.broadcastUpdate(sess.ID, &StateUpdate{Type: "noise", SessionID: sess.ID})
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("broadcastUpdate blocked on a full subscriber channel")
+	}
+	if len(ch) != 16 {
+		t.Fatalf("buffered updates = %d, want the 16-slot buffer to be full", len(ch))
+	}
+
+	// Broadcasting to a session with no in-memory entry is a no-op.
+	s.broadcastUpdate("ghost", &StateUpdate{Type: "noise"})
+}

--- a/internal/webdj/waveform_test.go
+++ b/internal/webdj/waveform_test.go
@@ -1,0 +1,472 @@
+/*
+Copyright (C) 2026 Friends Incode
+
+SPDX-License-Identifier: AGPL-3.0-or-later
+*/
+
+package webdj
+
+import (
+	"bufio"
+	"bytes"
+	"compress/gzip"
+	"encoding/binary"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+	"gorm.io/gorm"
+
+	"github.com/friendsincode/grimnir_radio/internal/models"
+)
+
+// newWaveformSvc reuses the sqlite harness from service_test.go. meClient is nil,
+// so generation always falls through the ffmpeg fallback to the placeholder.
+func newWaveformSvc(t *testing.T) (*WaveformService, *gorm.DB) {
+	t.Helper()
+	_, db := newSvc(t)
+	return NewWaveformService(db, nil, nil, t.TempDir(), zerolog.Nop()), db
+}
+
+// pcmStereo encodes frames as signed 16-bit little-endian interleaved stereo,
+// which is the exact format the ffmpeg fallback pipes back.
+func pcmStereo(frames [][2]int16) []byte {
+	var buf bytes.Buffer
+	for _, f := range frames {
+		_ = binary.Write(&buf, binary.LittleEndian, f[0])
+		_ = binary.Write(&buf, binary.LittleEndian, f[1])
+	}
+	return buf.Bytes()
+}
+
+// ---------------------------------------------------------------------------
+// PCM peak extraction
+// ---------------------------------------------------------------------------
+
+func TestComputePeaksFromPCM_WindowsAndPeaks(t *testing.T) {
+	// 100 Hz decoded at 10 samples/sec means a 10-frame window.
+	frames := make([][2]int16, 0, 25)
+	for i := 0; i < 25; i++ {
+		switch {
+		case i == 3:
+			frames = append(frames, [2]int16{16384, -8192}) // peak of window 0
+		case i == 15:
+			frames = append(frames, [2]int16{-32768, 32767}) // peak of window 1
+		case i == 22:
+			frames = append(frames, [2]int16{8192, 4096}) // peak of the short tail
+		default:
+			frames = append(frames, [2]int16{100, -100})
+		}
+	}
+
+	r := bufio.NewReader(bytes.NewReader(pcmStereo(frames)))
+	left, right, total, err := computePeaksFromPCM(r, 100, 10)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	if total != 25 {
+		t.Fatalf("frames = %d, want 25", total)
+	}
+	// Two full windows plus the partial tail flushed at EOF.
+	if len(left) != 3 || len(right) != 3 {
+		t.Fatalf("windows = (%d, %d), want 3 each", len(left), len(right))
+	}
+
+	want := []struct{ l, r float32 }{
+		{16384.0 / 32768.0, 8192.0 / 32768.0},
+		{32767.0 / 32768.0, 32767.0 / 32768.0}, // -32768 folds to 32767
+		{8192.0 / 32768.0, 4096.0 / 32768.0},
+	}
+	for i, w := range want {
+		if left[i] != w.l {
+			t.Fatalf("left[%d] = %v, want %v", i, left[i], w.l)
+		}
+		if right[i] != w.r {
+			t.Fatalf("right[%d] = %v, want %v", i, right[i], w.r)
+		}
+	}
+}
+
+// A trailing odd byte count must not produce a bogus final frame.
+func TestComputePeaksFromPCM_IgnoresPartialFrame(t *testing.T) {
+	data := append(pcmStereo([][2]int16{{1000, 2000}, {3000, 4000}}), 0x7f, 0x7f)
+	left, _, frames, err := computePeaksFromPCM(bufio.NewReader(bytes.NewReader(data)), 4, 2)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	if frames != 2 {
+		t.Fatalf("frames = %d, want 2 complete frames", frames)
+	}
+	if len(left) != 1 {
+		t.Fatalf("windows = %d, want 1", len(left))
+	}
+}
+
+func TestComputePeaksFromPCM_EmptyInput(t *testing.T) {
+	left, right, frames, err := computePeaksFromPCM(bufio.NewReader(bytes.NewReader(nil)), 100, 10)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	if len(left) != 0 || len(right) != 0 || frames != 0 {
+		t.Fatalf("got (%d, %d, %d), want all zero", len(left), len(right), frames)
+	}
+}
+
+func TestComputePeaksFromPCM_InvalidRates(t *testing.T) {
+	for _, tc := range []struct{ sampleRate, samplesPerSec int }{
+		{0, 10}, {100, 0}, {-1, 10}, {100, -5},
+	} {
+		if _, _, _, err := computePeaksFromPCM(bufio.NewReader(bytes.NewReader(nil)), tc.sampleRate, tc.samplesPerSec); err == nil {
+			t.Fatalf("computePeaksFromPCM(%d, %d) accepted, want error", tc.sampleRate, tc.samplesPerSec)
+		}
+	}
+}
+
+// When samplesPerSec exceeds sampleRate the window floor is 1 frame, not 0,
+// which would otherwise divide by zero.
+func TestComputePeaksFromPCM_WindowFloorOfOne(t *testing.T) {
+	frames := [][2]int16{{1000, -1000}, {2000, -2000}, {3000, -3000}}
+	left, _, _, err := computePeaksFromPCM(bufio.NewReader(bytes.NewReader(pcmStereo(frames))), 5, 50)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	if len(left) != 3 {
+		t.Fatalf("windows = %d, want 3 (one per frame)", len(left))
+	}
+}
+
+func TestAbs16(t *testing.T) {
+	cases := map[int16]int16{
+		0:      0,
+		7:      7,
+		-7:     7,
+		32767:  32767,
+		-32767: 32767,
+		-32768: 32767, // saturates instead of overflowing back to itself
+	}
+	for in, want := range cases {
+		if got := abs16(in); got != want {
+			t.Fatalf("abs16(%d) = %d, want %d", in, got, want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// placeholder generation
+// ---------------------------------------------------------------------------
+
+func TestGeneratePlaceholderWaveform_SampleCounts(t *testing.T) {
+	w, _ := newWaveformSvc(t)
+
+	for _, tc := range []struct {
+		name       string
+		durationMS int64
+		want       int
+	}{
+		{"zero duration floors at 10", 0, 10},
+		{"sub-second floors at 10", 400, 10},
+		{"five seconds at 10/sec", 5000, 50},
+		{"long recording caps at 10000", 5 * 60 * 60 * 1000, 10000},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := w.generatePlaceholderWaveform("m1", tc.durationMS)
+			if err != nil {
+				t.Fatalf("generate: %v", err)
+			}
+			if len(data.PeakLeft) != tc.want || len(data.PeakRight) != tc.want {
+				t.Fatalf("samples = (%d, %d), want %d", len(data.PeakLeft), len(data.PeakRight), tc.want)
+			}
+			if data.SamplesPerSec != 10 {
+				t.Fatalf("samples/sec = %d, want 10", data.SamplesPerSec)
+			}
+			if data.DurationMS != tc.durationMS {
+				t.Fatalf("duration = %d, want %d", data.DurationMS, tc.durationMS)
+			}
+			for i, v := range data.PeakLeft {
+				if v < 0 || v > 1 {
+					t.Fatalf("peakLeft[%d] = %v, outside the 0..1 range the UI draws", i, v)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// cache encoding
+// ---------------------------------------------------------------------------
+
+func TestCompressDecompressWaveform_RoundTrip(t *testing.T) {
+	w, _ := newWaveformSvc(t)
+	generated := time.Now().UTC().Truncate(time.Second)
+	orig := &WaveformData{
+		MediaID:       "m1",
+		SamplesPerSec: 10,
+		DurationMS:    4200,
+		PeakLeft:      []float32{0, 0.25, 0.5, 0.75, 1},
+		PeakRight:     []float32{1, 0.75, 0.5, 0.25, 0},
+		GeneratedAt:   generated,
+	}
+
+	blob, err := w.compressWaveform(orig)
+	if err != nil {
+		t.Fatalf("compress: %v", err)
+	}
+	if len(blob) == 0 {
+		t.Fatal("compressed blob empty")
+	}
+
+	got, err := w.decompressWaveform(&models.WaveformCache{
+		MediaID:       orig.MediaID,
+		SamplesPerSec: orig.SamplesPerSec,
+		DurationMS:    orig.DurationMS,
+		PeakData:      blob,
+		GeneratedAt:   generated,
+	})
+	if err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	if got.MediaID != orig.MediaID || got.SamplesPerSec != 10 || got.DurationMS != 4200 {
+		t.Fatalf("header = %+v", got)
+	}
+	if !got.GeneratedAt.Equal(generated) {
+		t.Fatalf("generated at = %v, want %v", got.GeneratedAt, generated)
+	}
+	for i := range orig.PeakLeft {
+		if got.PeakLeft[i] != orig.PeakLeft[i] || got.PeakRight[i] != orig.PeakRight[i] {
+			t.Fatalf("sample %d = (%v, %v), want (%v, %v)", i, got.PeakLeft[i], got.PeakRight[i], orig.PeakLeft[i], orig.PeakRight[i])
+		}
+	}
+}
+
+// Mono sources arrive with a short right channel; the encoder mirrors left so
+// the decoder always reads a full stereo pair.
+func TestCompressWaveform_MirrorsShortRightChannel(t *testing.T) {
+	w, _ := newWaveformSvc(t)
+	orig := &WaveformData{MediaID: "m1", PeakLeft: []float32{0.1, 0.2, 0.3}, PeakRight: []float32{0.9}}
+
+	blob, err := w.compressWaveform(orig)
+	if err != nil {
+		t.Fatalf("compress: %v", err)
+	}
+	got, err := w.decompressWaveform(&models.WaveformCache{MediaID: "m1", PeakData: blob})
+	if err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	if len(got.PeakRight) != 3 {
+		t.Fatalf("right channel = %d samples, want 3", len(got.PeakRight))
+	}
+	if got.PeakRight[0] != 0.9 {
+		t.Fatalf("right[0] = %v, want the supplied 0.9", got.PeakRight[0])
+	}
+	if got.PeakRight[1] != 0.2 || got.PeakRight[2] != 0.3 {
+		t.Fatalf("right tail = %v, want it mirrored from left", got.PeakRight[1:])
+	}
+}
+
+func TestCompressWaveform_Empty(t *testing.T) {
+	w, _ := newWaveformSvc(t)
+	blob, err := w.compressWaveform(&WaveformData{MediaID: "m1"})
+	if err != nil {
+		t.Fatalf("compress: %v", err)
+	}
+	got, err := w.decompressWaveform(&models.WaveformCache{MediaID: "m1", PeakData: blob})
+	if err != nil {
+		t.Fatalf("decompress: %v", err)
+	}
+	if len(got.PeakLeft) != 0 {
+		t.Fatalf("samples = %d, want 0", len(got.PeakLeft))
+	}
+}
+
+func TestDecompressWaveform_Errors(t *testing.T) {
+	w, _ := newWaveformSvc(t)
+
+	if _, err := w.decompressWaveform(&models.WaveformCache{MediaID: "m1", PeakData: []byte("not gzip at all")}); err == nil {
+		t.Fatal("non-gzip payload accepted, want error")
+	}
+
+	if _, err := w.decompressWaveform(&models.WaveformCache{MediaID: "m1", PeakData: gzipBytes(t, nil)}); err == nil {
+		t.Fatal("payload with no sample-count header accepted, want error")
+	}
+
+	// Header claims 4 samples but only one full stereo pair follows.
+	var body bytes.Buffer
+	_ = binary.Write(&body, binary.LittleEndian, int32(4))
+	_ = binary.Write(&body, binary.LittleEndian, float32(0.5))
+	_ = binary.Write(&body, binary.LittleEndian, float32(0.5))
+	if _, err := w.decompressWaveform(&models.WaveformCache{MediaID: "m1", PeakData: gzipBytes(t, body.Bytes())}); err == nil {
+		t.Fatal("truncated sample data accepted, want error")
+	}
+
+	// Header claims 1 sample but the right channel is missing.
+	var halfPair bytes.Buffer
+	_ = binary.Write(&halfPair, binary.LittleEndian, int32(1))
+	_ = binary.Write(&halfPair, binary.LittleEndian, float32(0.5))
+	if _, err := w.decompressWaveform(&models.WaveformCache{MediaID: "m1", PeakData: gzipBytes(t, halfPair.Bytes())}); err == nil {
+		t.Fatal("missing right channel accepted, want error")
+	}
+}
+
+func gzipBytes(t *testing.T, payload []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write(payload); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// ---------------------------------------------------------------------------
+// GetWaveform end to end
+// ---------------------------------------------------------------------------
+
+func TestGetWaveform_ServesFromCache(t *testing.T) {
+	w, db := newWaveformSvc(t)
+	orig := &WaveformData{
+		MediaID:       "m1",
+		SamplesPerSec: 10,
+		DurationMS:    2000,
+		PeakLeft:      []float32{0.1, 0.2},
+		PeakRight:     []float32{0.3, 0.4},
+		GeneratedAt:   time.Now().UTC().Truncate(time.Second),
+	}
+	if err := w.cacheWaveform(bg(), orig); err != nil {
+		t.Fatalf("cache: %v", err)
+	}
+
+	// No media_items row exists, so a cache miss would fail with ErrMediaNotFound.
+	got, err := w.GetWaveform(bg(), "m1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	if len(got.PeakLeft) != 2 || got.PeakLeft[1] != 0.2 {
+		t.Fatalf("peaks = %v", got.PeakLeft)
+	}
+
+	var rows int64
+	db.Model(&models.WaveformCache{}).Count(&rows)
+	if rows != 1 {
+		t.Fatalf("cache rows = %d, want 1", rows)
+	}
+}
+
+// cacheWaveform upserts: regenerating a waveform replaces the row instead of
+// erroring on the primary key.
+func TestCacheWaveform_Upserts(t *testing.T) {
+	w, db := newWaveformSvc(t)
+
+	if err := w.cacheWaveform(bg(), &WaveformData{MediaID: "m1", SamplesPerSec: 10, DurationMS: 1000, PeakLeft: []float32{0.1}, PeakRight: []float32{0.1}}); err != nil {
+		t.Fatalf("first cache: %v", err)
+	}
+	if err := w.cacheWaveform(bg(), &WaveformData{MediaID: "m1", SamplesPerSec: 5, DurationMS: 9999, PeakLeft: []float32{0.9}, PeakRight: []float32{0.9}}); err != nil {
+		t.Fatalf("second cache: %v", err)
+	}
+
+	var rows []models.WaveformCache
+	db.Find(&rows)
+	if len(rows) != 1 {
+		t.Fatalf("cache rows = %d, want 1", len(rows))
+	}
+	if rows[0].DurationMS != 9999 || rows[0].SamplesPerSec != 5 {
+		t.Fatalf("row = %+v, want the second write", rows[0])
+	}
+}
+
+// A cache row that no longer decodes must not be fatal: the service falls
+// through to regeneration, which here means the media lookup.
+func TestGetWaveform_CorruptCacheFallsThrough(t *testing.T) {
+	w, db := newWaveformSvc(t)
+	db.Create(&models.WaveformCache{MediaID: "m1", SamplesPerSec: 10, PeakData: []byte("corrupt")})
+
+	_, err := w.GetWaveform(bg(), "m1")
+	if !errors.Is(err, ErrMediaNotFound) {
+		t.Fatalf("err = %v, want ErrMediaNotFound after falling through the bad cache", err)
+	}
+}
+
+func TestGetWaveform_MediaNotFound(t *testing.T) {
+	w, _ := newWaveformSvc(t)
+	if _, err := w.GetWaveform(bg(), "ghost"); !errors.Is(err, ErrMediaNotFound) {
+		t.Fatalf("err = %v, want ErrMediaNotFound", err)
+	}
+}
+
+// With no media engine and no decodable file on disk, generation degrades to
+// the placeholder and still caches the result so the next call is a hit.
+func TestGetWaveform_GeneratesPlaceholderAndCaches(t *testing.T) {
+	w, db := newWaveformSvc(t)
+	seedMedia(t, db, "m1", "st1")
+
+	got, err := w.GetWaveform(bg(), "m1")
+	if err != nil {
+		t.Fatalf("get: %v", err)
+	}
+	// 7m29s at 10 samples/sec.
+	if len(got.PeakLeft) != 4490 {
+		t.Fatalf("samples = %d, want 4490", len(got.PeakLeft))
+	}
+
+	var rows int64
+	db.Model(&models.WaveformCache{}).Where("media_id = ?", "m1").Count(&rows)
+	if rows != 1 {
+		t.Fatalf("cached rows = %d, want the generated waveform to be stored", rows)
+	}
+
+	second, err := w.GetWaveform(bg(), "m1")
+	if err != nil {
+		t.Fatalf("second get: %v", err)
+	}
+	if len(second.PeakLeft) != len(got.PeakLeft) {
+		t.Fatalf("cached read returned %d samples, want %d", len(second.PeakLeft), len(got.PeakLeft))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// invalidation
+// ---------------------------------------------------------------------------
+
+func TestDeleteAndInvalidateWaveform(t *testing.T) {
+	w, db := newWaveformSvc(t)
+	db.Create(&models.WaveformCache{MediaID: "m1", SamplesPerSec: 10})
+	db.Create(&models.WaveformCache{MediaID: "m2", SamplesPerSec: 10})
+
+	if err := w.DeleteWaveform(bg(), "m1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	var remaining []models.WaveformCache
+	db.Find(&remaining)
+	if len(remaining) != 1 || remaining[0].MediaID != "m2" {
+		t.Fatalf("remaining = %+v, want only m2", remaining)
+	}
+
+	// Deleting a row that is already gone is not an error.
+	if err := w.DeleteWaveform(bg(), "m1"); err != nil {
+		t.Fatalf("repeat delete: %v", err)
+	}
+
+	if err := w.InvalidateWaveform(bg(), "m2"); err != nil {
+		t.Fatalf("invalidate: %v", err)
+	}
+	var count int64
+	db.Model(&models.WaveformCache{}).Count(&count)
+	if count != 0 {
+		t.Fatalf("rows after invalidate = %d, want 0", count)
+	}
+}
+
+func TestNewWaveformService(t *testing.T) {
+	_, db := newSvc(t)
+	root := t.TempDir()
+	w := NewWaveformService(db, nil, nil, root, zerolog.Nop())
+	if w.db != db {
+		t.Fatal("db not wired")
+	}
+	if w.mediaRoot != root {
+		t.Fatalf("mediaRoot = %q, want %q", w.mediaRoot, root)
+	}
+}


### PR DESCRIPTION
Continues the coverage push tracked on #255. Total statement coverage goes 63.10% -> 66.80%. Everything passes under `-race`; `gofmt` and `go vet` are clean.

| Package | Before | After |
|---|---|---|
| `internal/analyzer` | 0.0% | 82.4% |
| `internal/telemetry` | 0.0% | 76.1% |
| `internal/webdj` | 0.0% | 72.1% |
| `internal/models` | 21.0% | 50.9% |
| `internal/migration` | 19.8% | 34.7% |

## Two bugs found by the new tests

**`grimnir_media_library_duration_hours` was wrong by a factor of 10^6.** `UpdateStationMetrics` divided `SUM(duration)` by 3,600,000 as if the column were milliseconds. `MediaItem.Duration` is a Go `time.Duration`, which gorm persists as nanoseconds; a 5-minute library reported 83,333 hours. The Grafana panel "Media Library per Station" renders the raw gauge with no compensating multiplier, so it was wrong on screen too. No alert rule reads the metric.

**LibreTime `TestConnection` never reported a version.** It declared a `versionInfo` struct, decoded `/api/v2/version` into `decodeResponse[any]` and discarded it, so `LibreTimeConnectionStatus.Version` was always empty. It now decodes into a named `ltVersionInfo`.

## Production changes

Three, all small. The metric divisor above; the LibreTime version decode above; and narrowing the analyzer's concrete `*client.Client` field to a 5-method `MediaEngine` interface, the same seam used for the recording package in #305. `*client.Client` satisfies it unchanged, so that one is a field type change.

## What the tests actually pin

`webdj` was filed as needing websocket infrastructure. Only `Subscribe` and `broadcastUpdate` touch channels; the decks, mixer clamping, hot cues and the gzip waveform codec are sqlite and pure functions. Coverage there includes seek clamped to `[0, duration]`, EQ to +/-12 dB, pitch to +/-8%, `LoadTrack` refusing media owned by another station, and `broadcastUpdate` dropping rather than blocking once a subscriber's 16-slot buffer fills.

The migration API clients are driven by `httptest`, which covers request paths, both auth schemes, query encoding and the decode branches, plus `GetPlaylistContents` caching every row once because the LibreTime API ignores its own playlist filter. `Validate` and `AnalyzeDetailed` run end to end the same way: storage estimated from `Length` at 192kbps when a file reports no size, hidden and missing files counted but excluded from the byte total, and a station whose media endpoint 403s producing a warning that names it instead of aborting the analysis.

`CopyFiles` is what moves the audio during an import. With checksums on, `copyFile` hashes the source and then seeks back to 0 before handing the reader to storage; a missing rewind would store an empty file and still report success. The tests read every stored file back off disk and compare it.

The `models` work pins the per-station permission matrix field by field rather than against `DefaultPermissionsForRole`'s own output, so a flipped bool fails rather than moving the expectation with it.

## Two traps pinned rather than fixed

`CopyOptions.Concurrency` is required, not optional: passing 0 starts no workers, so nothing is copied and `CopyFiles` still returns a nil error. Both production callers use `DefaultCopyOptions`, which sets 4.

`Station.IsOwnedBy("")` on an unowned station returns true, because it is a plain string comparison. Callers must reject an empty subject before asking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)